### PR TITLE
Fix/warpsync milestone deadlock

### DIFF
--- a/pkg/model/milestone/milestone_index.go
+++ b/pkg/model/milestone/milestone_index.go
@@ -1,6 +1,18 @@
 package milestone
 
+import (
+	"strconv"
+)
+
 type Index uint32
+
+func (i *Index) Int() int {
+	return int(*i)
+}
+
+func (i *Index) String() string {
+	return strconv.Itoa(i.Int())
+}
 
 func IndexCaller(handler interface{}, params ...interface{}) {
 	handler.(func(index Index))(params[0].(Index))

--- a/pkg/model/milestonemanager/milestone_manager.go
+++ b/pkg/model/milestonemanager/milestone_manager.go
@@ -49,6 +49,11 @@ func New(
 	return t
 }
 
+// KeyManager returns the used key manager.
+func (m *MilestoneManager) KeyManager() *keymanager.KeyManager {
+	return m.keyManager
+}
+
 // FindClosestNextMilestoneOrNil searches for the next known cached milestone in the persistence layer.
 // message +1
 func (m *MilestoneManager) FindClosestNextMilestoneOrNil(index milestone.Index) *storage.CachedMilestone {

--- a/pkg/model/milestonemanager/milestones_manager_test.go
+++ b/pkg/model/milestonemanager/milestones_manager_test.go
@@ -1,0 +1,102 @@
+package milestonemanager_test
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gohornet/hornet/pkg/keymanager"
+	"github.com/gohornet/hornet/pkg/model/coordinator"
+	"github.com/gohornet/hornet/pkg/model/milestonemanager"
+	"github.com/gohornet/hornet/pkg/model/storage"
+	"github.com/gohornet/hornet/pkg/testsuite"
+	"github.com/gohornet/hornet/pkg/utils"
+	iotago "github.com/iotaledger/iota.go/v2"
+)
+
+const (
+	BelowMaxDepth           = 15
+	MinPowScore             = 1.0
+	MilestonePublicKeyCount = 2
+)
+
+var (
+	coordinatorPublicKeyRangesJSON = `
+[{
+	"key": "a9b46fe743df783dedd00c954612428b34241f5913cf249d75bed3aafd65e4cd",
+	"start": 0,
+	"end": 777600
+},
+{
+	"key": "365fb85e7568b9b32f7359d6cbafa9814472ad0ecbad32d77beaf5dd9e84c6ba",
+	"start": 0,
+	"end": 1555200
+},
+{
+	"key": "ba6d07d1a1aea969e7e435f9f7d1b736ea9e0fcb8de400bf855dba7f2a57e947",
+	"start": 552960,
+	"end": 2108160
+},
+{
+  "key": "760d88e112c0fd210cf16a3dce3443ecf7e18c456c2fb9646cabb2e13e367569",
+  "start": 1333460,
+  "end": 2888660
+},
+{
+  "key": "7bac2209b576ea2235539358c7df8ca4d2f2fc35a663c760449e65eba9f8a6e7",
+  "start": 2111060,
+  "end": 3666260
+},
+{
+  "key": "edd9c639a719325e465346b84133bf94740b7d476dd87fc949c0e8df516f9954",
+  "start": 2888660,
+  "end": 4443860
+}]`
+)
+
+func initTest(testInterface testing.TB) (*testsuite.TestEnvironment, *milestonemanager.MilestoneManager) {
+
+	te := testsuite.SetupTestEnvironment(testInterface, &iotago.Ed25519Address{}, 0, BelowMaxDepth, MinPowScore, false)
+
+	getKeyManager := func() *keymanager.KeyManager {
+		var coordinatorPublicKeyRanges coordinator.PublicKeyRanges
+
+		err := json.Unmarshal([]byte(coordinatorPublicKeyRangesJSON), &coordinatorPublicKeyRanges)
+		require.NoError(te.TestInterface, err)
+
+		keyManager := keymanager.New()
+		for _, keyRange := range coordinatorPublicKeyRanges {
+			pubKey, err := utils.ParseEd25519PublicKeyFromString(keyRange.Key)
+			require.NoError(te.TestInterface, err, "can't load public key ranges")
+			keyManager.AddKeyRange(pubKey, keyRange.StartIndex, keyRange.EndIndex)
+		}
+
+		return keyManager
+	}
+
+	milestoneManager := milestonemanager.New(te.Storage(), te.SyncManager(), getKeyManager(), MilestonePublicKeyCount)
+
+	return te, milestoneManager
+}
+
+func TestMilestoneManager_KeyManager(t *testing.T) {
+	te, milestoneManager := initTest(t)
+	defer te.CleanupTestEnvironment(true)
+
+	milestoneMessageHex := "b77f44715e0b30140612f48b64627ac6b754e5c3d313a878aa11f6e34fc3263134649c20d03b96d5ca3af97facd880c5cd8413a75c10b8372af44d5d65cd220e31026e868c55d5b15f68cc042cdaf55d7d00d6a553782e8bcd1c563aa2535f7a786f97b67b660c5fb39c8fea1ae3a3b2bdc3bdbdb590078b4da174714ac919222064f8051293029e2cd8b69354dd7936ee50abb76d53a2a60bc97a5dc86e5b75d8b2fcfba718181ed2e10b6d13233ac0158f9277fbf2bc236769ac5193896fcd9c83f7703a05e0e4d21f02000001000000ce5a140093b65561000000000612f48b64627ac6b754e5c3d313a878aa11f6e34fc3263134649c20d03b96d5ca3af97facd880c5cd8413a75c10b8372af44d5d65cd220e31026e868c55d5b15f68cc042cdaf55d7d00d6a553782e8bcd1c563aa2535f7a786f97b67b660c5fb39c8fea1ae3a3b2bdc3bdbdb590078b4da174714ac919222064f8051293029e2cd8b69354dd7936ee50abb76d53a2a60bc97a5dc86e5b75d8b2fcfba718181ed2e10b6d13233ac0158f9277fbf2bc236769ac5193896fcd9c83f7703a05e0e4d20e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8000000000000000003365fb85e7568b9b32f7359d6cbafa9814472ad0ecbad32d77beaf5dd9e84c6ba760d88e112c0fd210cf16a3dce3443ecf7e18c456c2fb9646cabb2e13e367569ba6d07d1a1aea969e7e435f9f7d1b736ea9e0fcb8de400bf855dba7f2a57e9470000000003702f9c530fe08343d5bec6a621897d4a82d59594814e5308e7c48238a6783deb34f3691f80b340408c5c6317be5136c07387ca4f1334767523247732b317130d48c47c016b24ce2a020734f35e354dda917ec92d10700e06cf270bd18691d364f9fdc4c1e4a2257bcc7a91450f31bd83141806c451b9fd095e5c77428bc7560074defe516c10ac16572ce33f97c0d8c5f65402e267cc1e43d495a69418ee5802524fbf726009bcddc42909787f449c1146c3865ae47ec9beae892ec721b3c2088ab5f98aaff88aaf"
+	milestoneMessageBytes, err := hex.DecodeString(milestoneMessageHex)
+	require.NoError(te.TestInterface, err)
+
+	// build HORNET representation of the message
+	msg, err := storage.MessageFromBytes(milestoneMessageBytes, iotago.DeSeriModePerformValidation)
+	require.NoError(te.TestInterface, err)
+
+	// parse the milestone payload
+	ms := msg.Milestone()
+	require.NotNil(te.TestInterface, ms)
+
+	verifiedMilestone := milestoneManager.VerifyMilestone(msg)
+	require.NotNil(te.TestInterface, verifiedMilestone)
+}

--- a/pkg/protocol/gossip/msg_proc.go
+++ b/pkg/protocol/gossip/msg_proc.go
@@ -369,7 +369,7 @@ func (proc *MessageProcessor) processWorkUnit(wu *WorkUnit, p *Protocol) {
 			}
 		}
 
-		wu.requested = requests.Requested()
+		wu.requested = requests.HasRequest()
 		return requests
 	}
 

--- a/pkg/protocol/gossip/rqueue.go
+++ b/pkg/protocol/gossip/rqueue.go
@@ -141,7 +141,8 @@ func (r *Request) MapKey() string {
 
 type Requests []*Request
 
-func (r Requests) Requested() bool {
+// HasRequest returns true if Requests contains a Request.
+func (r Requests) HasRequest() bool {
 	return len(r) > 0
 }
 

--- a/pkg/protocol/gossip/rqueue.go
+++ b/pkg/protocol/gossip/rqueue.go
@@ -2,7 +2,6 @@ package gossip
 
 import (
 	"container/heap"
-	"strconv"
 	"sync"
 	"time"
 
@@ -134,7 +133,7 @@ func (r *Request) MapKey() string {
 	case RequestTypeMessageID:
 		return r.MessageID.ToMapKey()
 	case RequestTypeMilestoneIndex:
-		return strconv.Itoa(int(r.MilestoneIndex))
+		return r.MilestoneIndex.String()
 	default:
 		panic(ErrUnknownRequestType)
 	}

--- a/pkg/protocol/gossip/warpsync.go
+++ b/pkg/protocol/gossip/warpsync.go
@@ -330,7 +330,6 @@ func (w *WarpSyncMilestoneRequester) Cleanup() {
 func (w *WarpSyncMilestoneRequester) RequestMilestoneRange(rangeToRequest int, onExistingMilestoneInRange func(milestone *storage.CachedMilestone), from ...milestone.Index) int {
 	var requested int
 
-	// make sure we only request what we don't have
 	startingPoint := w.syncManager.ConfirmedMilestoneIndex()
 	if len(from) > 0 {
 		startingPoint = from[0]
@@ -360,7 +359,7 @@ func (w *WarpSyncMilestoneRequester) RequestMilestoneRange(rangeToRequest int, o
 		return requested
 	}
 
-	// enque every milestone request to the request queue
+	// enqueue every milestone request to the request queue
 	for _, msIndex := range msIndexes {
 		w.requester.Request(msIndex, msIndex)
 	}

--- a/pkg/tangle/tangle_processor.go
+++ b/pkg/tangle/tangle_processor.go
@@ -191,7 +191,7 @@ func (t *Tangle) processIncomingTx(incomingMsg *storage.Message, requests gossip
 	latestMilestoneIndex := t.syncManager.LatestMilestoneIndex()
 	isNodeSyncedWithinBelowMaxDepth := t.syncManager.IsNodeSyncedWithinBelowMaxDepth()
 
-	requested := requests.Requested()
+	requested := requests.HasRequest()
 
 	// The msg will be added to the storage inside this function, so the message object automatically updates
 	cachedMsg, alreadyAdded := AddMessageToStorage(t.storage, t.milestoneManager, incomingMsg, latestMilestoneIndex, requested, !isNodeSyncedWithinBelowMaxDepth) // msg +1

--- a/pkg/tangle/tangle_processor.go
+++ b/pkg/tangle/tangle_processor.go
@@ -19,7 +19,7 @@ import (
 func (t *Tangle) ConfigureTangleProcessor() {
 
 	t.receiveMsgWorkerPool = workerpool.New(func(task workerpool.Task) {
-		t.processIncomingTx(task.Param(0).(*storage.Message), task.Param(1).(*gossip.Request), task.Param(2).(*gossip.Protocol))
+		t.processIncomingTx(task.Param(0).(*storage.Message), task.Param(1).(gossip.Requests), task.Param(2).(*gossip.Protocol))
 		task.Return(nil)
 	}, workerpool.WorkerCount(t.receiveMsgWorkerCount), workerpool.QueueSize(t.receiveMsgQueueSize))
 
@@ -54,8 +54,8 @@ func (t *Tangle) RunTangleProcessor() {
 
 	t.startWaitGroup.Add(5)
 
-	onMsgProcessed := events.NewClosure(func(message *storage.Message, request *gossip.Request, proto *gossip.Protocol) {
-		t.receiveMsgWorkerPool.Submit(message, request, proto)
+	onMsgProcessed := events.NewClosure(func(message *storage.Message, requests gossip.Requests, proto *gossip.Protocol) {
+		t.receiveMsgWorkerPool.Submit(message, requests, proto)
 	})
 
 	onLatestMilestoneIndexChanged := events.NewClosure(func(_ milestone.Index) {
@@ -186,13 +186,15 @@ func (t *Tangle) IsReceiveTxWorkerPoolBusy() bool {
 	return t.receiveMsgWorkerPool.GetPendingQueueSize() > (t.receiveMsgQueueSize / 2)
 }
 
-func (t *Tangle) processIncomingTx(incomingMsg *storage.Message, request *gossip.Request, proto *gossip.Protocol) {
+func (t *Tangle) processIncomingTx(incomingMsg *storage.Message, requests gossip.Requests, proto *gossip.Protocol) {
 
 	latestMilestoneIndex := t.syncManager.LatestMilestoneIndex()
 	isNodeSyncedWithinBelowMaxDepth := t.syncManager.IsNodeSyncedWithinBelowMaxDepth()
 
+	requested := requests.Requested()
+
 	// The msg will be added to the storage inside this function, so the message object automatically updates
-	cachedMsg, alreadyAdded := AddMessageToStorage(t.storage, t.milestoneManager, incomingMsg, latestMilestoneIndex, request != nil, !isNodeSyncedWithinBelowMaxDepth, false) // msg +1
+	cachedMsg, alreadyAdded := AddMessageToStorage(t.storage, t.milestoneManager, incomingMsg, latestMilestoneIndex, requested, !isNodeSyncedWithinBelowMaxDepth) // msg +1
 
 	// Release shouldn't be forced, to cache the latest messages
 	defer cachedMsg.Release(!isNodeSyncedWithinBelowMaxDepth) // msg -1
@@ -206,9 +208,11 @@ func (t *Tangle) processIncomingTx(incomingMsg *storage.Message, request *gossip
 
 		// since we only add the parents if there was a source request, we only
 		// request them for messages which should be part of milestone cones
-		if request != nil {
+		for _, request := range requests {
 			// add this newly received message's parents to the request queue
-			t.requester.RequestParents(cachedMsg.Retain(), request.MilestoneIndex, true)
+			if request.RequestType == gossip.RequestTypeMessageID {
+				t.requester.RequestParents(cachedMsg.Retain(), request.MilestoneIndex, true)
+			}
 		}
 
 		confirmedMilestoneIndex := t.syncManager.ConfirmedMilestoneIndex()
@@ -238,15 +242,15 @@ func (t *Tangle) processIncomingTx(incomingMsg *storage.Message, request *gossip
 	t.Events.ProcessedMessage.Trigger(incomingMsg.MessageID())
 	t.messageProcessedSyncEvent.Trigger(incomingMsg.MessageID().ToMapKey())
 
-	if request != nil {
+	for _, request := range requests {
 		// mark the received request as processed
-		t.requestQueue.Processed(incomingMsg.MessageID())
+		t.requestQueue.Processed(request)
 	}
 
 	// we check whether the request is nil, so we only trigger the solidifier when
-	// we actually handled a message stemming from a request (as otherwise the solidifier
+	// we actually handled a message coming from a request (as otherwise the solidifier
 	// is triggered too often through messages received from normal gossip)
-	if request != nil && !t.syncManager.IsNodeSynced() && t.requestQueue.Empty() {
+	if requested && !t.syncManager.IsNodeSynced() && t.requestQueue.Empty() {
 		// we trigger the milestone solidifier in order to solidify milestones
 		// which should be solid given that the request queue is empty
 		t.milestoneSolidifierWorkerPool.TrySubmit(milestone.Index(0), true)

--- a/pkg/testsuite/tangle.go
+++ b/pkg/testsuite/tangle.go
@@ -20,7 +20,7 @@ import (
 func (te *TestEnvironment) StoreMessage(msg *storage.Message) *storage.CachedMessage {
 
 	// Store message in the database
-	cachedMsg, alreadyAdded := tangle.AddMessageToStorage(te.storage, te.milestoneManager, msg, te.syncManager.LatestMilestoneIndex(), false, true, true)
+	cachedMsg, alreadyAdded := tangle.AddMessageToStorage(te.storage, te.milestoneManager, msg, te.syncManager.LatestMilestoneIndex(), false, true)
 	require.NotNil(te.TestInterface, cachedMsg)
 	require.False(te.TestInterface, alreadyAdded)
 

--- a/private_tangle/run_2nd.bat
+++ b/private_tangle/run_2nd.bat
@@ -12,6 +12,7 @@ go run "..\main.go" -c config_private_tangle.json ^
 --profiling.bindAddress="127.0.0.1:6061" ^
 --prometheus.bindAddress="localhost:9312" ^
 --prometheus.fileServiceDiscovery.target="localhost:9312" ^
+--mqtt.bindAddress="localhost:1884" ^
 --p2p.db.path="p2pstore2" ^
 --p2p.identityPrivateKey="a06b288ce7fc3b6f1e716f6f7d72050b53417aae4b305a68883550a3bb28597f254b082515a79391a7f13009b4133851a0c4d48e0e948809c3b46ff3e2500b4f" ^
 --p2p.peers="/ip4/127.0.0.1/tcp/15600/p2p/12D3KooWSagdVaCrS14GeJhM8CbQr41AW2PiYMgptTyAybCbQuEY,/ip4/127.0.0.1/tcp/15602/p2p/12D3KooWGdr8M5KX8KuKaXSiKfHJstdVnRkadYmupF7tFk2HrRoA,/ip4/127.0.0.1/tcp/15603/p2p/12D3KooWC7uE9w3RN4Vh1FJAZa8SbE8yMWR6wCVBajcWpyWguV73"

--- a/private_tangle/run_2nd.sh
+++ b/private_tangle/run_2nd.sh
@@ -13,6 +13,7 @@ go run ../main.go -c config_private_tangle.json \
 --profiling.bindAddress="127.0.0.1:6061" \
 --prometheus.bindAddress="localhost:9312" \
 --prometheus.fileServiceDiscovery.target="localhost:9312" \
+--mqtt.bindAddress="localhost:1884" \
 --p2p.db.path="p2pstore2" \
 --p2p.identityPrivateKey="a06b288ce7fc3b6f1e716f6f7d72050b53417aae4b305a68883550a3bb28597f254b082515a79391a7f13009b4133851a0c4d48e0e948809c3b46ff3e2500b4f" \
 --p2p.peers="/ip4/127.0.0.1/tcp/15600/p2p/12D3KooWSagdVaCrS14GeJhM8CbQr41AW2PiYMgptTyAybCbQuEY,/ip4/127.0.0.1/tcp/15602/p2p/12D3KooWGdr8M5KX8KuKaXSiKfHJstdVnRkadYmupF7tFk2HrRoA,/ip4/127.0.0.1/tcp/15603/p2p/12D3KooWC7uE9w3RN4Vh1FJAZa8SbE8yMWR6wCVBajcWpyWguV73"

--- a/private_tangle/run_3rd.bat
+++ b/private_tangle/run_3rd.bat
@@ -12,6 +12,7 @@ go run "..\main.go" -c config_private_tangle.json ^
 --profiling.bindAddress="127.0.0.1:6062" ^
 --prometheus.bindAddress="localhost:9313" ^
 --prometheus.fileServiceDiscovery.target="localhost:9313" ^
+--mqtt.bindAddress="localhost:1885" ^
 --p2p.db.path="p2pstore3" ^
 --p2p.identityPrivateKey="5126767a84e1ced849dbbf2be809fd40f90bcfb81bd0d3309e2e25e34f803bf265500854f1f0e8fd3c389cf7b6b59cfd422b9319f257e2a8d3a772973560acdd" ^
 --p2p.peers="/ip4/127.0.0.1/tcp/15600/p2p/12D3KooWSagdVaCrS14GeJhM8CbQr41AW2PiYMgptTyAybCbQuEY,/ip4/127.0.0.1/tcp/15601/p2p/12D3KooWCKwcTWevoRKa2kEBputeGASvEBuDfRDSbe8t1DWugUmL,/ip4/127.0.0.1/tcp/15603/p2p/12D3KooWC7uE9w3RN4Vh1FJAZa8SbE8yMWR6wCVBajcWpyWguV73"

--- a/private_tangle/run_3rd.sh
+++ b/private_tangle/run_3rd.sh
@@ -13,6 +13,7 @@ go run ../main.go -c config_private_tangle.json \
 --profiling.bindAddress="127.0.0.1:6062" \
 --prometheus.bindAddress="localhost:9313" \
 --prometheus.fileServiceDiscovery.target="localhost:9313" \
+--mqtt.bindAddress="localhost:1885" \
 --p2p.db.path="p2pstore3" \
 --p2p.identityPrivateKey="5126767a84e1ced849dbbf2be809fd40f90bcfb81bd0d3309e2e25e34f803bf265500854f1f0e8fd3c389cf7b6b59cfd422b9319f257e2a8d3a772973560acdd" \
 --p2p.peers="/ip4/127.0.0.1/tcp/15600/p2p/12D3KooWSagdVaCrS14GeJhM8CbQr41AW2PiYMgptTyAybCbQuEY,/ip4/127.0.0.1/tcp/15601/p2p/12D3KooWCKwcTWevoRKa2kEBputeGASvEBuDfRDSbe8t1DWugUmL,/ip4/127.0.0.1/tcp/15603/p2p/12D3KooWC7uE9w3RN4Vh1FJAZa8SbE8yMWR6wCVBajcWpyWguV73"

--- a/private_tangle/run_4th.bat
+++ b/private_tangle/run_4th.bat
@@ -12,6 +12,7 @@ go run "..\main.go" -c config_private_tangle.json ^
 --profiling.bindAddress="127.0.0.1:6063" ^
 --prometheus.bindAddress="localhost:9314" ^
 --prometheus.fileServiceDiscovery.target="localhost:9314" ^
+--mqtt.bindAddress="localhost:1886" ^
 --p2p.db.path="p2pstore4" ^
 --p2p.identityPrivateKey="996dceaeddcb5fc21480646f38ac53c4f5668fd33f3c0bfecfd004861d4a9dc722355dabd7f31a1266423abcf6c1db6228eb8283deb55731915ed06bd2ca387e" ^
 --p2p.peers="/ip4/127.0.0.1/tcp/15600/p2p/12D3KooWSagdVaCrS14GeJhM8CbQr41AW2PiYMgptTyAybCbQuEY,/ip4/127.0.0.1/tcp/15601/p2p/12D3KooWCKwcTWevoRKa2kEBputeGASvEBuDfRDSbe8t1DWugUmL,/ip4/127.0.0.1/tcp/15602/p2p/12D3KooWGdr8M5KX8KuKaXSiKfHJstdVnRkadYmupF7tFk2HrRoA"

--- a/private_tangle/run_4th.sh
+++ b/private_tangle/run_4th.sh
@@ -13,6 +13,7 @@ go run ../main.go -c config_private_tangle.json \
 --profiling.bindAddress="127.0.0.1:6063" \
 --prometheus.bindAddress="localhost:9314" \
 --prometheus.fileServiceDiscovery.target="localhost:9314" \
+--mqtt.bindAddress="localhost:1886" \
 --p2p.db.path="p2pstore4" \
 --p2p.identityPrivateKey="996dceaeddcb5fc21480646f38ac53c4f5668fd33f3c0bfecfd004861d4a9dc722355dabd7f31a1266423abcf6c1db6228eb8283deb55731915ed06bd2ca387e" \
 --p2p.peers="/ip4/127.0.0.1/tcp/15600/p2p/12D3KooWSagdVaCrS14GeJhM8CbQr41AW2PiYMgptTyAybCbQuEY,/ip4/127.0.0.1/tcp/15601/p2p/12D3KooWCKwcTWevoRKa2kEBputeGASvEBuDfRDSbe8t1DWugUmL,/ip4/127.0.0.1/tcp/15602/p2p/12D3KooWGdr8M5KX8KuKaXSiKfHJstdVnRkadYmupF7tFk2HrRoA"

--- a/private_tangle/run_coo.bat
+++ b/private_tangle/run_coo.bat
@@ -13,6 +13,7 @@ go run "..\main.go" -c config_private_tangle.json ^
 --profiling.bindAddress="127.0.0.1:6060" ^
 --prometheus.bindAddress="localhost:9311" ^
 --prometheus.fileServiceDiscovery.target="localhost:9311" ^
+--mqtt.bindAddress="localhost:1883" ^
 --p2p.db.path="p2pstore" ^
 --p2p.identityPrivateKey="1f46fad4f538a031d4f87f490f6bca4319dfd0307636a5759a22b5e8874bd608f9156ba976a12918c16a481c38c88a7b5351b769adc30390e93b6c0a63b09b79" ^
 --p2p.peers="/ip4/127.0.0.1/tcp/15601/p2p/12D3KooWCKwcTWevoRKa2kEBputeGASvEBuDfRDSbe8t1DWugUmL,/ip4/127.0.0.1/tcp/15602/p2p/12D3KooWGdr8M5KX8KuKaXSiKfHJstdVnRkadYmupF7tFk2HrRoA,/ip4/127.0.0.1/tcp/15603/p2p/12D3KooWC7uE9w3RN4Vh1FJAZa8SbE8yMWR6wCVBajcWpyWguV73"

--- a/private_tangle/run_coo.sh
+++ b/private_tangle/run_coo.sh
@@ -14,6 +14,7 @@ go run ../main.go -c config_private_tangle.json \
 --profiling.bindAddress="127.0.0.1:6060" \
 --prometheus.bindAddress="localhost:9311" \
 --prometheus.fileServiceDiscovery.target="localhost:9311" \
+--mqtt.bindAddress="localhost:1883" \
 --p2p.db.path="p2pstore" \
 --p2p.identityPrivateKey="1f46fad4f538a031d4f87f490f6bca4319dfd0307636a5759a22b5e8874bd608f9156ba976a12918c16a481c38c88a7b5351b769adc30390e93b6c0a63b09b79" \
 --p2p.peers="/ip4/127.0.0.1/tcp/15601/p2p/12D3KooWCKwcTWevoRKa2kEBputeGASvEBuDfRDSbe8t1DWugUmL,/ip4/127.0.0.1/tcp/15602/p2p/12D3KooWGdr8M5KX8KuKaXSiKfHJstdVnRkadYmupF7tFk2HrRoA,/ip4/127.0.0.1/tcp/15603/p2p/12D3KooWC7uE9w3RN4Vh1FJAZa8SbE8yMWR6wCVBajcWpyWguV73"

--- a/private_tangle/run_coo_bootstrap.bat
+++ b/private_tangle/run_coo_bootstrap.bat
@@ -18,6 +18,7 @@ go run "..\main.go" -c config_private_tangle.json ^
 --profiling.bindAddress="127.0.0.1:6060" ^
 --prometheus.bindAddress="localhost:9311" ^
 --prometheus.fileServiceDiscovery.target="localhost:9311" ^
+--mqtt.bindAddress="localhost:1883" ^
 --p2p.db.path="p2pstore" ^
 --p2p.identityPrivateKey="1f46fad4f538a031d4f87f490f6bca4319dfd0307636a5759a22b5e8874bd608f9156ba976a12918c16a481c38c88a7b5351b769adc30390e93b6c0a63b09b79" ^
 --p2p.peers="/ip4/127.0.0.1/tcp/15601/p2p/12D3KooWCKwcTWevoRKa2kEBputeGASvEBuDfRDSbe8t1DWugUmL,/ip4/127.0.0.1/tcp/15602/p2p/12D3KooWGdr8M5KX8KuKaXSiKfHJstdVnRkadYmupF7tFk2HrRoA,/ip4/127.0.0.1/tcp/15603/p2p/12D3KooWC7uE9w3RN4Vh1FJAZa8SbE8yMWR6wCVBajcWpyWguV73"

--- a/private_tangle/run_coo_bootstrap.sh
+++ b/private_tangle/run_coo_bootstrap.sh
@@ -19,6 +19,7 @@ go run ../main.go -c config_private_tangle.json \
 --profiling.bindAddress="127.0.0.1:6060" \
 --prometheus.bindAddress="localhost:9311" \
 --prometheus.fileServiceDiscovery.target="localhost:9311" \
+--mqtt.bindAddress="localhost:1883" \
 --p2p.db.path="p2pstore" \
 --p2p.identityPrivateKey="1f46fad4f538a031d4f87f490f6bca4319dfd0307636a5759a22b5e8874bd608f9156ba976a12918c16a481c38c88a7b5351b769adc30390e93b6c0a63b09b79" \
 --p2p.peers="/ip4/127.0.0.1/tcp/15601/p2p/12D3KooWCKwcTWevoRKa2kEBputeGASvEBuDfRDSbe8t1DWugUmL,/ip4/127.0.0.1/tcp/15602/p2p/12D3KooWGdr8M5KX8KuKaXSiKfHJstdVnRkadYmupF7tFk2HrRoA,/ip4/127.0.0.1/tcp/15603/p2p/12D3KooWC7uE9w3RN4Vh1FJAZa8SbE8yMWR6wCVBajcWpyWguV73"


### PR DESCRIPTION
This PR fixes an edge case, where the warpsync plugin could lead to a deadlock in the syncing process.

If for example the public keys of a milestone are not known to the node in the moment the milestone was received, the milestone message is stored to the database, but the payload is considered as invalid.

If the node operator then adds the correct public keys and the milestones are received again, the payload was not verified again because the message was already known to the node. This resulted in a deadlock in combination with the warpsync plugin, because warpsync will block the syncing process of newer milestones until the defined range of milestones are received and solidified.

The fix is to re-verify milestone payloads of unknown milestones, even if the message is already known.