### PR TITLE
grocksdb v1.6.38

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 replace github.com/labstack/gommon => github.com/muXxer/gommon v0.3.1-0.20210805133353-359faea1baf6
 
-replace github.com/linxGnu/grocksdb => github.com/gohornet/grocksdb v1.6.34-0.20210518222204-d6ea5eedcfb9
+replace github.com/linxGnu/grocksdb => github.com/gohornet/grocksdb v1.6.38-0.20211012114404-55f425442260
 
 require (
 	github.com/DataDog/zstd v1.4.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY1WM=
-github.com/gohornet/grocksdb v1.6.34-0.20210518222204-d6ea5eedcfb9 h1:XaOoA14ZQgURuB+DOZibjEDjx3vB/bD4u2thLB5tK9U=
-github.com/gohornet/grocksdb v1.6.34-0.20210518222204-d6ea5eedcfb9/go.mod h1:/+iSQrn7Izt6kFhHBQvcE6FkklsKXa8hc35pFyFDrDw=
+github.com/gohornet/grocksdb v1.6.38-0.20211012114404-55f425442260 h1:Pf6oR/aezlojjxzaNqIZa5q1+LKFgePrH+E9B57sKiE=
+github.com/gohornet/grocksdb v1.6.38-0.20211012114404-55f425442260/go.mod h1:/+iSQrn7Izt6kFhHBQvcE6FkklsKXa8hc35pFyFDrDw=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=

--- a/scripts/build_hornet_rocksdb_builtin.sh
+++ b/scripts/build_hornet_rocksdb_builtin.sh
@@ -5,4 +5,4 @@
 
 commit_hash=$(git rev-parse --short HEAD)
 
-go build -ldflags="-s -w -X github.com/gohornet/hornet/core/app.Version=$commit_hash" -tags rocksdb,builtin_static
+CGO_ENABLED=1 go build -ldflags="-s -w -X github.com/gohornet/hornet/core/app.Version=$commit_hash" -tags rocksdb,builtin_static


### PR DESCRIPTION
- Upgraded grocksdb to the latest version including RocksDB 6.22.1
- Now `-tags rocksdb,builtin_static` and the `scripts/build_hornet_rocksdb_builtin.sh` can be used for macOS on both Intel and Apple Silicon