### PR TITLE
Add coo-fix-state tool

### DIFF
--- a/pkg/toolset/coordinator_fix_state.go
+++ b/pkg/toolset/coordinator_fix_state.go
@@ -1,0 +1,110 @@
+package toolset
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/gohornet/hornet/pkg/database"
+	"github.com/gohornet/hornet/pkg/model/coordinator"
+	"github.com/gohornet/hornet/pkg/model/storage"
+	"github.com/gohornet/hornet/pkg/utils"
+	"github.com/iotaledger/hive.go/configuration"
+)
+
+func coordinatorFixStateFile(_ *configuration.Configuration, args []string) error {
+	printUsage := func() {
+		println("Usage:")
+		println(fmt.Sprintf("	%s [DATABASE_PATH] [COO_STATE_FILE_PATH]", ToolCoordinatorFixStateFile))
+		println()
+		println("   [DATABASE_PATH]       - the path to the database")
+		println("   [COO_STATE_FILE_PATH] - the path to the coordinator state file")
+		println()
+		println(fmt.Sprintf("example: %s %s %s", ToolCoordinatorFixStateFile, "mainnetdb", "./coordinator.state"))
+	}
+
+	if len(args) != 2 {
+		printUsage()
+		return fmt.Errorf("wrong argument count for '%s'", ToolCoordinatorFixStateFile)
+	}
+
+	databasePath := args[0]
+	if _, err := os.Stat(databasePath); err != nil || os.IsNotExist(err) {
+		return fmt.Errorf("DATABASE_PATH (%s) does not exist", databasePath)
+	}
+
+	coordinatorStateFilePath := args[1]
+	if coordinatorStateFilePath == "" {
+		return errors.New("COO_STATE_FILE_PATH is missing")
+	}
+
+	store, err := database.StoreWithDefaultSettings(databasePath, false)
+	if err != nil {
+		return fmt.Errorf("database initialization failed: %w", err)
+	}
+
+	// clean up store
+	defer func() {
+		store.Shutdown()
+		_ = store.Close()
+	}()
+
+	dbStorage, err := storage.New(store)
+	if err != nil {
+		return err
+	}
+
+	ledgerIndex, err := dbStorage.UTXOManager().ReadLedgerIndex()
+	if err != nil {
+		return err
+	}
+
+	latestMilestoneFromDatabase := dbStorage.SearchLatestMilestoneIndexInStore()
+
+	if ledgerIndex != latestMilestoneFromDatabase {
+		return fmt.Errorf("node is not synchronized (solid milestone index: %d, latest milestone index: %d)", ledgerIndex, latestMilestoneFromDatabase)
+	}
+
+	cachedMs := dbStorage.CachedMilestoneOrNil(ledgerIndex) // milestone +1
+	if cachedMs == nil {
+		return fmt.Errorf("milestone %d not found", ledgerIndex)
+	}
+	defer cachedMs.Release(true) // milestone -1
+
+	_, err = os.Stat(coordinatorStateFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("unable to check COO_STATE_FILE_PATH (%s), error: %w", coordinatorStateFilePath, err)
+	}
+
+	if err == nil {
+		// coordinator state file exists => rename it to not overwrite the original
+		backupFilePath := fmt.Sprintf("%s_backup", coordinatorStateFilePath)
+
+		_, err = os.Stat(backupFilePath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("unable to check backup file path (%s), error: %w", backupFilePath, err)
+		}
+
+		if err == nil {
+			return fmt.Errorf("backup file path already exists (%s), will not proceed to overwrite old backup file", backupFilePath)
+		}
+
+		if err := os.Rename(coordinatorStateFilePath, backupFilePath); err != nil {
+			return fmt.Errorf("unable to rename coordinator state file, error: %w", err)
+		}
+	}
+
+	// state of the coordinator holds information about the last issued milestones.
+	state := &coordinator.State{
+		LatestMilestoneIndex:     ledgerIndex,
+		LatestMilestoneMessageID: cachedMs.Milestone().MessageID,
+		LatestMilestoneTime:      cachedMs.Milestone().Timestamp,
+	}
+
+	if err := utils.WriteJSONToFile(coordinatorStateFilePath, state, 0660); err != nil {
+		return fmt.Errorf("failed to write coordinator state file (%s), error: %w", coordinatorStateFilePath, err)
+	}
+
+	return nil
+}

--- a/pkg/toolset/database_hash.go
+++ b/pkg/toolset/database_hash.go
@@ -154,7 +154,7 @@ func databaseLedgerHash(_ *configuration.Configuration, args []string) error {
 	// check arguments
 	if len(args) == 0 {
 		printUsage()
-		return errors.New("DATABASE_PATH missing")
+		return errors.New("DATABASE_PATH is missing")
 	}
 
 	databasePath := args[0]

--- a/pkg/toolset/ed25519.go
+++ b/pkg/toolset/ed25519.go
@@ -47,7 +47,7 @@ func generateEd25519Address(_ *configuration.Configuration, args []string) error
 	// check arguments
 	if len(args) == 0 {
 		printUsage()
-		return errors.New("ED25519_PUB_KEY missing")
+		return errors.New("ED25519_PUB_KEY is missing")
 	}
 
 	if len(args) > 1 {

--- a/pkg/toolset/snap_hash.go
+++ b/pkg/toolset/snap_hash.go
@@ -33,7 +33,7 @@ func snapshotHash(_ *configuration.Configuration, args []string) error {
 	// check arguments
 	if len(args) == 0 {
 		printUsage()
-		return errors.New("FULL_SNAPSHOT_PATH missing")
+		return errors.New("FULL_SNAPSHOT_PATH is missing")
 	}
 
 	fullPath := args[0]

--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -9,20 +9,21 @@ import (
 )
 
 const (
-	ToolPwdHash            = "pwd-hash"
-	ToolP2PIdentityGen     = "p2pidentity-gen"
-	ToolP2PExtractIdentity = "p2pidentity-extract"
-	ToolEd25519Key         = "ed25519-key"
-	ToolEd25519Addr        = "ed25519-addr"
-	ToolJWTApi             = "jwt-api"
-	ToolSnapGen            = "snap-gen"
-	ToolSnapMerge          = "snap-merge"
-	ToolSnapInfo           = "snap-info"
-	ToolSnapHash           = "snap-hash"
-	ToolBenchmarkIO        = "bench-io"
-	ToolBenchmarkCPU       = "bench-cpu"
-	ToolDatabaseMigration  = "db-migration"
-	ToolDatabaseLedgerHash = "db-hash"
+	ToolPwdHash                 = "pwd-hash"
+	ToolP2PIdentityGen          = "p2pidentity-gen"
+	ToolP2PExtractIdentity      = "p2pidentity-extract"
+	ToolEd25519Key              = "ed25519-key"
+	ToolEd25519Addr             = "ed25519-addr"
+	ToolJWTApi                  = "jwt-api"
+	ToolSnapGen                 = "snap-gen"
+	ToolSnapMerge               = "snap-merge"
+	ToolSnapInfo                = "snap-info"
+	ToolSnapHash                = "snap-hash"
+	ToolBenchmarkIO             = "bench-io"
+	ToolBenchmarkCPU            = "bench-cpu"
+	ToolDatabaseMigration       = "db-migration"
+	ToolDatabaseLedgerHash      = "db-hash"
+	ToolCoordinatorFixStateFile = "coo-fix-state"
 )
 
 // HandleTools handles available tools.
@@ -49,20 +50,21 @@ func HandleTools(nodeConfig *configuration.Configuration) {
 	}
 
 	tools := map[string]func(*configuration.Configuration, []string) error{
-		ToolPwdHash:            hashPasswordAndSalt,
-		ToolP2PIdentityGen:     generateP2PIdentity,
-		ToolP2PExtractIdentity: extractP2PIdentity,
-		ToolEd25519Key:         generateEd25519Key,
-		ToolEd25519Addr:        generateEd25519Address,
-		ToolJWTApi:             generateJWTApiToken,
-		ToolSnapGen:            snapshotGen,
-		ToolSnapMerge:          snapshotMerge,
-		ToolSnapInfo:           snapshotInfo,
-		ToolSnapHash:           snapshotHash,
-		ToolBenchmarkIO:        benchmarkIO,
-		ToolBenchmarkCPU:       benchmarkCPU,
-		ToolDatabaseMigration:  databaseMigration,
-		ToolDatabaseLedgerHash: databaseLedgerHash,
+		ToolPwdHash:                 hashPasswordAndSalt,
+		ToolP2PIdentityGen:          generateP2PIdentity,
+		ToolP2PExtractIdentity:      extractP2PIdentity,
+		ToolEd25519Key:              generateEd25519Key,
+		ToolEd25519Addr:             generateEd25519Address,
+		ToolJWTApi:                  generateJWTApiToken,
+		ToolSnapGen:                 snapshotGen,
+		ToolSnapMerge:               snapshotMerge,
+		ToolSnapInfo:                snapshotInfo,
+		ToolSnapHash:                snapshotHash,
+		ToolBenchmarkIO:             benchmarkIO,
+		ToolBenchmarkCPU:            benchmarkCPU,
+		ToolDatabaseMigration:       databaseMigration,
+		ToolDatabaseLedgerHash:      databaseLedgerHash,
+		ToolCoordinatorFixStateFile: coordinatorFixStateFile,
 	}
 
 	tool, exists := tools[strings.ToLower(args[1])]
@@ -95,4 +97,5 @@ func listTools() {
 	fmt.Printf("%-20s benchmarks the CPU performance\n", fmt.Sprintf("%s:", ToolBenchmarkCPU))
 	fmt.Printf("%-20s migrates the database to another engine\n", fmt.Sprintf("%s:", ToolDatabaseMigration))
 	fmt.Printf("%-20s calculates the sha256 hash of the ledger state of a database\n", fmt.Sprintf("%s:", ToolDatabaseLedgerHash))
+	fmt.Printf("%-20s applies the latest milestone in the database to the coordinator state file\n", fmt.Sprintf("%s:", ToolCoordinatorFixStateFile))
 }


### PR DESCRIPTION
This PR adds a tool `./hornet tool coo-fix-state` that helps to fix the `coordinator.state` file in case of a failed state update.

It scans the database for the latest milestone index, checks if the node is synced, and then writes the informations about this milestone to the `coordinator.state` file.