### PR TITLE
Use contexts to cancel instead of signal channels

### DIFF
--- a/core/pow/core.go
+++ b/core/pow/core.go
@@ -1,6 +1,7 @@
 package pow
 
 import (
+	"context"
 	"time"
 
 	"go.uber.org/dig"
@@ -61,9 +62,9 @@ func provide(c *dig.Container) {
 func run() {
 
 	// close the PoW handler on shutdown
-	if err := CorePlugin.Daemon().BackgroundWorker("PoW Handler", func(shutdownSignal <-chan struct{}) {
+	if err := CorePlugin.Daemon().BackgroundWorker("PoW Handler", func(ctx context.Context) {
 		CorePlugin.LogInfo("Starting PoW Handler ... done")
-		<-shutdownSignal
+		<-ctx.Done()
 		CorePlugin.LogInfo("Stopping PoW Handler ...")
 		deps.Handler.Close()
 		CorePlugin.LogInfo("Stopping PoW Handler ... done")

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gorilla/websocket v1.4.2
 	github.com/iotaledger/go-ds-kvstore v0.0.0-20210819121432-6e2ce2d41200
-	github.com/iotaledger/hive.go v0.0.0-20211011085923-fd2eb0a47bf8
+	github.com/iotaledger/hive.go v0.0.0-20211012165228-2f217dcf2ad7
 	github.com/iotaledger/iota.go v1.0.0
 	github.com/iotaledger/iota.go/v2 v2.0.1-0.20210830162758-173bada804f9
 	github.com/ipfs/go-datastore v0.4.6

--- a/go.sum
+++ b/go.sum
@@ -702,8 +702,8 @@ github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod
 github.com/iotaledger/go-ds-kvstore v0.0.0-20210819121432-6e2ce2d41200 h1:3beBqwDfcLFho8awOyVzbsC376sYpATan6/Px13N92M=
 github.com/iotaledger/go-ds-kvstore v0.0.0-20210819121432-6e2ce2d41200/go.mod h1:3RqFJgmkTw9Iiw2hflD4OG17H1OlLTY9kNHr7PmHVC4=
 github.com/iotaledger/hive.go v0.0.0-20210819120742-a8536d801087/go.mod h1:sWc4uLQAt20Zugh1caFmI5NL+1KgfKiums4TrxGf3nk=
-github.com/iotaledger/hive.go v0.0.0-20211011085923-fd2eb0a47bf8 h1:kAB5+8LBTMZSXaud4PrPsklqf7LUBrUy6ZtAlq+El9g=
-github.com/iotaledger/hive.go v0.0.0-20211011085923-fd2eb0a47bf8/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
+github.com/iotaledger/hive.go v0.0.0-20211012165228-2f217dcf2ad7 h1:1Qln5H8tEpzuof23p0EnURyhfqfqV8ynizMGY8QcAPA=
+github.com/iotaledger/hive.go v0.0.0-20211012165228-2f217dcf2ad7/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20210120184258-7eac7c1cc80b/go.mod h1:Rn6v5hLAn8YBaJlRu1ZQdPAgKlshJR1PTeLQaft2778=
 github.com/iotaledger/iota.go v1.0.0 h1:tqm1FxJ/zOdzbrAaQ5BQpVF8dUy2eeGlSeWlNG8GoXY=
 github.com/iotaledger/iota.go v1.0.0/go.mod h1:RiKYwDyY7aCD1L0YRzHSjOsJ5mUR9yvQpvhZncNcGQI=

--- a/pkg/dag/children_traverser.go
+++ b/pkg/dag/children_traverser.go
@@ -2,6 +2,7 @@ package dag
 
 import (
 	"container/list"
+	"context"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -9,6 +10,7 @@ import (
 	"github.com/gohornet/hornet/pkg/common"
 	"github.com/gohornet/hornet/pkg/model/hornet"
 	"github.com/gohornet/hornet/pkg/model/storage"
+	"github.com/gohornet/hornet/pkg/utils"
 )
 
 type ChildrenTraverser struct {
@@ -21,11 +23,11 @@ type ChildrenTraverser struct {
 	// discovers map with already found messages
 	discovered map[string]struct{}
 
+	ctx                   context.Context
 	iteratorOptions       []storage.IteratorOption
 	condition             Predicate
 	consumer              Consumer
 	walkAlreadyDiscovered bool
-	abortSignal           <-chan struct{}
 
 	traverserLock sync.Mutex
 }
@@ -63,7 +65,7 @@ func (t *ChildrenTraverser) Cleanup(forceRelease bool) {
 // Traverse starts to traverse the children (future cone) of the given start message until
 // the traversal stops due to no more messages passing the given condition.
 // It is unsorted BFS because the children are not ordered in the database.
-func (t *ChildrenTraverser) Traverse(startMessageID hornet.MessageID, condition Predicate, consumer Consumer, walkAlreadyDiscovered bool, abortSignal <-chan struct{}, iteratorOptions ...storage.IteratorOption) error {
+func (t *ChildrenTraverser) Traverse(ctx context.Context, startMessageID hornet.MessageID, condition Predicate, consumer Consumer, walkAlreadyDiscovered bool, iteratorOptions ...storage.IteratorOption) error {
 
 	// make sure only one traversal is running
 	t.traverserLock.Lock()
@@ -71,11 +73,11 @@ func (t *ChildrenTraverser) Traverse(startMessageID hornet.MessageID, condition 
 	// release lock so the traverser can be reused
 	defer t.traverserLock.Unlock()
 
+	t.ctx = ctx
 	t.iteratorOptions = iteratorOptions
 	t.condition = condition
 	t.consumer = consumer
 	t.walkAlreadyDiscovered = walkAlreadyDiscovered
-	t.abortSignal = abortSignal
 
 	// Prepare for a new traversal
 	t.reset()
@@ -98,10 +100,8 @@ func (t *ChildrenTraverser) Traverse(startMessageID hornet.MessageID, condition 
 // current element gets consumed first, afterwards it's children get traversed in random order.
 func (t *ChildrenTraverser) processStackChildren() error {
 
-	select {
-	case <-t.abortSignal:
-		return common.ErrOperationAborted
-	default:
+	if err := utils.ReturnErrIfCtxDone(t.ctx, common.ErrOperationAborted); err != nil {
+		return err
 	}
 
 	// load candidate msg

--- a/pkg/dag/cone_root_indexes_test.go
+++ b/pkg/dag/cone_root_indexes_test.go
@@ -1,6 +1,7 @@
 package dag_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,8 @@ func TestConeRootIndexes(t *testing.T) {
 			cmi := latestMilestone.Milestone().Index
 
 			cachedMsgMeta := te.Storage().CachedMessageMetadataOrNil(messages[len(messages)-1])
-			ycri, ocri := dag.ConeRootIndexes(te.Storage(), cachedMsgMeta, cmi)
+			ycri, ocri, err := dag.ConeRootIndexes(context.Background(), te.Storage(), cachedMsgMeta, cmi)
+			require.NoError(te.TestInterface, err)
 
 			minOldestConeRootIndex := milestone.Index(1)
 			if cmi > milestone.Index(BelowMaxDepth) {
@@ -62,7 +64,8 @@ func TestConeRootIndexes(t *testing.T) {
 	msg := te.NewMessageBuilder("below max depth").Parents(parents.RemoveDupsAndSortByLexicalOrder()).BuildIndexation().Store()
 
 	cachedMsgMeta := te.Storage().CachedMessageMetadataOrNil(msg.StoredMessageID())
-	ycri, ocri := dag.ConeRootIndexes(te.Storage(), cachedMsgMeta, cmi)
+	ycri, ocri, err := dag.ConeRootIndexes(context.Background(), te.Storage(), cachedMsgMeta, cmi)
+	require.NoError(te.TestInterface, err)
 
 	// NullHash is SEP for index 0
 	require.Equal(te.TestInterface, uint32(0), uint32(ocri))

--- a/pkg/dag/helper.go
+++ b/pkg/dag/helper.go
@@ -1,6 +1,8 @@
 package dag
 
 import (
+	"context"
+
 	"github.com/gohornet/hornet/pkg/model/hornet"
 	"github.com/gohornet/hornet/pkg/model/storage"
 )
@@ -21,33 +23,33 @@ type OnSolidEntryPoint func(messageID hornet.MessageID)
 // the traversal stops due to no more messages passing the given condition.
 // It is a DFS of the paths of the parents one after another.
 // Caution: condition func is not in DFS order
-func TraverseParents(dbStorage *storage.Storage, parents hornet.MessageIDs, condition Predicate, consumer Consumer, onMissingParent OnMissingParent, onSolidEntryPoint OnSolidEntryPoint, traverseSolidEntryPoints bool, abortSignal <-chan struct{}) error {
+func TraverseParents(ctx context.Context, dbStorage *storage.Storage, parents hornet.MessageIDs, condition Predicate, consumer Consumer, onMissingParent OnMissingParent, onSolidEntryPoint OnSolidEntryPoint, traverseSolidEntryPoints bool) error {
 
 	t := NewParentTraverser(dbStorage)
 	defer t.Cleanup(true)
 
-	return t.Traverse(parents, condition, consumer, onMissingParent, onSolidEntryPoint, traverseSolidEntryPoints, abortSignal)
+	return t.Traverse(ctx, parents, condition, consumer, onMissingParent, onSolidEntryPoint, traverseSolidEntryPoints)
 }
 
 // TraverseParentsOfMessage starts to traverse the parents (past cone) of the given start message until
 // the traversal stops due to no more messages passing the given condition.
 // It is a DFS of the paths of the parents one after another.
 // Caution: condition func is not in DFS order
-func TraverseParentsOfMessage(dbStorage *storage.Storage, startMessageID hornet.MessageID, condition Predicate, consumer Consumer, onMissingParent OnMissingParent, onSolidEntryPoint OnSolidEntryPoint, traverseSolidEntryPoints bool, abortSignal <-chan struct{}) error {
+func TraverseParentsOfMessage(ctx context.Context, dbStorage *storage.Storage, startMessageID hornet.MessageID, condition Predicate, consumer Consumer, onMissingParent OnMissingParent, onSolidEntryPoint OnSolidEntryPoint, traverseSolidEntryPoints bool) error {
 
 	t := NewParentTraverser(dbStorage)
 	defer t.Cleanup(true)
 
-	return t.Traverse(hornet.MessageIDs{startMessageID}, condition, consumer, onMissingParent, onSolidEntryPoint, traverseSolidEntryPoints, abortSignal)
+	return t.Traverse(ctx, hornet.MessageIDs{startMessageID}, condition, consumer, onMissingParent, onSolidEntryPoint, traverseSolidEntryPoints)
 }
 
 // TraverseChildren starts to traverse the children (future cone) of the given start message until
 // the traversal stops due to no more messages passing the given condition.
 // It is unsorted BFS because the children are not ordered in the database.
-func TraverseChildren(dbStorage *storage.Storage, startMessageID hornet.MessageID, condition Predicate, consumer Consumer, walkAlreadyDiscovered bool, abortSignal <-chan struct{}, iteratorOptions ...storage.IteratorOption) error {
+func TraverseChildren(ctx context.Context, dbStorage *storage.Storage, startMessageID hornet.MessageID, condition Predicate, consumer Consumer, walkAlreadyDiscovered bool, iteratorOptions ...storage.IteratorOption) error {
 
 	t := NewChildrenTraverser(dbStorage)
 	defer t.Cleanup(true)
 
-	return t.Traverse(startMessageID, condition, consumer, walkAlreadyDiscovered, abortSignal, iteratorOptions...)
+	return t.Traverse(ctx, startMessageID, condition, consumer, walkAlreadyDiscovered, iteratorOptions...)
 }

--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -335,7 +336,9 @@ func (coo *Coordinator) createAndSendMilestone(parents hornet.MessageIDs, newMil
 	parents = parents.RemoveDupsAndSortByLexicalOrder()
 
 	// compute merkle tree root
-	mutations, err := whiteflag.ComputeWhiteFlagMutations(coo.storage, newMilestoneIndex, metadataMemcache, messagesMemcache, parents)
+	// we pass a background context here to not cancel the whiteflag computation!
+	// otherwise the coordinator could panic at shutdown.
+	mutations, err := whiteflag.ComputeWhiteFlagMutations(context.Background(), coo.storage, newMilestoneIndex, metadataMemcache, messagesMemcache, parents)
 	if err != nil {
 		return common.CriticalError(fmt.Errorf("failed to compute white flag mutations: %w", err))
 	}

--- a/pkg/model/coordinator/milestones.go
+++ b/pkg/model/coordinator/milestones.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"context"
 	"time"
 
 	"github.com/gohornet/hornet/pkg/model/hornet"
@@ -17,7 +18,8 @@ func (coo *Coordinator) createCheckpoint(parents hornet.MessageIDs) (*storage.Me
 		Payload:   nil,
 	}
 
-	if err := coo.powHandler.DoPoW(iotaMsg, nil, coo.opts.powWorkerCount); err != nil {
+	// we pass a background context here to not create invalid checkpoints at node shutdown.
+	if err := coo.powHandler.DoPoW(context.Background(), iotaMsg, coo.opts.powWorkerCount); err != nil {
 		return nil, err
 	}
 
@@ -57,7 +59,9 @@ func (coo *Coordinator) createMilestone(index milestone.Index, parents hornet.Me
 		return nil, err
 	}
 
-	if err := coo.powHandler.DoPoW(iotaMsg, nil, coo.opts.powWorkerCount); err != nil {
+	// we pass a background context here to not create invalid milestones at node shutdown.
+	// otherwise the coordinator could panic at shutdown.
+	if err := coo.powHandler.DoPoW(context.Background(), iotaMsg, coo.opts.powWorkerCount); err != nil {
 		return nil, err
 	}
 

--- a/pkg/model/migrator/service_test.go
+++ b/pkg/model/migrator/service_test.go
@@ -1,6 +1,7 @@
 package migrator_test
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"os"
@@ -108,16 +109,16 @@ func newTestService(t *testing.T, msIndex uint32, maxEntries int) (*migrator.Mig
 		require.NoError(t, err)
 	}
 
-	closing := make(chan struct{})
+	ctx, ctxCancel := context.WithCancel(context.Background())
 	started := make(chan struct{})
 	go func() {
 		close(started)
-		s.Start(closing, nil)
+		s.Start(ctx, nil)
 	}()
 
 	<-started
 	return s, func() {
-		close(closing)
+		ctxCancel()
 		// we don't need to check the error, maybe the file doesn't exist
 		_ = os.Remove(stateFileName)
 	}

--- a/pkg/model/mselection/heaviest_test.go
+++ b/pkg/model/mselection/heaviest_test.go
@@ -1,6 +1,7 @@
 package mselection
 
 import (
+	"context"
 	"math"
 	"math/rand"
 	"testing"
@@ -168,7 +169,10 @@ func TestHeaviestSelector_SelectTipsCheckTresholds(t *testing.T) {
 			}
 		}
 
-		err := dag.TraverseParentsOfMessage(te.Storage(), tip,
+		err := dag.TraverseParentsOfMessage(
+			context.Background(),
+			te.Storage(),
+			tip,
 			// traversal stops if no more messages pass the given condition
 			// Caution: condition func is not in DFS order
 			func(cachedMetadata *storage.CachedMetadata) (bool, error) { // meta +1
@@ -192,7 +196,7 @@ func TestHeaviestSelector_SelectTipsCheckTresholds(t *testing.T) {
 				// if the parent is a solid entry point, use the index of the solid entry point as ORTSI
 				at, _ := te.Storage().SolidEntryPointsIndex(messageID)
 				updateIndexes(at, at)
-			}, false, nil)
+			}, false)
 		require.NoError(te.TestInterface, err)
 
 		return youngestConeRootIndex, oldestConeRootIndex
@@ -258,7 +262,7 @@ func TestHeaviestSelector_SelectTipsCheckTresholds(t *testing.T) {
 			return tips
 		},
 		func(_ milestone.Index, _ hornet.MessageIDs, conf *whiteflag.Confirmation, _ *whiteflag.ConfirmedMilestoneStats) {
-			dag.UpdateConeRootIndexes(te.Storage(), nil, conf.Mutations.MessagesReferenced, conf.MilestoneIndex)
+			_ = dag.UpdateConeRootIndexes(context.Background(), te.Storage(), nil, conf.Mutations.MessagesReferenced, conf.MilestoneIndex)
 		},
 	)
 

--- a/pkg/p2p/autopeering/autopeering.go
+++ b/pkg/p2p/autopeering/autopeering.go
@@ -1,6 +1,7 @@
 package autopeering
 
 import (
+	"context"
 	"fmt"
 	"hash/fnv"
 	"net"
@@ -376,7 +377,7 @@ func (a *AutopeeringManager) Init(localPeerContainer *LocalPeerContainer, initSe
 	a.selectionProtocol = selection.New(localPeerContainer.Local(), a.discoveryProtocol, selection.Logger(a.log.Named("sel")), selection.NeighborValidator(selection.ValidatorFunc(isValidPeer)))
 }
 
-func (a *AutopeeringManager) Run(shutdownSignal <-chan struct{}) {
+func (a *AutopeeringManager) Run(ctx context.Context) {
 	a.log.Info("\n\nWARNING: The autopeering plugin will disclose your public IP address to possibly all nodes and entry points. Please disable this plugin if you do not want this to happen!\n")
 
 	lPeer := a.localPeerContainer.Local()
@@ -411,7 +412,7 @@ func (a *AutopeeringManager) Run(shutdownSignal <-chan struct{}) {
 
 	a.log.Infof("started: Address=%s/%s PublicKey=%s", localAddr.String(), localAddr.Network(), lPeer.PublicKey().String())
 
-	<-shutdownSignal
+	<-ctx.Done()
 	a.log.Info("Stopping Autopeering ...")
 
 	if a.selectionProtocol != nil {

--- a/pkg/p2p/manager.go
+++ b/pkg/p2p/manager.go
@@ -237,15 +237,15 @@ type Manager struct {
 }
 
 // Start starts the Manager's event loop.
-// This method blocks until shutdownSignal has been signaled.
-func (m *Manager) Start(shutdownSignal <-chan struct{}) {
+// This method blocks until the given context is done.
+func (m *Manager) Start(ctx context.Context) {
 	// manage libp2p network events
 	m.host.Network().Notify((*netNotifiee)(m))
 
 	m.Events.StateChange.Trigger(ManagerStateStarted)
 
 	// run the event loop machinery
-	m.eventLoop(shutdownSignal)
+	m.eventLoop(ctx)
 
 	m.Events.StateChange.Trigger(ManagerStateStopping)
 
@@ -457,10 +457,10 @@ type callmsg struct {
 // because dealing with the natural concurrency of handling network connections
 // becomes very messy, especially since libp2p's notifiee system isn't clear on
 // what event is triggered when.
-func (m *Manager) eventLoop(shutdownSignal <-chan struct{}) {
+func (m *Manager) eventLoop(ctx context.Context) {
 	for {
 		select {
-		case <-shutdownSignal:
+		case <-ctx.Done():
 			m.shutdown()
 			return
 

--- a/pkg/p2p/manager_test.go
+++ b/pkg/p2p/manager_test.go
@@ -37,8 +37,6 @@ func newNode(ctx context.Context, t require.TestingT) host.Host {
 func TestManager(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	shutdownSignal := make(chan struct{})
-	defer close(shutdownSignal)
 
 	reconnectOpt := p2p.WithManagerReconnectInterval(1*time.Second, 500*time.Millisecond)
 
@@ -52,25 +50,25 @@ func TestManager(t *testing.T) {
 	node1 := newNode(ctx, t)
 	node1Logger := logger.NewLogger(fmt.Sprintf("node1/%s", node1.ID().ShortString()))
 	node1Manager := p2p.NewManager(node1, p2p.WithManagerLogger(node1Logger), reconnectOpt)
-	go node1Manager.Start(shutdownSignal)
+	go node1Manager.Start(ctx)
 	node1AddrInfo := &peer.AddrInfo{ID: node1.ID(), Addrs: node1.Addrs()[:1]}
 
 	node2 := newNode(ctx, t)
 	node2Logger := logger.NewLogger(fmt.Sprintf("node2/%s", node2.ID().ShortString()))
 	node2Manager := p2p.NewManager(node2, p2p.WithManagerLogger(node2Logger), reconnectOpt)
-	go node2Manager.Start(shutdownSignal)
+	go node2Manager.Start(ctx)
 	node2AddrInfo := &peer.AddrInfo{ID: node2.ID(), Addrs: node2.Addrs()[:1]}
 
 	node3 := newNode(ctx, t)
 	node3Logger := logger.NewLogger(fmt.Sprintf("node3/%s", node3.ID().ShortString()))
 	node3Manager := p2p.NewManager(node3, p2p.WithManagerLogger(node3Logger), reconnectOpt)
-	go node3Manager.Start(shutdownSignal)
+	go node3Manager.Start(ctx)
 	node3AddrInfo := &peer.AddrInfo{ID: node3.ID(), Addrs: node3.Addrs()[:1]}
 
 	node4 := newNode(ctx, t)
 	node4Logger := logger.NewLogger(fmt.Sprintf("node4/%s", node4.ID().ShortString()))
 	node4Manager := p2p.NewManager(node4, p2p.WithManagerLogger(node4Logger), reconnectOpt)
-	go node4Manager.Start(shutdownSignal)
+	go node4Manager.Start(ctx)
 	node4AddrInfo := &peer.AddrInfo{ID: node4.ID(), Addrs: node4.Addrs()[:1]}
 
 	//fmt.Println("node 1", node1.ID())
@@ -208,8 +206,6 @@ func connections(t *testing.T, node host.Host, targets peer.IDSlice) {
 func TestManagerEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	shutdownSignal := make(chan struct{})
-	defer close(shutdownSignal)
 
 	cfg := configuration.New()
 	err := cfg.Set("logger.disableStacktrace", true)
@@ -223,14 +219,14 @@ func TestManagerEvents(t *testing.T) {
 	node1 := newNode(ctx, t)
 	node1Logger := logger.NewLogger(fmt.Sprintf("node1/%s", node1.ID().ShortString()))
 	node1Manager := p2p.NewManager(node1, p2p.WithManagerLogger(node1Logger), reconnectOpt)
-	go node1Manager.Start(shutdownSignal)
+	go node1Manager.Start(ctx)
 	node1AddrInfo := &peer.AddrInfo{ID: node1.ID(), Addrs: node1.Addrs()}
 	_ = node1AddrInfo
 
 	node2 := newNode(ctx, t)
 	node2Logger := logger.NewLogger(fmt.Sprintf("node2/%s", node2.ID().ShortString()))
 	node2Manager := p2p.NewManager(node2, p2p.WithManagerLogger(node2Logger), reconnectOpt)
-	go node2Manager.Start(shutdownSignal)
+	go node2Manager.Start(ctx)
 	node2AddrInfo := &peer.AddrInfo{ID: node2.ID(), Addrs: node2.Addrs()}
 
 	var connectCalled, connectedCalled bool
@@ -312,11 +308,9 @@ func TestManagerEvents(t *testing.T) {
 func BenchmarkManager_ForEach(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	shutdownSignal := make(chan struct{})
-	defer close(shutdownSignal)
 	node1 := newNode(ctx, b)
 	node1Manager := p2p.NewManager(node1)
-	go node1Manager.Start(shutdownSignal)
+	go node1Manager.Start(ctx)
 	time.Sleep(1 * time.Second)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/pow/pow.go
+++ b/pkg/pow/pow.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gohornet/hornet/pkg/common"
 	"github.com/gohornet/hornet/pkg/model/hornet"
+	"github.com/gohornet/hornet/pkg/utils"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/syncutils"
 	iotago "github.com/iotaledger/iota.go/v2"
@@ -166,12 +167,10 @@ func (h *Handler) PoWType() string {
 // DoPoW does the proof-of-work required to hit the target score configured on this Handler.
 // The given iota.Message's nonce is automatically updated.
 // If a powsrv.io key was provided, then powsrv.io is used to commence the proof-of-work.
-func (h *Handler) DoPoW(msg *iotago.Message, shutdownSignal <-chan struct{}, parallelism int, refreshTipsFunc ...RefreshTipsFunc) (err error) {
+func (h *Handler) DoPoW(ctx context.Context, msg *iotago.Message, parallelism int, refreshTipsFunc ...RefreshTipsFunc) (err error) {
 
-	select {
-	case <-shutdownSignal:
-		return common.ErrOperationAborted
-	default:
+	if err := utils.ReturnErrIfCtxDone(ctx, common.ErrOperationAborted); err != nil {
+		return err
 	}
 
 	getPoWData := func(msg *iotago.Message) (powData []byte, err error) {

--- a/pkg/protocol/gossip/broadcaster.go
+++ b/pkg/protocol/gossip/broadcaster.go
@@ -1,6 +1,8 @@
 package gossip
 
 import (
+	"context"
+
 	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/model/syncmanager"
 	"github.com/gohornet/hornet/pkg/p2p"
@@ -38,11 +40,11 @@ func NewBroadcaster(
 }
 
 // RunBroadcastQueueDrainer runs the broadcast queue drainer.
-func (b *Broadcaster) RunBroadcastQueueDrainer(shutdownSignal <-chan struct{}) {
+func (b *Broadcaster) RunBroadcastQueueDrainer(ctx context.Context) {
 exit:
 	for {
 		select {
-		case <-shutdownSignal:
+		case <-ctx.Done():
 			break exit
 		case broadcast := <-b.queue:
 			b.service.ForEach(func(proto *Protocol) bool {

--- a/pkg/protocol/gossip/msg_proc_test.go
+++ b/pkg/protocol/gossip/msg_proc_test.go
@@ -28,9 +28,6 @@ func TestMsgProcessorEmit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	shutdownSignal := make(chan struct{})
-	defer close(shutdownSignal)
-
 	te := testsuite.SetupTestEnvironment(t, &iotago.Ed25519Address{}, 0, BelowMaxDepth, MinPoWScore, false)
 	defer te.CleanupTestEnvironment(true)
 
@@ -46,10 +43,10 @@ func TestMsgProcessorEmit(t *testing.T) {
 	serverMetrics := &metrics.ServerMetrics{}
 
 	manager := p2p.NewManager(n)
-	go manager.Start(shutdownSignal)
+	go manager.Start(ctx)
 
 	service := gossip.NewService(protocolID, n, manager, serverMetrics)
-	go service.Start(shutdownSignal)
+	go service.Start(ctx)
 
 	networkID := iotago.NetworkIDFromString("testnet4")
 
@@ -92,7 +89,7 @@ func TestMsgProcessorEmit(t *testing.T) {
 	msg.Parents = iotago.MessageIDs{[32]byte{}}
 
 	// pow again, so we have a valid message
-	err = te.PoWHandler.DoPoW(msg, nil, 1)
+	err = te.PoWHandler.DoPoW(context.Background(), msg, 1)
 	assert.NoError(t, err)
 
 	// need to create a new message, so the iotago message is serialized again
@@ -107,7 +104,7 @@ func TestMsgProcessorEmit(t *testing.T) {
 	msg.NetworkID = 1
 
 	// pow again, so we have a valid message
-	err = te.PoWHandler.DoPoW(msg, nil, 1)
+	err = te.PoWHandler.DoPoW(context.Background(), msg, 1)
 	assert.NoError(t, err)
 
 	// need to create a new message, so the iotago message is serialized again
@@ -122,7 +119,7 @@ func TestMsgProcessorEmit(t *testing.T) {
 	msg.NetworkID = networkID
 
 	// pow again, so we have a valid message
-	err = te.PoWHandler.DoPoW(msg, nil, 1)
+	err = te.PoWHandler.DoPoW(context.Background(), msg, 1)
 	assert.NoError(t, err)
 
 	// need to create a new message, so the iotago message is serialized again

--- a/pkg/protocol/gossip/requester.go
+++ b/pkg/protocol/gossip/requester.go
@@ -1,6 +1,7 @@
 package gossip
 
 import (
+	"context"
 	"time"
 
 	"github.com/gohornet/hornet/pkg/model/hornet"
@@ -82,11 +83,11 @@ func NewRequester(
 }
 
 // RunRequestQueueDrainer runs the RequestQueue drainer.
-func (r *Requester) RunRequestQueueDrainer(shutdownSignal <-chan struct{}) {
+func (r *Requester) RunRequestQueueDrainer(ctx context.Context) {
 	r.running = true
 	for {
 		select {
-		case <-shutdownSignal:
+		case <-ctx.Done():
 			return
 		case <-r.drainSignal:
 
@@ -137,13 +138,13 @@ func (r *Requester) RunRequestQueueDrainer(shutdownSignal <-chan struct{}) {
 }
 
 // RunPendingRequestEnqueuer runs the loop to periodically re-request pending requests from the RequestQueue.
-func (r *Requester) RunPendingRequestEnqueuer(shutdownSignal <-chan struct{}) {
+func (r *Requester) RunPendingRequestEnqueuer(ctx context.Context) {
 	r.running = true
 	reEnqueueTicker := time.NewTicker(r.opts.PendingRequestReEnqueueInterval)
 reEnqueueLoop:
 	for {
 		select {
-		case <-shutdownSignal:
+		case <-ctx.Done():
 			return
 		case <-reEnqueueTicker.C:
 

--- a/pkg/protocol/gossip/service.go
+++ b/pkg/protocol/gossip/service.go
@@ -257,7 +257,7 @@ func (s *Service) SynchronizedCount(latestMilestoneIndex milestone.Index) int {
 }
 
 // Start starts the Service's event loop.
-func (s *Service) Start(shutdownSignal <-chan struct{}) {
+func (s *Service) Start(ctx context.Context) {
 	s.host.SetStreamHandler(s.protocol, func(stream network.Stream) {
 		if s.stopped.IsSet() {
 			return
@@ -284,7 +284,7 @@ func (s *Service) Start(shutdownSignal <-chan struct{}) {
 	}))
 	// manage libp2p network events
 	s.host.Network().Notify((*netNotifiee)(s))
-	s.eventLoop(shutdownSignal)
+	s.eventLoop(ctx)
 	// de-register libp2p network events
 	s.host.Network().StopNotify((*netNotifiee)(s))
 }
@@ -347,10 +347,10 @@ type foreachmsg struct {
 }
 
 // runs the Service's event loop, handling inbound/outbound streams.
-func (s *Service) eventLoop(shutdownSignal <-chan struct{}) {
+func (s *Service) eventLoop(ctx context.Context) {
 	for {
 		select {
-		case <-shutdownSignal:
+		case <-ctx.Done():
 			s.shutdown()
 			return
 

--- a/pkg/protocol/gossip/service_test.go
+++ b/pkg/protocol/gossip/service_test.go
@@ -23,7 +23,7 @@ import (
 
 const protocolID = "/iota/abcdf/1.0.0"
 
-func newNode(name string, ctx context.Context, t *testing.T, shutdownSignal chan struct{}, mngOpts []p2p.ManagerOption, srvOpts []gossip.ServiceOption) (
+func newNode(name string, ctx context.Context, t *testing.T, mngOpts []p2p.ManagerOption, srvOpts []gossip.ServiceOption) (
 	host.Host, *p2p.Manager, *gossip.Service, peer.AddrInfo,
 ) {
 	// we use Ed25519 because otherwise it takes longer as the default is RSA
@@ -41,18 +41,16 @@ func newNode(name string, ctx context.Context, t *testing.T, shutdownSignal chan
 	nLogger := logger.NewLogger(fmt.Sprintf("%s/%s", name, n.ID().ShortString()))
 
 	nManager := p2p.NewManager(n, append(mngOpts, p2p.WithManagerLogger(nLogger))...)
-	go nManager.Start(shutdownSignal)
+	go nManager.Start(ctx)
 
 	service := gossip.NewService(protocolID, n, nManager, serverMetrics, append(srvOpts, gossip.WithLogger(nLogger))...)
-	go service.Start(shutdownSignal)
+	go service.Start(ctx)
 	return n, nManager, service, peer.AddrInfo{ID: n.ID(), Addrs: n.Addrs()}
 }
 
 func TestServiceEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	shutdownSignal := make(chan struct{})
-	defer close(shutdownSignal)
 
 	cfg := configuration.New()
 	err := cfg.Set("logger.disableStacktrace", true)
@@ -66,8 +64,8 @@ func TestServiceEvents(t *testing.T) {
 	}
 	var srvOpts []gossip.ServiceOption
 
-	node1, node1Manager, node1Service, node1AddrInfo := newNode("node1", ctx, t, shutdownSignal, mngOpts, srvOpts)
-	node2, node2Manager, node2Service, node2AddrInfo := newNode("node2", ctx, t, shutdownSignal, mngOpts, srvOpts)
+	node1, node1Manager, node1Service, node1AddrInfo := newNode("node1", ctx, t, mngOpts, srvOpts)
+	node2, node2Manager, node2Service, node2AddrInfo := newNode("node2", ctx, t, mngOpts, srvOpts)
 
 	fmt.Println("node 1", node1.ID().ShortString())
 	fmt.Println("node 2", node2.ID().ShortString())
@@ -171,8 +169,6 @@ func connectivity(t *testing.T, source *p2p.Manager, target peer.ID, disconnecte
 func TestWithUnknownPeersLimit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	shutdownSignal := make(chan struct{})
-	defer close(shutdownSignal)
 
 	cfg := configuration.New()
 	err := cfg.Set("logger.disableStacktrace", true)
@@ -188,9 +184,9 @@ func TestWithUnknownPeersLimit(t *testing.T) {
 		gossip.WithUnknownPeersLimit(1),
 	}
 
-	node1, node1Manager, node1Service, node1AddrInfo := newNode("node1", ctx, t, shutdownSignal, mngOpts, srvOpts)
-	node2, node2Manager, node2Service, node2AddrInfo := newNode("node2", ctx, t, shutdownSignal, mngOpts, srvOpts)
-	node3, node3Manager, node3Service, _ := newNode("node3", ctx, t, shutdownSignal, mngOpts, []gossip.ServiceOption{
+	node1, node1Manager, node1Service, node1AddrInfo := newNode("node1", ctx, t, mngOpts, srvOpts)
+	node2, node2Manager, node2Service, node2AddrInfo := newNode("node2", ctx, t, mngOpts, srvOpts)
+	node3, node3Manager, node3Service, _ := newNode("node3", ctx, t, mngOpts, []gossip.ServiceOption{
 		gossip.WithUnknownPeersLimit(2),
 	})
 

--- a/pkg/spammer/spammer.go
+++ b/pkg/spammer/spammer.go
@@ -1,6 +1,7 @@
 package spammer
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -44,7 +45,7 @@ func New(networkID uint64, message string, index string, indexSemiLazy string, t
 	}
 }
 
-func (s *Spammer) DoSpam(shutdownSignal <-chan struct{}) (time.Duration, time.Duration, error) {
+func (s *Spammer) DoSpam(ctx context.Context) (time.Duration, time.Duration, error) {
 
 	timeStart := time.Now()
 	isSemiLazy, tips, err := s.tipselFunc()
@@ -78,7 +79,7 @@ func (s *Spammer) DoSpam(shutdownSignal <-chan struct{}) (time.Duration, time.Du
 	}
 
 	timeStart = time.Now()
-	if err := s.powHandler.DoPoW(iotaMsg, shutdownSignal, 1, func() (tips hornet.MessageIDs, err error) {
+	if err := s.powHandler.DoPoW(ctx, iotaMsg, 1, func() (tips hornet.MessageIDs, err error) {
 		// refresh tips of the spammer if PoW takes longer than a configured duration.
 		_, refreshedTips, err := s.tipselFunc()
 		return refreshedTips, err

--- a/pkg/tangle/revalidation.go
+++ b/pkg/tangle/revalidation.go
@@ -562,7 +562,7 @@ func (t *Tangle) applySnapshotLedger(snapshotInfo *storage.SnapshotInfo, snapsho
 	t.syncManager.OverwriteConfirmedMilestoneIndex(0)
 
 	// Restore the ledger state of the last snapshot
-	if err := snapshotManager.ImportSnapshots(); err != nil {
+	if err := snapshotManager.ImportSnapshots(t.shutdownCtx); err != nil {
 		t.log.Panic(err)
 	}
 

--- a/pkg/testsuite/tangle.go
+++ b/pkg/testsuite/tangle.go
@@ -2,6 +2,7 @@ package testsuite
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"github.com/stretchr/testify/require"
@@ -100,7 +101,10 @@ func (te *TestEnvironment) generateDotFileFromConfirmation(conf *whiteflag.Confi
 
 	visitedCachedMessages := make(map[string]*storage.CachedMessage)
 
-	err := dag.TraverseParentsOfMessage(te.storage, conf.MilestoneMessageID,
+	err := dag.TraverseParentsOfMessage(
+		context.Background(),
+		te.storage,
+		conf.MilestoneMessageID,
 		// traversal stops if no more messages pass the given condition
 		// Caution: condition func is not in DFS order
 		func(cachedMsgMeta *storage.CachedMetadata) (bool, error) { // meta +1
@@ -124,7 +128,7 @@ func (te *TestEnvironment) generateDotFileFromConfirmation(conf *whiteflag.Confi
 		// called on solid entry points
 		// Ignore solid entry points (snapshot milestone included)
 		nil,
-		false, nil)
+		false)
 	require.NoError(te.TestInterface, err)
 
 	var milestoneMsgs []string

--- a/pkg/testsuite/utils.go
+++ b/pkg/testsuite/utils.go
@@ -1,6 +1,7 @@
 package testsuite
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 
@@ -97,7 +98,7 @@ func (b *MessageBuilder) BuildIndexation() *Message {
 	msg, err := iotago.NewMessageBuilder().Parents(parents).Payload(&iotago.Indexation{Index: []byte(b.indexation), Data: nil}).Build()
 	require.NoError(b.te.TestInterface, err)
 
-	err = b.te.PoWHandler.DoPoW(msg, nil, 1)
+	err = b.te.PoWHandler.DoPoW(context.Background(), msg, 1)
 	require.NoError(b.te.TestInterface, err)
 
 	message, err := storage.NewMessage(msg, iotago.DeSeriModePerformValidation)
@@ -178,7 +179,7 @@ func (b *MessageBuilder) Build() *Message {
 	msg, err := iotago.NewMessageBuilder().Parents(b.parents.ToSliceOfSlices()).Payload(transaction).Build()
 	require.NoError(b.te.TestInterface, err)
 
-	err = b.te.PoWHandler.DoPoW(msg, nil, 1)
+	err = b.te.PoWHandler.DoPoW(context.Background(), msg, 1)
 	require.NoError(b.te.TestInterface, err)
 
 	message, err := storage.NewMessage(msg, iotago.DeSeriModePerformValidation)

--- a/pkg/whiteflag/confirmation.go
+++ b/pkg/whiteflag/confirmation.go
@@ -1,6 +1,7 @@
 package whiteflag
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"time"
@@ -83,7 +84,9 @@ func ConfirmMilestone(
 
 	timeStart := time.Now()
 
-	mutations, err := ComputeWhiteFlagMutations(dbStorage, milestoneIndex, metadataMemcache, messagesMemcache, message.Parents())
+	// we pass a background context here to not cancel the whiteflag computation!
+	// otherwise the node could panic at shutdown.
+	mutations, err := ComputeWhiteFlagMutations(context.Background(), dbStorage, milestoneIndex, metadataMemcache, messagesMemcache, message.Parents())
 	if err != nil {
 		// According to the RFC we should panic if we encounter any invalid messages during confirmation
 		return nil, nil, fmt.Errorf("confirmMilestone: whiteflag.ComputeConfirmation failed with Error: %w", err)

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -1,6 +1,7 @@
 package autopeering
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -222,9 +223,9 @@ func configure() {
 }
 
 func run() {
-	if err := Plugin.Node.Daemon().BackgroundWorker(Plugin.Name, func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Node.Daemon().BackgroundWorker(Plugin.Name, func(ctx context.Context) {
 		attachEvents()
-		deps.AutopeeringManager.Run(shutdownSignal)
+		deps.AutopeeringManager.Run(ctx)
 		detachEvents()
 	}, shutdown.PriorityAutopeering); err != nil {
 		Plugin.Panicf("failed to start worker: %s", err)

--- a/plugins/dashboard/livefeed.go
+++ b/plugins/dashboard/livefeed.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"context"
+
 	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/shutdown"
 	"github.com/iotaledger/hive.go/events"
@@ -14,11 +16,11 @@ func runLiveFeed() {
 		}
 	})
 
-	if err := Plugin.Daemon().BackgroundWorker("Dashboard[TxUpdater]", func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Daemon().BackgroundWorker("Dashboard[TxUpdater]", func(ctx context.Context) {
 		deps.Tangle.Events.LatestMilestoneIndexChanged.Attach(onLatestMilestoneIndexChanged)
 		defer deps.Tangle.Events.LatestMilestoneIndexChanged.Detach(onLatestMilestoneIndexChanged)
 
-		<-shutdownSignal
+		<-ctx.Done()
 		Plugin.LogInfo("Stopping Dashboard[TxUpdater] ...")
 		Plugin.LogInfo("Stopping Dashboard[TxUpdater] ... done")
 	}, shutdown.PriorityDashboard); err != nil {

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"net/http"
 	"runtime"
 	"time"
@@ -193,13 +194,13 @@ func run() {
 		hub.BroadcastMsg(&Msg{Type: MsgTypeConfirmedMsMetrics, Data: []*tangle.ConfirmedMilestoneMetric{metric}})
 	})
 
-	if err := Plugin.Daemon().BackgroundWorker("Dashboard[WSSend]", func(shutdownSignal <-chan struct{}) {
-		go hub.Run(shutdownSignal)
+	if err := Plugin.Daemon().BackgroundWorker("Dashboard[WSSend]", func(ctx context.Context) {
+		go hub.Run(ctx)
 		deps.Tangle.Events.MPSMetricsUpdated.Attach(onMPSMetricsUpdated)
 		deps.Tangle.Events.ConfirmedMilestoneIndexChanged.Attach(onConfirmedMilestoneIndexChanged)
 		deps.Tangle.Events.LatestMilestoneIndexChanged.Attach(onLatestMilestoneIndexChanged)
 		deps.Tangle.Events.NewConfirmedMilestoneMetric.Attach(onNewConfirmedMilestoneMetric)
-		<-shutdownSignal
+		<-ctx.Done()
 		Plugin.LogInfo("Stopping Dashboard[WSSend] ...")
 		deps.Tangle.Events.MPSMetricsUpdated.Detach(onMPSMetricsUpdated)
 		deps.Tangle.Events.ConfirmedMilestoneIndexChanged.Detach(onConfirmedMilestoneIndexChanged)

--- a/plugins/dashboard/spammer.go
+++ b/plugins/dashboard/spammer.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"context"
+
 	"github.com/gohornet/hornet/pkg/shutdown"
 	"github.com/gohornet/hornet/pkg/spammer"
 	spammerplugin "github.com/gohornet/hornet/plugins/spammer"
@@ -17,10 +19,10 @@ func runSpammerMetricWorker() {
 		hub.BroadcastMsg(&Msg{Type: MsgTypeAvgSpamMetrics, Data: metrics})
 	})
 
-	if err := Plugin.Daemon().BackgroundWorker("Dashboard[SpammerMetricUpdater]", func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Daemon().BackgroundWorker("Dashboard[SpammerMetricUpdater]", func(ctx context.Context) {
 		spammerplugin.Events.SpamPerformed.Attach(onSpamPerformed)
 		spammerplugin.Events.AvgSpamMetricsUpdated.Attach(onAvgSpamMetricsUpdated)
-		<-shutdownSignal
+		<-ctx.Done()
 		Plugin.LogInfo("Stopping Dashboard[SpammerMetricUpdater] ...")
 		spammerplugin.Events.SpamPerformed.Detach(onSpamPerformed)
 		spammerplugin.Events.AvgSpamMetricsUpdated.Detach(onAvgSpamMetricsUpdated)

--- a/plugins/dashboard/tipsel.go
+++ b/plugins/dashboard/tipsel.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"context"
+
 	"github.com/gohornet/hornet/pkg/shutdown"
 	"github.com/gohornet/hornet/pkg/tipselect"
 	"github.com/gohornet/hornet/plugins/urts"
@@ -18,9 +20,9 @@ func runTipSelMetricWorker() {
 		hub.BroadcastMsg(&Msg{Type: MsgTypeTipSelMetric, Data: metrics})
 	})
 
-	if err := Plugin.Daemon().BackgroundWorker("Dashboard[TipSelMetricUpdater]", func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Daemon().BackgroundWorker("Dashboard[TipSelMetricUpdater]", func(ctx context.Context) {
 		deps.TipSelector.Events.TipSelPerformed.Attach(onTipSelPerformed)
-		<-shutdownSignal
+		<-ctx.Done()
 		Plugin.LogInfo("Stopping Dashboard[TipSelMetricUpdater] ...")
 		deps.TipSelector.Events.TipSelPerformed.Detach(onTipSelPerformed)
 		Plugin.LogInfo("Stopping Dashboard[TipSelMetricUpdater] ... done")

--- a/plugins/dashboard/visualizer.go
+++ b/plugins/dashboard/visualizer.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"context"
+
 	"github.com/gohornet/hornet/pkg/model/hornet"
 	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/model/storage"
@@ -175,7 +177,7 @@ func runVisualizer() {
 		)
 	})
 
-	if err := Plugin.Daemon().BackgroundWorker("Dashboard[Visualizer]", func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Daemon().BackgroundWorker("Dashboard[Visualizer]", func(ctx context.Context) {
 		deps.Tangle.Events.ReceivedNewMessage.Attach(onReceivedNewMessage)
 		defer deps.Tangle.Events.ReceivedNewMessage.Detach(onReceivedNewMessage)
 		deps.Tangle.Events.MessageSolid.Attach(onMessageSolid)
@@ -196,7 +198,7 @@ func runVisualizer() {
 			defer deps.TipSelector.Events.TipRemoved.Detach(onTipRemoved)
 		}
 
-		<-shutdownSignal
+		<-ctx.Done()
 
 		Plugin.LogInfo("Stopping Dashboard[Visualizer] ...")
 		Plugin.LogInfo("Stopping Dashboard[Visualizer] ... done")

--- a/plugins/faucet/plugin.go
+++ b/plugins/faucet/plugin.go
@@ -1,6 +1,7 @@
 package faucet
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -220,8 +221,8 @@ func configure() {
 
 func run() {
 	// create a background worker that handles the enqueued faucet requests
-	if err := Plugin.Daemon().BackgroundWorker("Faucet", func(shutdownSignal <-chan struct{}) {
-		if err := deps.Faucet.RunFaucetLoop(shutdownSignal); err != nil {
+	if err := Plugin.Daemon().BackgroundWorker("Faucet", func(ctx context.Context) {
+		if err := deps.Faucet.RunFaucetLoop(ctx); err != nil {
 			deps.ShutdownHandler.SelfShutdown(fmt.Sprintf("faucet plugin hit a critical error: %s", err.Error()))
 		}
 	}, shutdown.PriorityFaucet); err != nil {

--- a/plugins/mqtt/plugin.go
+++ b/plugins/mqtt/plugin.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -295,7 +296,7 @@ func run() {
 		receiptWorkerPool.TrySubmit(receipt)
 	})
 
-	if err := Plugin.Daemon().BackgroundWorker("MQTT Broker", func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Daemon().BackgroundWorker("MQTT Broker", func(ctx context.Context) {
 		go func() {
 			mqttBroker.Start()
 			Plugin.LogInfof("Starting MQTT Broker (port %s) ... done", mqttBroker.Config().Port)
@@ -309,14 +310,14 @@ func run() {
 			Plugin.LogInfof("You can now listen to MQTT via: https://%s:%s", mqttBroker.Config().TlsHost, mqttBroker.Config().TlsPort)
 		}
 
-		<-shutdownSignal
+		<-ctx.Done()
 		Plugin.LogInfo("Stopping MQTT Broker ...")
 		Plugin.LogInfo("Stopping MQTT Broker ... done")
 	}, shutdown.PriorityMetricsPublishers); err != nil {
 		Plugin.Panicf("failed to start worker: %s", err)
 	}
 
-	if err := Plugin.Daemon().BackgroundWorker("MQTT Events", func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Daemon().BackgroundWorker("MQTT Events", func(ctx context.Context) {
 		Plugin.LogInfo("Starting MQTT Events ... done")
 
 		deps.Tangle.Events.LatestMilestoneChanged.Attach(onLatestMilestoneChanged)
@@ -339,7 +340,7 @@ func run() {
 		utxoOutputWorkerPool.Start()
 		receiptWorkerPool.Start()
 
-		<-shutdownSignal
+		<-ctx.Done()
 
 		deps.Tangle.Events.LatestMilestoneChanged.Detach(onLatestMilestoneChanged)
 		deps.Tangle.Events.ConfirmedMilestoneChanged.Detach(onConfirmedMilestoneChanged)

--- a/plugins/mqtt/plugin.go
+++ b/plugins/mqtt/plugin.go
@@ -186,10 +186,10 @@ func configure() {
 
 	var err error
 	mqttBroker, err = mqttpkg.NewBroker(deps.NodeConfig.String(CfgMQTTBindAddress), deps.NodeConfig.Int(CfgMQTTWSPort), "/ws", deps.NodeConfig.Int(CfgMQTTWorkerCount), func(topic []byte) {
-		Plugin.LogInfof("Subscribe to topic: %s", string(topic))
+		Plugin.LogDebugf("Subscribe to topic: %s", string(topic))
 		topicSubscriptionWorkerPool.TrySubmit(topic)
 	}, func(topic []byte) {
-		Plugin.LogInfof("Unsubscribe from topic: %s", string(topic))
+		Plugin.LogDebugf("Unsubscribe from topic: %s", string(topic))
 	})
 
 	if err != nil {

--- a/plugins/restapi/plugin.go
+++ b/plugins/restapi/plugin.go
@@ -128,7 +128,7 @@ func run() {
 
 	Plugin.LogInfo("Starting REST-API server ...")
 
-	if err := Plugin.Daemon().BackgroundWorker("REST-API server", func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Daemon().BackgroundWorker("REST-API server", func(ctx context.Context) {
 		Plugin.LogInfo("Starting REST-API server ... done")
 
 		bindAddr := deps.RestAPIBindAddress
@@ -141,15 +141,15 @@ func run() {
 			}
 		}()
 
-		<-shutdownSignal
+		<-ctx.Done()
 		Plugin.LogInfo("Stopping REST-API server ...")
 
 		if server != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if err := server.Shutdown(ctx); err != nil {
+			shutdownCtx, shutdownCtxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := server.Shutdown(shutdownCtx); err != nil {
 				Plugin.LogWarn(err)
 			}
-			cancel()
+			shutdownCtxCancel()
 		}
 		Plugin.LogInfo("Stopping REST-API server ... done")
 	}, shutdown.PriorityRestAPI); err != nil {

--- a/plugins/spammer/cpu_usage.go
+++ b/plugins/spammer/cpu_usage.go
@@ -1,6 +1,7 @@
 package spammer
 
 import (
+	"context"
 	"math/rand"
 	"runtime"
 	"time"
@@ -62,7 +63,7 @@ func cpuUsageGuessWithAdditionalWorker() (float64, error) {
 }
 
 // waitForLowerCPUUsage waits until the cpu usage drops below cpuMaxUsage.
-func waitForLowerCPUUsage(cpuMaxUsage float64, shutdownSignal <-chan struct{}) error {
+func waitForLowerCPUUsage(ctx context.Context, cpuMaxUsage float64) error {
 	if cpuMaxUsage == 0.0 {
 		return nil
 	}
@@ -78,7 +79,7 @@ func waitForLowerCPUUsage(cpuMaxUsage float64, shutdownSignal <-chan struct{}) e
 		}
 
 		select {
-		case <-shutdownSignal:
+		case <-ctx.Done():
 			return common.ErrOperationAborted
 		default:
 		}

--- a/plugins/urts/plugin.go
+++ b/plugins/urts/plugin.go
@@ -1,10 +1,13 @@
 package urts
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"go.uber.org/dig"
 
+	"github.com/gohornet/hornet/pkg/common"
 	"github.com/gohornet/hornet/pkg/metrics"
 	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/model/syncmanager"
@@ -43,9 +46,10 @@ var (
 
 type dependencies struct {
 	dig.In
-	TipSelector *tipselect.TipSelector
-	SyncManager *syncmanager.SyncManager
-	Tangle      *tangle.Tangle
+	TipSelector     *tipselect.TipSelector
+	SyncManager     *syncmanager.SyncManager
+	Tangle          *tangle.Tangle
+	ShutdownHandler *shutdown.ShutdownHandler
 }
 
 func initConfigPars(c *dig.Container) {
@@ -88,6 +92,7 @@ func provide(c *dig.Container) {
 
 	if err := c.Provide(func(deps tipselDeps) *tipselect.TipSelector {
 		return tipselect.New(
+			Plugin.Daemon().ContextStopped(),
 			deps.Storage,
 			deps.SyncManager,
 			deps.ServerMetrics,
@@ -117,18 +122,18 @@ func configure() {
 
 func run() {
 
-	if err := Plugin.Daemon().BackgroundWorker("Tipselection[Events]", func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Daemon().BackgroundWorker("Tipselection[Events]", func(ctx context.Context) {
 		attachEvents()
-		<-shutdownSignal
+		<-ctx.Done()
 		detachEvents()
 	}, shutdown.PriorityTipselection); err != nil {
 		Plugin.Panicf("failed to start worker: %s", err)
 	}
 
-	if err := Plugin.Daemon().BackgroundWorker("Tipselection[Cleanup]", func(shutdownSignal <-chan struct{}) {
+	if err := Plugin.Daemon().BackgroundWorker("Tipselection[Cleanup]", func(ctx context.Context) {
 		for {
 			select {
-			case <-shutdownSignal:
+			case <-ctx.Done():
 				return
 			case <-time.After(time.Second):
 				ts := time.Now()
@@ -160,7 +165,10 @@ func configureEvents() {
 		}
 
 		ts := time.Now()
-		removedTipCount := deps.TipSelector.UpdateScores()
+		removedTipCount, err := deps.TipSelector.UpdateScores()
+		if err != nil && err != common.ErrOperationAborted {
+			deps.ShutdownHandler.SelfShutdown(fmt.Sprintf("urts tipselection plugin hit a critical error while updating scores: %s", err))
+		}
 		Plugin.LogDebugf("UpdateScores finished, removed: %d, took: %v", removedTipCount, time.Since(ts).Truncate(time.Millisecond))
 	})
 }

--- a/plugins/versioncheck/plugin.go
+++ b/plugins/versioncheck/plugin.go
@@ -1,6 +1,7 @@
 package versioncheck
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -50,8 +51,8 @@ func configure() {
 
 func run() {
 	// create a background worker that checks for latest version every hour
-	if err := Plugin.Node.Daemon().BackgroundWorker("Version update checker", func(shutdownSignal <-chan struct{}) {
-		ticker := timeutil.NewTicker(checkLatestVersion, 1*time.Hour, shutdownSignal)
+	if err := Plugin.Node.Daemon().BackgroundWorker("Version update checker", func(ctx context.Context) {
+		ticker := timeutil.NewTicker(checkLatestVersion, 1*time.Hour, ctx)
 		ticker.WaitForGracefulShutdown()
 	}, shutdown.PriorityUpdateCheck); err != nil {
 		Plugin.Panicf("failed to start worker: %s", err)


### PR DESCRIPTION
This PR replaces most of the signal channels we used for cancellation or shutdown with contexts.

This is more go-idiomatic.