### PR TITLE
Separate UTXO database

### DIFF
--- a/.github/workflows/test_HORNET.yml
+++ b/.github/workflows/test_HORNET.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: go test `go list ./... | grep -v -e integration-tests -e testsuite -e whiteflag`
+          command: go test `go list ./... | grep -v -e integration-tests`

--- a/core/database/core.go
+++ b/core/database/core.go
@@ -28,6 +28,9 @@ const (
 	CfgTangleDeleteDatabase = "deleteDatabase"
 	// whether to delete the database and snapshots at startup
 	CfgTangleDeleteAll = "deleteAll"
+
+	TangleDatabaseDirectoryName = "tangle"
+	UTXODatabaseDirectoryName   = "utxo"
 )
 
 func init() {
@@ -93,8 +96,8 @@ func initConfigPars(c *dig.Container) {
 		return cfgResult{
 			DatabaseEngine:           dbEngine,
 			DatabasePath:             databasePath,
-			TangleDatabasePath:       filepath.Join(databasePath, "tangle"),
-			UTXODatabasePath:         filepath.Join(databasePath, "utxo"),
+			TangleDatabasePath:       filepath.Join(databasePath, TangleDatabaseDirectoryName),
+			UTXODatabasePath:         filepath.Join(databasePath, UTXODatabaseDirectoryName),
 			DeleteDatabaseFlag:       *deleteDatabase,
 			DeleteAllFlag:            *deleteAll,
 			DatabaseDebug:            deps.NodeConfig.Bool(CfgDatabaseDebug),

--- a/core/database/core.go
+++ b/core/database/core.go
@@ -202,19 +202,22 @@ func provide(c *dig.Container) {
 		Profile        *profile.Profile
 	}
 
-	if err := c.Provide(func(deps storageDeps) *storage.Storage {
+	type storageOut struct {
+		dig.Out
+		Storage     *storage.Storage
+		UTXOManager *utxo.Manager
+	}
+
+	if err := c.Provide(func(deps storageDeps) storageOut {
 
 		store, err := storage.New(deps.TangleDatabase.KVStore(), deps.UTXODatabase.KVStore(), deps.Profile.Caches)
 		if err != nil {
 			CorePlugin.Panicf("can't initialize storage: %s", err)
 		}
-		return store
-	}); err != nil {
-		CorePlugin.Panic(err)
-	}
-
-	if err := c.Provide(func(storage *storage.Storage) *utxo.Manager {
-		return storage.UTXOManager()
+		return storageOut{
+			Storage:     store,
+			UTXOManager: store.UTXOManager(),
+		}
 	}); err != nil {
 		CorePlugin.Panic(err)
 	}

--- a/core/database/core.go
+++ b/core/database/core.go
@@ -142,6 +142,11 @@ func provide(c *dig.Container) {
 			}
 		}
 
+		// Check if we need to migrate a legacy database into the split format
+		if err := SplitIntoTangleAndUTXO(deps.DatabasePath); err != nil {
+			CorePlugin.Panic(err)
+		}
+
 		targetEngine, err := database.CheckDatabaseEngine(deps.TangleDatabasePath, true, deps.DatabaseEngine)
 		if err != nil {
 			CorePlugin.Panic(err)

--- a/core/database/core.go
+++ b/core/database/core.go
@@ -273,7 +273,7 @@ func configure() {
 		}
 
 		CorePlugin.LogInfo("Syncing databases to disk...")
-		if err = closeDatabases(); err != nil {
+		if err = deps.Storage.FlushAndCloseStores(); err != nil {
 			CorePlugin.Panicf("Syncing databases to disk... failed: %s", err)
 		}
 		CorePlugin.LogInfo("Syncing databases to disk... done")
@@ -292,27 +292,6 @@ func run() {
 	}, shutdown.PriorityMetricsUpdater); err != nil {
 		CorePlugin.Panicf("failed to start worker: %s", err)
 	}
-}
-
-func closeDatabases() error {
-
-	if err := deps.TangleDatabase.KVStore().Flush(); err != nil {
-		return err
-	}
-
-	if err := deps.TangleDatabase.KVStore().Close(); err != nil {
-		return err
-	}
-
-	if err := deps.UTXODatabase.KVStore().Flush(); err != nil {
-		return err
-	}
-
-	if err := deps.UTXODatabase.KVStore().Close(); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func configureEvents() {

--- a/core/database/core.go
+++ b/core/database/core.go
@@ -332,13 +332,13 @@ func provide(c *dig.Container) {
 
 func configure() {
 
-	correctDatabaseVersion, err := deps.Storage.IsCorrectDatabaseVersion()
+	correctDatabasesVersion, err := deps.Storage.CheckCorrectDatabasesVersion()
 	if err != nil {
 		CorePlugin.Panic(err)
 	}
 
-	if !correctDatabaseVersion {
-		databaseVersionUpdated, err := deps.Storage.UpdateDatabaseVersion()
+	if !correctDatabasesVersion {
+		databaseVersionUpdated, err := deps.Storage.UpdateDatabasesVersion()
 		if err != nil {
 			CorePlugin.Panic(err)
 		}
@@ -351,7 +351,7 @@ func configure() {
 	if err = CorePlugin.Daemon().BackgroundWorker("Close database", func(ctx context.Context) {
 		<-ctx.Done()
 
-		if err = deps.Storage.MarkDatabaseHealthy(); err != nil {
+		if err = deps.Storage.MarkDatabasesHealthy(); err != nil {
 			CorePlugin.Panic(err)
 		}
 

--- a/core/database/pebble.go
+++ b/core/database/pebble.go
@@ -1,0 +1,41 @@
+package database
+
+import (
+	"github.com/gohornet/hornet/pkg/database"
+	"github.com/gohornet/hornet/pkg/metrics"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/kvstore/pebble"
+)
+
+func newPebble(path string, metrics *metrics.DatabaseMetrics) *database.Database {
+
+	events := &database.Events{
+		DatabaseCleanup:    events.NewEvent(database.DatabaseCleanupCaller),
+		DatabaseCompaction: events.NewEvent(events.BoolCaller),
+	}
+
+	reportCompactionRunning := func(running bool) {
+		metrics.CompactionRunning.Store(running)
+		if running {
+			metrics.CompactionCount.Inc()
+		}
+		events.DatabaseCompaction.Trigger(running)
+	}
+
+	db, err := database.NewPebbleDB(path, reportCompactionRunning, true)
+	if err != nil {
+		CorePlugin.Panicf("pebble database initialization failed: %s", err)
+	}
+
+	return database.New(
+		CorePlugin.Logger(),
+		path,
+		pebble.New(db),
+		events,
+		true,
+		func() bool {
+			return metrics.CompactionRunning.Load()
+		},
+	)
+
+}

--- a/core/database/rocksdb.go
+++ b/core/database/rocksdb.go
@@ -1,0 +1,47 @@
+package database
+
+import (
+	"github.com/gohornet/hornet/pkg/database"
+	"github.com/gohornet/hornet/pkg/metrics"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/kvstore/rocksdb"
+)
+
+func newRocksDB(path string, metrics *metrics.DatabaseMetrics) *database.Database {
+
+	events := &database.Events{
+		DatabaseCleanup:    events.NewEvent(database.DatabaseCleanupCaller),
+		DatabaseCompaction: events.NewEvent(events.BoolCaller),
+	}
+
+	rocksDatabase, err := database.NewRocksDB(path)
+	if err != nil {
+		CorePlugin.Panicf("rocksdb database initialization failed: %s", err)
+	}
+
+	database := database.New(
+		CorePlugin.Logger(),
+		path,
+		rocksdb.New(rocksDatabase),
+		events,
+		true,
+		func() bool {
+			if numCompactions, success := rocksDatabase.GetIntProperty("rocksdb.num-running-compactions"); success {
+				runningBefore := metrics.CompactionRunning.Load()
+				running := numCompactions != 0
+
+				metrics.CompactionRunning.Store(running)
+				if running && !runningBefore {
+					// we may miss some compactions, since this is only calculated if polled.
+					metrics.CompactionCount.Inc()
+					events.DatabaseCompaction.Trigger(running)
+				}
+				return running
+			}
+			return false
+		},
+	)
+
+	return database
+
+}

--- a/core/database/split.go
+++ b/core/database/split.go
@@ -86,13 +86,13 @@ func SplitIntoTangleAndUTXO(databasePath string) error {
 
 	tangleStore, err := database.StoreWithDefaultSettings(tangleDatabasePath, false, dbEngine)
 	if err != nil {
-		return fmt.Errorf("tangle database initialization failed: %w", err)
+		return fmt.Errorf("%s database initialization failed: %w", TangleDatabaseDirectoryName, err)
 	}
 	defer func() { _ = tangleStore.Close() }()
 
 	utxoStore, err := database.StoreWithDefaultSettings(utxoDatabasePath, true, dbEngine)
 	if err != nil {
-		return fmt.Errorf("utxo database initialization failed: %w", err)
+		return fmt.Errorf("%s database initialization failed: %w", UTXODatabaseDirectoryName, err)
 	}
 	defer func() { _ = utxoStore.Close() }()
 

--- a/core/database/split.go
+++ b/core/database/split.go
@@ -1,0 +1,166 @@
+package database
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/gohornet/hornet/pkg/common"
+	"github.com/gohornet/hornet/pkg/database"
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/kvstore/utils"
+)
+
+func NeedsSplitting(databasePath string) (bool, error) {
+
+	exists, err := utils.PathExists(databasePath)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		// There is no database, so no need to even split
+		return false, nil
+	}
+
+	tangleDatabasePath := filepath.Join(databasePath, TangleDatabaseDirectoryName)
+	utxoDatabasePath := filepath.Join(databasePath, UTXODatabaseDirectoryName)
+
+	tangleExists, err := utils.PathExists(tangleDatabasePath)
+	if err != nil {
+		return false, err
+	}
+
+	utxoExists, err := utils.PathExists(utxoDatabasePath)
+	if err != nil {
+		return false, err
+	}
+
+	return !tangleExists || !utxoExists, nil
+}
+
+func SplitIntoTangleAndUTXO(databasePath string) error {
+
+	needsSplitting, err := NeedsSplitting(databasePath)
+	if err != nil {
+		return err
+	}
+	if !needsSplitting {
+		return nil
+	}
+
+	legacyDatabasePath := databasePath
+	tangleDatabasePath := filepath.Join(legacyDatabasePath, TangleDatabaseDirectoryName)
+	utxoDatabasePath := filepath.Join(legacyDatabasePath, UTXODatabaseDirectoryName)
+
+	// Read the engine the current database is using
+	dbEngine, err := database.CheckDatabaseEngine(legacyDatabasePath, false)
+	if err != nil {
+		return err
+	}
+
+	if err := utils.CreateDirectory(tangleDatabasePath, 0700); err != nil {
+		return err
+	}
+
+	if err := utils.CreateDirectory(utxoDatabasePath, 0700); err != nil {
+		return err
+	}
+
+	// Move the legacy database into the tangle directory
+	files, err := ioutil.ReadDir(legacyDatabasePath)
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
+		if f.IsDir() && (f.Name() == TangleDatabaseDirectoryName || f.Name() == UTXODatabaseDirectoryName) {
+			continue
+		}
+		os.Rename(filepath.Join(legacyDatabasePath, f.Name()), filepath.Join(tangleDatabasePath, f.Name()))
+	}
+
+	tangleStore, err := database.StoreWithDefaultSettings(tangleDatabasePath, false, dbEngine)
+	if err != nil {
+		return fmt.Errorf("tangle database initialization failed: %w", err)
+	}
+	defer func() { _ = tangleStore.Close() }()
+
+	utxoStore, err := database.StoreWithDefaultSettings(utxoDatabasePath, true, dbEngine)
+	if err != nil {
+		return fmt.Errorf("utxo database initialization failed: %w", err)
+	}
+	defer func() { _ = utxoStore.Close() }()
+
+	fmt.Printf("Splitting database using %s...\n", dbEngine)
+
+	// Migrate the UTXO data by removing the old 8 prefix
+	legacyStorePrefixUTXO := kvstore.KeyPrefix{byte(8)}
+	if err := databaseMigrateKeys(tangleStore, utxoStore, legacyStorePrefixUTXO, kvstore.EmptyPrefix); err != nil {
+		return fmt.Errorf("error migrating data to utxo database: %w", err)
+	}
+
+	// Remove UTXO data from tangle database
+	if err := tangleStore.DeletePrefix(legacyStorePrefixUTXO); err != nil {
+		return fmt.Errorf("error deleting utxo data from tangle database: %w", err)
+	}
+
+	// Copy the DB health data to UTXO by replacing the old 0 prefix with the new 255 prefix
+	if err := databaseMigrateKeys(tangleStore, utxoStore, kvstore.KeyPrefix{common.StorePrefixHealthDeprecated}, kvstore.KeyPrefix{common.StorePrefixHealth}); err != nil {
+		return fmt.Errorf("error copying health data to utxo database: %w", err)
+	}
+
+	// Migrate the DB health data in the tangle database to the new keys
+	if err := databaseMigrateKeys(tangleStore, tangleStore, kvstore.KeyPrefix{common.StorePrefixHealthDeprecated}, kvstore.KeyPrefix{common.StorePrefixHealth}); err != nil {
+		return fmt.Errorf("error migrating tangle health database: %w", err)
+	}
+
+	// Remove old DB health data from tangle database
+	if err := tangleStore.DeletePrefix(kvstore.KeyPrefix{common.StorePrefixHealthDeprecated}); err != nil {
+		return fmt.Errorf("error deleting legacy health data from tangle database: %w", err)
+	}
+
+	if err := tangleStore.Flush(); err != nil {
+		return fmt.Errorf("error flushing tangle database: %w", err)
+	}
+
+	if err := utxoStore.Flush(); err != nil {
+		return fmt.Errorf("error flushing utxo database: %w", err)
+	}
+
+	return nil
+}
+
+func databaseMigrateKeys(source kvstore.KVStore, target kvstore.KVStore, prefix kvstore.KeyPrefix, replacementPrefix kvstore.KeyPrefix) error {
+
+	copyBytes := func(source []byte) []byte {
+		cpy := make([]byte, len(source))
+		copy(cpy, source)
+		return cpy
+	}
+
+	copyBytesReplacingPrefix := func(source []byte, prefix []byte, replacementPrefix []byte) []byte {
+		cpy := make([]byte, len(source)+(len(replacementPrefix)-len(prefix)))
+		copy(cpy, replacementPrefix)
+		copy(cpy[len(replacementPrefix):], source[len(prefix):])
+		return cpy
+	}
+
+	var errDB error
+	if err := source.Iterate(prefix, func(key []byte, value kvstore.Value) bool {
+		dstKey := copyBytesReplacingPrefix(key, prefix, replacementPrefix)
+		dstValue := copyBytes(value)
+
+		if errDB = target.Set(dstKey, dstValue); errDB != nil {
+			return false
+		}
+
+		return true
+	}); err != nil {
+		return fmt.Errorf("source database iteration failed: %w", err)
+	}
+
+	if errDB != nil {
+		return fmt.Errorf("taget database set failed: %w", errDB)
+	}
+	return nil
+}

--- a/core/snapshot/core.go
+++ b/core/snapshot/core.go
@@ -106,7 +106,8 @@ func provide(c *dig.Container) {
 
 	type snapshotDeps struct {
 		dig.In
-		Database             *database.Database
+		TangleDatabase       *database.Database `name:"tangleDatabase"`
+		UTXODatabase         *database.Database `name:"utxoDatabase"`
 		Storage              *storage.Storage
 		SyncManager          *syncmanager.SyncManager
 		UTXOManager          *utxo.Manager
@@ -173,9 +174,10 @@ func provide(c *dig.Container) {
 			CorePlugin.Panicf("%s has to be specified if %s is enabled", CfgPruningSizeTargetSize, CfgPruningSizeEnabled)
 		}
 
+		//TODO: also add deps.UTXODatabase here
 		return snapshot.NewSnapshotManager(
 			CorePlugin.Logger(),
-			deps.Database,
+			deps.TangleDatabase,
 			deps.Storage,
 			deps.SyncManager,
 			deps.UTXOManager,

--- a/core/snapshot/core.go
+++ b/core/snapshot/core.go
@@ -174,10 +174,10 @@ func provide(c *dig.Container) {
 			CorePlugin.Panicf("%s has to be specified if %s is enabled", CfgPruningSizeTargetSize, CfgPruningSizeEnabled)
 		}
 
-		//TODO: also add deps.UTXODatabase here
 		return snapshot.NewSnapshotManager(
 			CorePlugin.Logger(),
 			deps.TangleDatabase,
+			deps.UTXODatabase,
 			deps.Storage,
 			deps.SyncManager,
 			deps.UTXOManager,

--- a/core/tangle/core.go
+++ b/core/tangle/core.go
@@ -67,7 +67,7 @@ var (
 
 type dependencies struct {
 	dig.In
-	Database                 *database.Database
+	TangleDatabase           *database.Database `name:"tangleDatabase"`
 	Storage                  *storage.Storage
 	Tangle                   *tangle.Tangle
 	Requester                *gossip.Requester
@@ -194,7 +194,8 @@ Please restart HORNET with one of the following flags or enable "db.autoRevalida
 func run() {
 
 	// run a full database garbage collection at startup
-	deps.Database.RunGarbageCollection()
+	deps.TangleDatabase.RunGarbageCollection()
+	//TODO: run it for the UTXODatabase? If yes, where?
 
 	if err := CorePlugin.Daemon().BackgroundWorker("Tangle[HeartbeatEvents]", func(ctx context.Context) {
 		attachHeartbeatEvents()

--- a/core/tangle/core.go
+++ b/core/tangle/core.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/dig"
 
 	"github.com/gohornet/hornet/pkg/common"
-	"github.com/gohornet/hornet/pkg/database"
 	"github.com/gohornet/hornet/pkg/keymanager"
 	"github.com/gohornet/hornet/pkg/metrics"
 	"github.com/gohornet/hornet/pkg/model/migrator"
@@ -67,7 +66,6 @@ var (
 
 type dependencies struct {
 	dig.In
-	TangleDatabase           *database.Database `name:"tangleDatabase"`
 	Storage                  *storage.Storage
 	Tangle                   *tangle.Tangle
 	Requester                *gossip.Requester
@@ -192,10 +190,6 @@ Please restart HORNET with one of the following flags or enable "db.autoRevalida
 }
 
 func run() {
-
-	// run a full database garbage collection at startup
-	deps.TangleDatabase.RunGarbageCollection()
-	//TODO: run it for the UTXODatabase? If yes, where?
 
 	if err := CorePlugin.Daemon().BackgroundWorker("Tangle[HeartbeatEvents]", func(ctx context.Context) {
 		attachHeartbeatEvents()

--- a/core/tangle/core.go
+++ b/core/tangle/core.go
@@ -148,14 +148,14 @@ func configure() {
 	// a shutdown signal during startup. If that is the case, the BackgroundWorker will never be started
 	// and the database will never be marked as corrupted.
 	if err := CorePlugin.Daemon().BackgroundWorker("Database Health", func(_ context.Context) {
-		if err := deps.Storage.MarkDatabaseCorrupted(); err != nil {
+		if err := deps.Storage.MarkDatabasesCorrupted(); err != nil {
 			CorePlugin.Panic(err)
 		}
 	}, shutdown.PriorityDatabaseHealth); err != nil {
 		CorePlugin.Panicf("failed to start worker: %s", err)
 	}
 
-	databaseCorrupted, err := deps.Storage.IsDatabaseCorrupted()
+	databaseCorrupted, err := deps.Storage.AreDatabasesCorrupted()
 	if err != nil {
 		CorePlugin.Panic(err)
 	}

--- a/pkg/common/database_prefixes.go
+++ b/pkg/common/database_prefixes.go
@@ -1,7 +1,7 @@
 package common
 
 const (
-	StorePrefixHealth               byte = 0
+	StorePrefixHealthDeprecated     byte = 0
 	StorePrefixMessages             byte = 1
 	StorePrefixMessageMetadata      byte = 2
 	StorePrefixMilestones           byte = 3
@@ -9,5 +9,5 @@ const (
 	StorePrefixSnapshot             byte = 5
 	StorePrefixUnreferencedMessages byte = 6
 	StorePrefixIndexation           byte = 7
-	StorePrefixUTXO                 byte = 8
+	StorePrefixHealth               byte = 255
 )

--- a/pkg/common/database_prefixes.go
+++ b/pkg/common/database_prefixes.go
@@ -1,7 +1,6 @@
 package common
 
 const (
-	StorePrefixHealthDeprecated     byte = 0
 	StorePrefixMessages             byte = 1
 	StorePrefixMessageMetadata      byte = 2
 	StorePrefixMilestones           byte = 3

--- a/pkg/common/database_prefixes.go
+++ b/pkg/common/database_prefixes.go
@@ -10,5 +10,4 @@ const (
 	StorePrefixUnreferencedMessages byte = 6
 	StorePrefixIndexation           byte = 7
 	StorePrefixUTXO                 byte = 8
-	StorePrefixAutopeering          byte = 9
 )

--- a/pkg/model/storage/health.go
+++ b/pkg/model/storage/health.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/gohornet/hornet/pkg/common"
+	"github.com/iotaledger/hive.go/kvstore"
+)
+
+type storeHealthTracker struct {
+	store kvstore.KVStore
+}
+
+func newStoreHealthTracker(store kvstore.KVStore) *storeHealthTracker {
+	s := &storeHealthTracker{
+		store: store.WithRealm([]byte{common.StorePrefixHealth}),
+	}
+	s.setDatabaseVersion(DBVersion)
+	return s
+}
+
+func (s *storeHealthTracker) markCorrupted() error {
+
+	if err := s.store.Set([]byte("dbCorrupted"), []byte{}); err != nil {
+		return errors.Wrap(NewDatabaseError(err), "failed to set database healthTrackers status")
+	}
+	return s.store.Flush()
+}
+
+func (s *storeHealthTracker) markTainted() error {
+
+	if err := s.store.Set([]byte("dbTainted"), []byte{}); err != nil {
+		return errors.Wrap(NewDatabaseError(err), "failed to set database healthTrackers status")
+	}
+	return s.store.Flush()
+}
+
+func (s *storeHealthTracker) markHealthy() error {
+
+	if err := s.store.Delete([]byte("dbCorrupted")); err != nil {
+		return errors.Wrap(NewDatabaseError(err), "failed to set database healthTrackers status")
+	}
+
+	return nil
+}
+
+func (s *storeHealthTracker) isCorrupted() (bool, error) {
+
+	contains, err := s.store.Has([]byte("dbCorrupted"))
+	if err != nil {
+		return true, errors.Wrap(NewDatabaseError(err), "failed to read database healthTrackers status")
+	}
+	return contains, nil
+}
+
+func (s *storeHealthTracker) isTainted() (bool, error) {
+
+	contains, err := s.store.Has([]byte("dbTainted"))
+	if err != nil {
+		return true, errors.Wrap(NewDatabaseError(err), "failed to read database healthTrackers status")
+	}
+	return contains, nil
+}
+
+func (s *storeHealthTracker) setDatabaseVersion(version byte) error {
+
+	_, err := s.store.Get([]byte("dbVersion"))
+	if errors.Is(err, kvstore.ErrKeyNotFound) {
+		// Only create the entry, if it doesn't exist already (fresh database)
+		if err := s.store.Set([]byte("dbVersion"), []byte{version}); err != nil {
+			return errors.Wrap(NewDatabaseError(err), "failed to set database version")
+		}
+	}
+	return nil
+}
+
+func (s *storeHealthTracker) checkCorrectDatabaseVersion(expectedVersion byte) (bool, error) {
+
+	value, err := s.store.Get([]byte("dbVersion"))
+	if err != nil {
+		return false, errors.Wrap(NewDatabaseError(err), "failed to read database version")
+	}
+
+	if len(value) > 0 {
+		return value[0] == expectedVersion, nil
+	}
+
+	return false, nil
+}
+
+// UpdateDatabaseVersion tries to migrate the existing data to the new database version.
+func (s *storeHealthTracker) updateDatabaseVersion() (bool, error) {
+
+	value, err := s.store.Get([]byte("dbVersion"))
+	if err != nil {
+		return false, errors.Wrap(NewDatabaseError(err), "failed to read database version")
+	}
+
+	if len(value) < 1 {
+		return false, nil
+	}
+
+	return false, nil
+}

--- a/pkg/model/storage/health_db.go
+++ b/pkg/model/storage/health_db.go
@@ -6,31 +6,30 @@ const (
 
 func (s *Storage) MarkDatabasesCorrupted() error {
 
+	var markingErr error
 	for _, h := range s.healthTrackers {
-		err := h.markCorrupted()
-		if err != nil {
-			return err
+		if err := h.markCorrupted(); err != nil {
+			markingErr = err
 		}
 	}
-	return nil
+	return markingErr
 }
 
 func (s *Storage) MarkDatabasesTainted() error {
 
+	var markingErr error
 	for _, h := range s.healthTrackers {
-		err := h.markTainted()
-		if err != nil {
-			return err
+		if err := h.markTainted(); err != nil {
+			markingErr = err
 		}
 	}
-	return nil
+	return markingErr
 }
 
 func (s *Storage) MarkDatabasesHealthy() error {
 
 	for _, h := range s.healthTrackers {
-		err := h.markHealthy()
-		if err != nil {
+		if err := h.markHealthy(); err != nil {
 			return err
 		}
 	}

--- a/pkg/model/storage/health_db.go
+++ b/pkg/model/storage/health_db.go
@@ -83,20 +83,21 @@ func (s *Storage) CheckCorrectDatabasesVersion() (bool, error) {
 // UpdateDatabasesVersion tries to migrate the existing data to the new database version.
 func (s *Storage) UpdateDatabasesVersion() (bool, error) {
 
-	var updatedAll bool
+	allCorrect := true
 	for _, h := range s.healthTrackers {
-		updated, err := h.updateDatabaseVersion()
+		_, err := h.updateDatabaseVersion()
 		if err != nil {
 			return false, err
 		}
-		updatedAll = updatedAll && updated
 
 		correct, err := h.checkCorrectDatabaseVersion(DBVersion)
 		if err != nil {
 			return false, err
 		}
-		updatedAll = updated && correct
+		if !correct {
+			allCorrect = false
+		}
 	}
 
-	return updatedAll, nil
+	return allCorrect, nil
 }

--- a/pkg/model/storage/storage.go
+++ b/pkg/model/storage/storage.go
@@ -49,13 +49,13 @@ type Storage struct {
 	Events *packageEvents
 }
 
-func New(store kvstore.KVStore, utxoStore kvstore.KVStore, cachesProfile ...*profile.Caches) (*Storage, error) {
+func New(tangleStore kvstore.KVStore, utxoStore kvstore.KVStore, cachesProfile ...*profile.Caches) (*Storage, error) {
 
 	utxoManager := utxo.New(utxoStore)
 
 	s := &Storage{
 		healthTrackers: []*storeHealthTracker{
-			newStoreHealthTracker(store),
+			newStoreHealthTracker(tangleStore),
 			newStoreHealthTracker(utxoStore),
 		},
 		utxoManager: utxoManager,
@@ -64,7 +64,7 @@ func New(store kvstore.KVStore, utxoStore kvstore.KVStore, cachesProfile ...*pro
 		},
 	}
 
-	if err := s.configureStorages(store, cachesProfile...); err != nil {
+	if err := s.configureStorages(tangleStore, cachesProfile...); err != nil {
 		return nil, err
 	}
 
@@ -152,34 +152,34 @@ func (s *Storage) profileCachesDisabled() *profile.Caches {
 	}
 }
 
-func (s *Storage) configureStorages(store kvstore.KVStore, cachesProfile ...*profile.Caches) error {
+func (s *Storage) configureStorages(tangleStore kvstore.KVStore, cachesProfile ...*profile.Caches) error {
 
 	cachesOpts := s.profileCachesDisabled()
 	if len(cachesProfile) > 0 {
 		cachesOpts = cachesProfile[0]
 	}
 
-	if err := s.configureMessageStorage(store, cachesOpts.Messages); err != nil {
+	if err := s.configureMessageStorage(tangleStore, cachesOpts.Messages); err != nil {
 		return err
 	}
 
-	if err := s.configureChildrenStorage(store, cachesOpts.Children); err != nil {
+	if err := s.configureChildrenStorage(tangleStore, cachesOpts.Children); err != nil {
 		return err
 	}
 
-	if err := s.configureMilestoneStorage(store, cachesOpts.Milestones); err != nil {
+	if err := s.configureMilestoneStorage(tangleStore, cachesOpts.Milestones); err != nil {
 		return err
 	}
 
-	if err := s.configureUnreferencedMessageStorage(store, cachesOpts.UnreferencedMessages); err != nil {
+	if err := s.configureUnreferencedMessageStorage(tangleStore, cachesOpts.UnreferencedMessages); err != nil {
 		return err
 	}
 
-	if err := s.configureIndexationStorage(store, cachesOpts.Indexations); err != nil {
+	if err := s.configureIndexationStorage(tangleStore, cachesOpts.Indexations); err != nil {
 		return err
 	}
 
-	s.configureSnapshotStore(store)
+	s.configureSnapshotStore(tangleStore)
 
 	return nil
 }

--- a/pkg/model/storage/storage.go
+++ b/pkg/model/storage/storage.go
@@ -19,9 +19,6 @@ type ReadOption = objectstorage.ReadOption
 type IteratorOption = objectstorage.IteratorOption
 
 type Storage struct {
-	// database
-	store kvstore.KVStore
-
 	// kv storages
 	healthStore   kvstore.KVStore
 	snapshotStore kvstore.KVStore
@@ -49,19 +46,18 @@ type Storage struct {
 	Events *packageEvents
 }
 
-func New(store kvstore.KVStore, cachesProfile ...*profile.Caches) (*Storage, error) {
+func New(store kvstore.KVStore, utxoStore kvstore.KVStore, cachesProfile ...*profile.Caches) (*Storage, error) {
 
-	utxoManager := utxo.New(store)
+	utxoManager := utxo.New(utxoStore)
 
 	s := &Storage{
-		store:       store,
 		utxoManager: utxoManager,
 		Events: &packageEvents{
 			PruningStateChanged: events.NewEvent(events.BoolCaller),
 		},
 	}
 
-	if err := s.configureStorages(s.store, cachesProfile...); err != nil {
+	if err := s.configureStorages(store, cachesProfile...); err != nil {
 		return nil, err
 	}
 
@@ -74,10 +70,6 @@ func New(store kvstore.KVStore, cachesProfile ...*profile.Caches) (*Storage, err
 	}
 
 	return s, nil
-}
-
-func (s *Storage) KVStore() kvstore.KVStore {
-	return s.store
 }
 
 func (s *Storage) UTXOManager() *utxo.Manager {

--- a/pkg/model/utxo/utxo.go
+++ b/pkg/model/utxo/utxo.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/gohornet/hornet/pkg/common"
 	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/iotaledger/hive.go/kvstore"
 	iotago "github.com/iotaledger/iota.go/v2"
@@ -28,7 +27,7 @@ type Manager struct {
 
 func New(store kvstore.KVStore) *Manager {
 	return &Manager{
-		utxoStorage: store.WithRealm([]byte{common.StorePrefixUTXO}),
+		utxoStorage: store,
 	}
 }
 

--- a/pkg/snapshot/pruning.go
+++ b/pkg/snapshot/pruning.go
@@ -30,18 +30,25 @@ func (s *SnapshotManager) calcTargetIndexBySize(targetSizeBytes ...int64) (miles
 		return 0, ErrNoPruningNeeded
 	}
 
-	if !s.database.CompactionSupported() {
+	if !s.tangleDatabase.CompactionSupported() || !s.utxoDatabase.CompactionSupported() {
 		return 0, ErrDatabaseCompactionNotSupported
 	}
 
-	if s.database.CompactionRunning() {
+	if s.tangleDatabase.CompactionRunning() || s.utxoDatabase.CompactionRunning() {
 		return 0, ErrDatabaseCompactionRunning
 	}
 
-	currentDatabaseSizeBytes, err := s.database.Size()
+	currentTangleDatabaseSizeBytes, err := s.tangleDatabase.Size()
 	if err != nil {
 		return 0, err
 	}
+
+	currentUTXODatabaseSizeBytes, err := s.utxoDatabase.Size()
+	if err != nil {
+		return 0, err
+	}
+
+	currentDatabaseSizeBytes := currentTangleDatabaseSizeBytes + currentUTXODatabaseSizeBytes
 
 	targetDatabaseSizeBytes := s.pruningSizeTargetSizeBytes
 	if len(targetSizeBytes) > 0 {
@@ -59,7 +66,7 @@ func (s *SnapshotManager) calcTargetIndexBySize(targetSizeBytes ...int64) (miles
 
 	milestoneRange := s.syncManager.ConfirmedMilestoneIndex() - s.storage.SnapshotInfo().PruningIndex
 	prunedDatabaseSizeBytes := float64(targetDatabaseSizeBytes) * ((100.0 - s.pruningSizeThresholdPercentage) / 100.0)
-	diffPercentage := (prunedDatabaseSizeBytes / float64(currentDatabaseSizeBytes))
+	diffPercentage := prunedDatabaseSizeBytes / float64(currentDatabaseSizeBytes)
 	milestoneDiff := milestone.Index(math.Ceil(float64(milestoneRange) * diffPercentage))
 
 	return s.syncManager.ConfirmedMilestoneIndex() - milestoneDiff, nil
@@ -153,7 +160,7 @@ func (s *SnapshotManager) pruneDatabase(ctx context.Context, targetIndex milesto
 		return 0, err
 	}
 
-	if s.database.CompactionRunning() {
+	if s.tangleDatabase.CompactionRunning() || s.utxoDatabase.CompactionRunning() {
 		return 0, ErrDatabaseCompactionRunning
 	}
 
@@ -331,7 +338,8 @@ func (s *SnapshotManager) pruneDatabase(ctx context.Context, targetIndex milesto
 	}
 	s.storage.WriteUnlockSolidEntryPoints()
 
-	s.database.RunGarbageCollection()
+	s.tangleDatabase.RunGarbageCollection()
+	s.utxoDatabase.RunGarbageCollection()
 
 	return targetIndex, nil
 }

--- a/pkg/snapshot/pruning.go
+++ b/pkg/snapshot/pruning.go
@@ -338,9 +338,6 @@ func (s *SnapshotManager) pruneDatabase(ctx context.Context, targetIndex milesto
 	}
 	s.storage.WriteUnlockSolidEntryPoints()
 
-	s.tangleDatabase.RunGarbageCollection()
-	s.utxoDatabase.RunGarbageCollection()
-
 	return targetIndex, nil
 }
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -65,7 +65,8 @@ const (
 // SnapshotManager handles reading and writing snapshot data.
 type SnapshotManager struct {
 	log                                  *logger.Logger
-	database                             *database.Database
+	tangleDatabase                       *database.Database
+	utxoDatabase                         *database.Database
 	storage                              *storage.Storage
 	syncManager                          *syncmanager.SyncManager
 	utxoManager                          *utxo.Manager
@@ -100,7 +101,8 @@ type SnapshotManager struct {
 // NewSnapshotManager creates a new snapshot manager instance.
 func NewSnapshotManager(
 	log *logger.Logger,
-	database *database.Database,
+	tangleDatabase *database.Database,
+	utxoDatabase *database.Database,
 	storage *storage.Storage,
 	syncManager *syncmanager.SyncManager,
 	utxoManager *utxo.Manager,
@@ -125,7 +127,8 @@ func NewSnapshotManager(
 
 	return &SnapshotManager{
 		log:                                  log,
-		database:                             database,
+		tangleDatabase:                       tangleDatabase,
+		utxoDatabase:                         utxoDatabase,
 		storage:                              storage,
 		syncManager:                          syncManager,
 		utxoManager:                          utxoManager,

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -530,7 +530,7 @@ func (s *SnapshotManager) ImportSnapshots(ctx context.Context) error {
 	}
 
 	if err = s.LoadSnapshotFromFile(ctx, Full, s.networkID, s.snapshotFullPath); err != nil {
-		_ = s.storage.MarkDatabaseCorrupted()
+		_ = s.storage.MarkDatabasesCorrupted()
 		return err
 	}
 
@@ -539,7 +539,7 @@ func (s *SnapshotManager) ImportSnapshots(ctx context.Context) error {
 	}
 
 	if err = s.LoadSnapshotFromFile(ctx, Delta, s.networkID, s.snapshotDeltaPath); err != nil {
-		_ = s.storage.MarkDatabaseCorrupted()
+		_ = s.storage.MarkDatabasesCorrupted()
 		return err
 	}
 

--- a/pkg/tangle/revalidation.go
+++ b/pkg/tangle/revalidation.go
@@ -58,7 +58,7 @@ func (t *Tangle) RevalidateDatabase(snapshotManager *snapshot.SnapshotManager, p
 
 	// mark the database as tainted forever.
 	// this is used to signal the coordinator plugin that it should never use a revalidated database.
-	if err := t.storage.MarkDatabaseTainted(); err != nil {
+	if err := t.storage.MarkDatabasesTainted(); err != nil {
 		t.log.Panic(err)
 	}
 

--- a/pkg/testsuite/test_environment.go
+++ b/pkg/testsuite/test_environment.go
@@ -71,7 +71,7 @@ type TestEnvironment struct {
 	// syncManager is used to determine the sync status of the node in this test.
 	syncManager *syncmanager.SyncManager
 
-	// milestoneManager is used to retrieve, verify and tangleStore milestones.
+	// milestoneManager is used to retrieve, verify and store milestones.
 	milestoneManager *milestonemanager.MilestoneManager
 
 	// serverMetrics holds metrics about the tangle.

--- a/pkg/toolset/coordinator_fix_state.go
+++ b/pkg/toolset/coordinator_fix_state.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	coreDatabase "github.com/gohornet/hornet/core/database"
 	"github.com/gohornet/hornet/pkg/database"
 	"github.com/gohornet/hornet/pkg/model/coordinator"
 	"github.com/gohornet/hornet/pkg/model/storage"
@@ -40,26 +41,26 @@ func coordinatorFixStateFile(_ *configuration.Configuration, args []string) erro
 		return errors.New("COO_STATE_FILE_PATH is missing")
 	}
 
-	store, err := database.StoreWithDefaultSettings(databasePath, false)
+	tangleStore, err := database.StoreWithDefaultSettings(filepath.Join(databasePath, coreDatabase.TangleDatabaseDirectoryName), false)
 	if err != nil {
-		return fmt.Errorf("database initialization failed: %w", err)
+		return fmt.Errorf("%s database initialization failed: %w", coreDatabase.TangleDatabaseDirectoryName, err)
 	}
 
-	utxoStore, err := database.StoreWithDefaultSettings(filepath.Join(databasePath, "utxo"), false)
+	utxoStore, err := database.StoreWithDefaultSettings(filepath.Join(databasePath, coreDatabase.UTXODatabaseDirectoryName), false)
 	if err != nil {
-		return fmt.Errorf("utxo database initialization failed: %w", err)
+		return fmt.Errorf("%s database initialization failed: %w", coreDatabase.UTXODatabaseDirectoryName, err)
 	}
 
 	// clean up store
 	defer func() {
-		store.Shutdown()
-		_ = store.Close()
+		tangleStore.Shutdown()
+		_ = tangleStore.Close()
 
 		utxoStore.Shutdown()
 		_ = utxoStore.Close()
 	}()
 
-	dbStorage, err := storage.New(store, utxoStore)
+	dbStorage, err := storage.New(tangleStore, utxoStore)
 	if err != nil {
 		return err
 	}

--- a/pkg/toolset/coordinator_fix_state.go
+++ b/pkg/toolset/coordinator_fix_state.go
@@ -3,6 +3,7 @@ package toolset
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -44,13 +45,21 @@ func coordinatorFixStateFile(_ *configuration.Configuration, args []string) erro
 		return fmt.Errorf("database initialization failed: %w", err)
 	}
 
+	utxoStore, err := database.StoreWithDefaultSettings(filepath.Join(databasePath, "utxo"), false)
+	if err != nil {
+		return fmt.Errorf("utxo database initialization failed: %w", err)
+	}
+
 	// clean up store
 	defer func() {
 		store.Shutdown()
 		_ = store.Close()
+
+		utxoStore.Shutdown()
+		_ = utxoStore.Close()
 	}()
 
-	dbStorage, err := storage.New(store)
+	dbStorage, err := storage.New(store, utxoStore)
 	if err != nil {
 		return err
 	}

--- a/pkg/toolset/database_hash.go
+++ b/pkg/toolset/database_hash.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"time"
 
@@ -173,7 +174,18 @@ func databaseLedgerHash(_ *configuration.Configuration, args []string) error {
 		_ = store.Close()
 	}()
 
-	dbStorage, err := storage.New(store)
+	utxoStore, err := database.StoreWithDefaultSettings(filepath.Join(databasePath, "utxo"), false)
+	if err != nil {
+		return fmt.Errorf("utxo database initialization failed: %w", err)
+	}
+
+	// clean up store
+	defer func() {
+		utxoStore.Shutdown()
+		_ = utxoStore.Close()
+	}()
+
+	dbStorage, err := storage.New(store, utxoStore)
 	if err != nil {
 		return err
 	}

--- a/pkg/toolset/database_hash.go
+++ b/pkg/toolset/database_hash.go
@@ -196,7 +196,7 @@ func databaseLedgerHash(_ *configuration.Configuration, args []string) error {
 
 	tangleStore, err := database.StoreWithDefaultSettings(filepath.Join(databasePath, coreDatabase.TangleDatabaseDirectoryName), false)
 	if err != nil {
-		return fmt.Errorf("database initialization failed: %w", err)
+		return fmt.Errorf("%s database initialization failed: %w", coreDatabase.TangleDatabaseDirectoryName, err)
 	}
 
 	// clean up store
@@ -207,7 +207,7 @@ func databaseLedgerHash(_ *configuration.Configuration, args []string) error {
 
 	utxoStore, err := database.StoreWithDefaultSettings(filepath.Join(databasePath, coreDatabase.UTXODatabaseDirectoryName), false)
 	if err != nil {
-		return fmt.Errorf("utxo database initialization failed: %w", err)
+		return fmt.Errorf("%s database initialization failed: %w", coreDatabase.UTXODatabaseDirectoryName, err)
 	}
 
 	// clean up store

--- a/pkg/toolset/database_split.go
+++ b/pkg/toolset/database_split.go
@@ -2,26 +2,18 @@ package toolset
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
 
 	flag "github.com/spf13/pflag"
 
-	coreDatabase "github.com/gohornet/hornet/core/database"
-	"github.com/gohornet/hornet/pkg/common"
-	"github.com/gohornet/hornet/pkg/database"
+	"github.com/gohornet/hornet/core/database"
 	"github.com/iotaledger/hive.go/configuration"
-	"github.com/iotaledger/hive.go/kvstore"
-	storeUtils "github.com/iotaledger/hive.go/kvstore/utils"
 )
 
 func databaseSplit(_ *configuration.Configuration, args []string) error {
 
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 	databasePath := fs.String("database", "", "the path to the p2p database folder")
-	databaseEngine := fs.String("engine", "rocksdb", "the engine of the target database (values: pebble, rocksdb [default])")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", ToolDatabaseSplit)
@@ -38,138 +30,17 @@ func databaseSplit(_ *configuration.Configuration, args []string) error {
 		os.Exit(2)
 	}
 
-	legacyDatabasePath := *databasePath
-	tangleDatabasePath := filepath.Join(legacyDatabasePath, coreDatabase.TangleDatabaseDirectoryName)
-	utxoDatabasePath := filepath.Join(legacyDatabasePath, coreDatabase.UTXODatabaseDirectoryName)
-
-	exists, err := storeUtils.PathExists(legacyDatabasePath)
+	needsSplitting, err := database.NeedsSplitting(*databasePath)
 	if err != nil {
 		return err
 	}
-	if !exists {
-		return fmt.Errorf("%s does not exist\n", legacyDatabasePath)
+	if !needsSplitting {
+		return fmt.Errorf("legacy database not found. Already migrated?")
 	}
 
-	exists, err = storeUtils.PathExists(tangleDatabasePath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error %s:\n", err)
-		os.Exit(1)
+	err = database.SplitIntoTangleAndUTXO(*databasePath)
+	if err == nil {
+		fmt.Println("The split database might be larger. Run your node to compact the new database automatically")
 	}
-	if exists {
-		fmt.Fprint(os.Stderr, "database already migrated?\n")
-		os.Exit(1)
-	}
-
-	if err := storeUtils.CreateDirectory(tangleDatabasePath, 0700); err != nil {
-		fmt.Fprintf(os.Stderr, "error %s:\n", err)
-		os.Exit(1)
-	}
-
-	if err := storeUtils.CreateDirectory(utxoDatabasePath, 0700); err != nil {
-		fmt.Fprintf(os.Stderr, "error %s:\n", err)
-		os.Exit(1)
-	}
-
-	// Move the legacy database into the tangle directory
-	files, err := ioutil.ReadDir(legacyDatabasePath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error %s:\n", err)
-		os.Exit(1)
-	}
-	for _, f := range files {
-		if f.IsDir() && (f.Name() == coreDatabase.TangleDatabaseDirectoryName || f.Name() == coreDatabase.UTXODatabaseDirectoryName) {
-			continue
-		}
-		os.Rename(filepath.Join(legacyDatabasePath, f.Name()), filepath.Join(tangleDatabasePath, f.Name()))
-	}
-
-	dbEngine, err := database.DatabaseEngine(strings.ToLower(*databaseEngine))
-	if err != nil {
-		return err
-	}
-
-	tangleStore, err := database.StoreWithDefaultSettings(tangleDatabasePath, false, dbEngine)
-	if err != nil {
-		return fmt.Errorf("tangle database initialization failed: %w", err)
-	}
-	defer func() { _ = tangleStore.Close() }()
-
-	utxoStore, err := database.StoreWithDefaultSettings(utxoDatabasePath, true, dbEngine)
-	if err != nil {
-		return fmt.Errorf("utxo database initialization failed: %w", err)
-	}
-	defer func() { _ = utxoStore.Close() }()
-
-	fmt.Println("Splitting database... ")
-
-	// Migrate the UTXO data by removing the old 8 prefix
-	legacyStorePrefixUTXO := kvstore.KeyPrefix{byte(8)}
-	if err := databaseMigrateKeys(tangleStore, utxoStore, legacyStorePrefixUTXO, kvstore.EmptyPrefix); err != nil {
-		return fmt.Errorf("error migrating data to utxo database: %w", err)
-	}
-
-	// Remove UTXO data from tangle database
-	if err := tangleStore.DeletePrefix(legacyStorePrefixUTXO); err != nil {
-		return fmt.Errorf("error deleting utxo data from tangle database: %w", err)
-	}
-
-	// Copy the DB health data to UTXO by replacing the old 0 prefix with the new 255 prefix
-	if err := databaseMigrateKeys(tangleStore, utxoStore, kvstore.KeyPrefix{common.StorePrefixHealthDeprecated}, kvstore.KeyPrefix{common.StorePrefixHealth}); err != nil {
-		return fmt.Errorf("error copying health data to utxo database: %w", err)
-	}
-
-	// Migrate the DB health data in the tangle database to the new keys
-	if err := databaseMigrateKeys(tangleStore, tangleStore, kvstore.KeyPrefix{common.StorePrefixHealthDeprecated}, kvstore.KeyPrefix{common.StorePrefixHealth}); err != nil {
-		return fmt.Errorf("error migrating tangle health database: %w", err)
-	}
-
-	// Remove old DB health data from tangle database
-	if err := tangleStore.DeletePrefix(kvstore.KeyPrefix{common.StorePrefixHealthDeprecated}); err != nil {
-		return fmt.Errorf("error deleting legacy health data from tangle database: %w", err)
-	}
-
-	if err := tangleStore.Flush(); err != nil {
-		return fmt.Errorf("error flushing tangle database: %w", err)
-	}
-
-	if err := utxoStore.Flush(); err != nil {
-		return fmt.Errorf("error flushing utxo database: %w", err)
-	}
-
-	return nil
-}
-
-func databaseMigrateKeys(source kvstore.KVStore, target kvstore.KVStore, prefix kvstore.KeyPrefix, replacementPrefix kvstore.KeyPrefix) error {
-
-	copyBytes := func(source []byte) []byte {
-		cpy := make([]byte, len(source))
-		copy(cpy, source)
-		return cpy
-	}
-
-	copyBytesReplacingPrefix := func(source []byte, prefix []byte, replacementPrefix []byte) []byte {
-		cpy := make([]byte, len(source)+(len(replacementPrefix)-len(prefix)))
-		copy(cpy, replacementPrefix)
-		copy(cpy[len(replacementPrefix):], source[len(prefix):])
-		return cpy
-	}
-
-	var errDB error
-	if err := source.Iterate(prefix, func(key []byte, value kvstore.Value) bool {
-		dstKey := copyBytesReplacingPrefix(key, prefix, replacementPrefix)
-		dstValue := copyBytes(value)
-
-		if errDB = target.Set(dstKey, dstValue); errDB != nil {
-			return false
-		}
-
-		return true
-	}); err != nil {
-		return fmt.Errorf("source database iteration failed: %w", err)
-	}
-
-	if errDB != nil {
-		return fmt.Errorf("taget database set failed: %w", errDB)
-	}
-	return nil
+	return err
 }

--- a/pkg/toolset/database_split.go
+++ b/pkg/toolset/database_split.go
@@ -1,0 +1,175 @@
+package toolset
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+
+	coreDatabase "github.com/gohornet/hornet/core/database"
+	"github.com/gohornet/hornet/pkg/common"
+	"github.com/gohornet/hornet/pkg/database"
+	"github.com/iotaledger/hive.go/configuration"
+	"github.com/iotaledger/hive.go/kvstore"
+	storeUtils "github.com/iotaledger/hive.go/kvstore/utils"
+)
+
+func databaseSplit(_ *configuration.Configuration, args []string) error {
+
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	databasePath := fs.String("database", "", "the path to the p2p database folder")
+	databaseEngine := fs.String("engine", "rocksdb", "the engine of the target database (values: pebble, rocksdb [default])")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", ToolDatabaseSplit)
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Check if all parameters were parsed
+	if len(args) == 0 || fs.NArg() != 0 {
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	legacyDatabasePath := *databasePath
+	tangleDatabasePath := filepath.Join(legacyDatabasePath, coreDatabase.TangleDatabaseDirectoryName)
+	utxoDatabasePath := filepath.Join(legacyDatabasePath, coreDatabase.UTXODatabaseDirectoryName)
+
+	exists, err := storeUtils.PathExists(legacyDatabasePath)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("%s does not exist\n", legacyDatabasePath)
+	}
+
+	exists, err = storeUtils.PathExists(tangleDatabasePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error %s:\n", err)
+		os.Exit(1)
+	}
+	if exists {
+		fmt.Fprint(os.Stderr, "database already migrated?\n")
+		os.Exit(1)
+	}
+
+	if err := storeUtils.CreateDirectory(tangleDatabasePath, 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "error %s:\n", err)
+		os.Exit(1)
+	}
+
+	if err := storeUtils.CreateDirectory(utxoDatabasePath, 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "error %s:\n", err)
+		os.Exit(1)
+	}
+
+	// Move the legacy database into the tangle directory
+	files, err := ioutil.ReadDir(legacyDatabasePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error %s:\n", err)
+		os.Exit(1)
+	}
+	for _, f := range files {
+		if f.IsDir() && (f.Name() == coreDatabase.TangleDatabaseDirectoryName || f.Name() == coreDatabase.UTXODatabaseDirectoryName) {
+			continue
+		}
+		os.Rename(filepath.Join(legacyDatabasePath, f.Name()), filepath.Join(tangleDatabasePath, f.Name()))
+	}
+
+	dbEngine, err := database.DatabaseEngine(strings.ToLower(*databaseEngine))
+	if err != nil {
+		return err
+	}
+
+	tangleStore, err := database.StoreWithDefaultSettings(tangleDatabasePath, false, dbEngine)
+	if err != nil {
+		return fmt.Errorf("tangle database initialization failed: %w", err)
+	}
+	defer func() { _ = tangleStore.Close() }()
+
+	utxoStore, err := database.StoreWithDefaultSettings(utxoDatabasePath, true, dbEngine)
+	if err != nil {
+		return fmt.Errorf("utxo database initialization failed: %w", err)
+	}
+	defer func() { _ = utxoStore.Close() }()
+
+	fmt.Println("Splitting database... ")
+
+	// Migrate the UTXO data by removing the old 8 prefix
+	legacyStorePrefixUTXO := kvstore.KeyPrefix{byte(8)}
+	if err := databaseMigrateKeys(tangleStore, utxoStore, legacyStorePrefixUTXO, kvstore.EmptyPrefix); err != nil {
+		return fmt.Errorf("error migrating data to utxo database: %w", err)
+	}
+
+	// Remove UTXO data from tangle database
+	if err := tangleStore.DeletePrefix(legacyStorePrefixUTXO); err != nil {
+		return fmt.Errorf("error deleting utxo data from tangle database: %w", err)
+	}
+
+	// Copy the DB health data to UTXO by replacing the old 0 prefix with the new 255 prefix
+	if err := databaseMigrateKeys(tangleStore, utxoStore, kvstore.KeyPrefix{common.StorePrefixHealthDeprecated}, kvstore.KeyPrefix{common.StorePrefixHealth}); err != nil {
+		return fmt.Errorf("error copying health data to utxo database: %w", err)
+	}
+
+	// Migrate the DB health data in the tangle database to the new keys
+	if err := databaseMigrateKeys(tangleStore, tangleStore, kvstore.KeyPrefix{common.StorePrefixHealthDeprecated}, kvstore.KeyPrefix{common.StorePrefixHealth}); err != nil {
+		return fmt.Errorf("error migrating tangle health database: %w", err)
+	}
+
+	// Remove old DB health data from tangle database
+	if err := tangleStore.DeletePrefix(kvstore.KeyPrefix{common.StorePrefixHealthDeprecated}); err != nil {
+		return fmt.Errorf("error deleting legacy health data from tangle database: %w", err)
+	}
+
+	if err := tangleStore.Flush(); err != nil {
+		return fmt.Errorf("error flushing tangle database: %w", err)
+	}
+
+	if err := utxoStore.Flush(); err != nil {
+		return fmt.Errorf("error flushing utxo database: %w", err)
+	}
+
+	return nil
+}
+
+func databaseMigrateKeys(source kvstore.KVStore, target kvstore.KVStore, prefix kvstore.KeyPrefix, replacementPrefix kvstore.KeyPrefix) error {
+
+	copyBytes := func(source []byte) []byte {
+		cpy := make([]byte, len(source))
+		copy(cpy, source)
+		return cpy
+	}
+
+	copyBytesReplacingPrefix := func(source []byte, prefix []byte, replacementPrefix []byte) []byte {
+		cpy := make([]byte, len(source)+(len(replacementPrefix)-len(prefix)))
+		copy(cpy, replacementPrefix)
+		copy(cpy[len(replacementPrefix):], source[len(prefix):])
+		return cpy
+	}
+
+	var errDB error
+	if err := source.Iterate(prefix, func(key []byte, value kvstore.Value) bool {
+		dstKey := copyBytesReplacingPrefix(key, prefix, replacementPrefix)
+		dstValue := copyBytes(value)
+
+		if errDB = target.Set(dstKey, dstValue); errDB != nil {
+			return false
+		}
+
+		return true
+	}); err != nil {
+		return fmt.Errorf("source database iteration failed: %w", err)
+	}
+
+	if errDB != nil {
+		return fmt.Errorf("taget database set failed: %w", errDB)
+	}
+	return nil
+}

--- a/pkg/toolset/database_split.go
+++ b/pkg/toolset/database_split.go
@@ -13,7 +13,7 @@ import (
 func databaseSplit(_ *configuration.Configuration, args []string) error {
 
 	fs := flag.NewFlagSet("", flag.ExitOnError)
-	databasePath := fs.String("database", "", "the path to the p2p database folder")
+	databasePath := fs.String("database", "", "the path to the database folder that should be split")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", ToolDatabaseSplit)

--- a/pkg/toolset/snap_hash.go
+++ b/pkg/toolset/snap_hash.go
@@ -57,12 +57,12 @@ func snapshotHash(_ *configuration.Configuration, args []string) error {
 
 	tangleStore, err := database.StoreWithDefaultSettings(filepath.Join(tempDir, coreDatabase.TangleDatabaseDirectoryName), true, targetEngine)
 	if err != nil {
-		return fmt.Errorf("database initialization failed: %w", err)
+		return fmt.Errorf("%s database initialization failed: %w", coreDatabase.TangleDatabaseDirectoryName, err)
 	}
 
 	utxoStore, err := database.StoreWithDefaultSettings(filepath.Join(tempDir, coreDatabase.UTXODatabaseDirectoryName), true, targetEngine)
 	if err != nil {
-		return fmt.Errorf("utxo database initialization failed: %w", err)
+		return fmt.Errorf("%s database initialization failed: %w", coreDatabase.UTXODatabaseDirectoryName, err)
 	}
 
 	// clean up temp db

--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -23,6 +23,7 @@ const (
 	ToolBenchmarkCPU            = "bench-cpu"
 	ToolDatabaseMigration       = "db-migration"
 	ToolDatabaseLedgerHash      = "db-hash"
+	ToolDatabaseSplit           = "db-split"
 	ToolCoordinatorFixStateFile = "coo-fix-state"
 )
 
@@ -63,6 +64,7 @@ func HandleTools(nodeConfig *configuration.Configuration) {
 		ToolBenchmarkCPU:            benchmarkCPU,
 		ToolDatabaseMigration:       databaseMigration,
 		ToolDatabaseLedgerHash:      databaseLedgerHash,
+		ToolDatabaseSplit:           databaseSplit,
 		ToolCoordinatorFixStateFile: coordinatorFixStateFile,
 	}
 
@@ -96,5 +98,6 @@ func listTools() {
 	fmt.Printf("%-20s benchmarks the CPU performance\n", fmt.Sprintf("%s:", ToolBenchmarkCPU))
 	fmt.Printf("%-20s migrates the database to another engine\n", fmt.Sprintf("%s:", ToolDatabaseMigration))
 	fmt.Printf("%-20s calculates the sha256 hash of the ledger state of a database\n", fmt.Sprintf("%s:", ToolDatabaseLedgerHash))
+	fmt.Printf("%-20s split a legacy database into `tangle` and `utxo`\n", fmt.Sprintf("%s:", ToolDatabaseSplit))
 	fmt.Printf("%-20s applies the latest milestone in the database to the coordinator state file\n", fmt.Sprintf("%s:", ToolCoordinatorFixStateFile))
 }

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -203,12 +203,12 @@ func provide(c *dig.Container) {
 
 func configure() {
 
-	databaseTainted, err := deps.Storage.IsDatabaseTainted()
+	databasesTainted, err := deps.Storage.AreDatabasesTainted()
 	if err != nil {
 		Plugin.Panic(err)
 	}
 
-	if databaseTainted {
+	if databasesTainted {
 		Plugin.Panic(ErrDatabaseTainted)
 	}
 

--- a/plugins/dashboard/dbsize.go
+++ b/plugins/dashboard/dbsize.go
@@ -18,35 +18,47 @@ var (
 
 // DBSizeMetric represents database size metrics.
 type DBSizeMetric struct {
-	Total    int64
-	Snapshot int64
-	Time     time.Time
+	Tangle int64
+	UTXO   int64
+	Total  int64
+	Time   time.Time
 }
 
 func (s *DBSizeMetric) MarshalJSON() ([]byte, error) {
 	size := struct {
-		Total int64 `json:"total"`
-		Time  int64 `json:"ts"`
+		Tangle int64 `json:"tangle"`
+		UTXO   int64 `json:"utxo"`
+		Total  int64 `json:"total"`
+		Time   int64 `json:"ts"`
 	}{
-		Total: s.Total,
-		Time:  s.Time.Unix(),
+		Tangle: s.Tangle,
+		UTXO:   s.UTXO,
+		Total:  s.Total,
+		Time:   s.Time.Unix(),
 	}
 
 	return json.Marshal(size)
 }
 
 func currentDatabaseSize() *DBSizeMetric {
-	//TODO: Also add UTXO or separate into 2 metrics?
 
-	dbSize, err := deps.TangleDatabase.Size()
+	tangleDbSize, err := deps.TangleDatabase.Size()
 	if err != nil {
-		Plugin.LogWarnf("error in database size calculation: %s", err)
+		Plugin.LogWarnf("error in tangle database size calculation: %s", err)
+		return nil
+	}
+
+	utxoDbSize, err := deps.UTXODatabase.Size()
+	if err != nil {
+		Plugin.LogWarnf("error in utxo database size calculation: %s", err)
 		return nil
 	}
 
 	newValue := &DBSizeMetric{
-		Total: dbSize,
-		Time:  time.Now(),
+		Tangle: tangleDbSize,
+		UTXO:   utxoDbSize,
+		Total:  tangleDbSize + utxoDbSize,
+		Time:   time.Now(),
 	}
 	cachedDBSizeMetrics = append(cachedDBSizeMetrics, newValue)
 	if len(cachedDBSizeMetrics) > 600 {
@@ -68,6 +80,9 @@ func runDatabaseSizeCollector() {
 	if err := Plugin.Daemon().BackgroundWorker("Dashboard[DBSize]", func(ctx context.Context) {
 		deps.TangleDatabase.Events().DatabaseCleanup.Attach(onDatabaseCleanup)
 		defer deps.TangleDatabase.Events().DatabaseCleanup.Detach(onDatabaseCleanup)
+
+		deps.UTXODatabase.Events().DatabaseCleanup.Attach(onDatabaseCleanup)
+		defer deps.UTXODatabase.Events().DatabaseCleanup.Detach(onDatabaseCleanup)
 
 		ticker := timeutil.NewTicker(func() {
 			dbSizeMetric := currentDatabaseSize()

--- a/plugins/dashboard/dbsize.go
+++ b/plugins/dashboard/dbsize.go
@@ -36,7 +36,9 @@ func (s *DBSizeMetric) MarshalJSON() ([]byte, error) {
 }
 
 func currentDatabaseSize() *DBSizeMetric {
-	dbSize, err := deps.Database.Size()
+	//TODO: Also add UTXO or separate into 2 metrics?
+
+	dbSize, err := deps.TangleDatabase.Size()
 	if err != nil {
 		Plugin.LogWarnf("error in database size calculation: %s", err)
 		return nil
@@ -64,8 +66,8 @@ func runDatabaseSizeCollector() {
 	})
 
 	if err := Plugin.Daemon().BackgroundWorker("Dashboard[DBSize]", func(ctx context.Context) {
-		deps.Database.Events().DatabaseCleanup.Attach(onDatabaseCleanup)
-		defer deps.Database.Events().DatabaseCleanup.Detach(onDatabaseCleanup)
+		deps.TangleDatabase.Events().DatabaseCleanup.Attach(onDatabaseCleanup)
+		defer deps.TangleDatabase.Events().DatabaseCleanup.Detach(onDatabaseCleanup)
 
 		ticker := timeutil.NewTicker(func() {
 			dbSizeMetric := currentDatabaseSize()

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -77,7 +77,7 @@ var (
 
 type dependencies struct {
 	dig.In
-	Database                 *database.Database
+	TangleDatabase           *database.Database `name:"tangleDatabase"`
 	Storage                  *storage.Storage
 	SyncManager              *syncmanager.SyncManager
 	Tangle                   *tangle.Tangle

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -78,6 +78,7 @@ var (
 type dependencies struct {
 	dig.In
 	TangleDatabase           *database.Database `name:"tangleDatabase"`
+	UTXODatabase             *database.Database `name:"utxoDatabase"`
 	Storage                  *storage.Storage
 	SyncManager              *syncmanager.SyncManager
 	Tangle                   *tangle.Tangle

--- a/plugins/prometheus/database.go
+++ b/plugins/prometheus/database.go
@@ -1,55 +1,43 @@
 package prometheus
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/gohornet/hornet/pkg/database"
+	"github.com/gohornet/hornet/pkg/metrics"
+	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/iotaledger/hive.go/events"
 )
 
-var (
+type storageMetrics struct {
+	storage        *storage.Storage
+	storageMetrics *metrics.StorageMetrics
+
+	pruningCount   prometheus.Counter
+	pruningRunning prometheus.Gauge
+}
+
+type databaseMetrics struct {
+	database        *database.Database
+	databaseMetrics *metrics.DatabaseMetrics
+
 	databaseSizeBytes prometheus.Gauge
 	compactionCount   prometheus.Counter
 	compactionRunning prometheus.Gauge
-	pruningCount      prometheus.Counter
-	pruningRunning    prometheus.Gauge
-)
+}
 
-func configureDatabase() {
+func configureStorage(storage *storage.Storage, metrics *metrics.StorageMetrics) {
 
-	databaseSizeBytes = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "iota",
-			Subsystem: "database",
-			Name:      "size_bytes",
-			Help:      "Database sizes in bytes.",
-		})
+	m := &storageMetrics{
+		storage:        storage,
+		storageMetrics: metrics,
+	}
 
-	compactionCount = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "iota",
-			Subsystem: "database",
-			Name:      "compaction_count",
-			Help:      "The total amount of database compactions.",
-		},
-	)
-
-	deps.Database.Events().DatabaseCompaction.Attach(events.NewClosure(func(running bool) {
-		if running {
-			compactionCount.Inc()
-		}
-	}))
-
-	compactionRunning = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "iota",
-		Subsystem: "database",
-		Name:      "compaction_running",
-		Help:      "Current state of database compaction process.",
-	})
-
-	pruningCount = prometheus.NewCounter(
+	m.pruningCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "iota",
 			Subsystem: "database",
@@ -58,43 +46,87 @@ func configureDatabase() {
 		},
 	)
 
-	deps.Storage.Events.PruningStateChanged.Attach(events.NewClosure(func(running bool) {
+	storage.Events.PruningStateChanged.Attach(events.NewClosure(func(running bool) {
 		if running {
-			pruningCount.Inc()
+			m.pruningCount.Inc()
 		}
 	}))
 
-	pruningRunning = prometheus.NewGauge(prometheus.GaugeOpts{
+	m.pruningRunning = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "iota",
 		Subsystem: "database",
 		Name:      "pruning_running",
 		Help:      "Current state of database pruning process.",
 	})
 
-	registry.MustRegister(databaseSizeBytes)
-	registry.MustRegister(compactionCount)
-	registry.MustRegister(compactionRunning)
-	registry.MustRegister(pruningCount)
-	registry.MustRegister(pruningRunning)
+	registry.MustRegister(m.pruningRunning)
+	registry.MustRegister(m.pruningCount)
 
-	addCollect(collectDatabase)
+	addCollect(m.collect)
 }
 
-func collectDatabase() {
-	databaseSizeBytes.Set(0)
-	dbSize, err := directorySize(deps.DatabasePath)
+func (m *storageMetrics) collect() {
+
+	m.pruningRunning.Set(0)
+	if m.storageMetrics.PruningRunning.Load() {
+		m.pruningRunning.Set(1)
+	}
+}
+
+func configureDatabase(name string, db *database.Database, metrics *metrics.DatabaseMetrics) {
+
+	m := &databaseMetrics{
+		database:        db,
+		databaseMetrics: metrics,
+	}
+
+	m.databaseSizeBytes = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "iota",
+			Subsystem: "database",
+			Name:      fmt.Sprintf("%s_size_bytes", name),
+			Help:      "Database sizes in bytes.",
+		})
+
+	m.compactionCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "iota",
+			Subsystem: "database",
+			Name:      fmt.Sprintf("%s_compaction_count", name),
+			Help:      "The total amount of tangle database compactions.",
+		},
+	)
+
+	db.Events().DatabaseCompaction.Attach(events.NewClosure(func(running bool) {
+		if running {
+			m.compactionCount.Inc()
+		}
+	}))
+
+	m.compactionRunning = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "iota",
+		Subsystem: "database",
+		Name:      fmt.Sprintf("%s_compaction_running", name),
+		Help:      "Current state of database compaction process.",
+	})
+
+	registry.MustRegister(m.databaseSizeBytes)
+	registry.MustRegister(m.compactionCount)
+	registry.MustRegister(m.compactionRunning)
+
+	addCollect(m.collect)
+}
+
+func (m *databaseMetrics) collect() {
+	m.databaseSizeBytes.Set(0)
+	dbSize, err := m.database.Size()
 	if err == nil {
-		databaseSizeBytes.Set(float64(dbSize))
+		m.databaseSizeBytes.Set(float64(dbSize))
 	}
 
-	compactionRunning.Set(0)
-	if deps.Database.CompactionRunning() {
-		compactionRunning.Set(1)
-	}
-
-	pruningRunning.Set(0)
-	if deps.StorageMetrics.PruningRunning.Load() {
-		pruningRunning.Set(1)
+	m.compactionRunning.Set(0)
+	if m.database.CompactionRunning() {
+		m.compactionRunning.Set(1)
 	}
 }
 

--- a/plugins/prometheus/database.go
+++ b/plugins/prometheus/database.go
@@ -93,7 +93,7 @@ func configureDatabase(name string, db *database.Database, metrics *metrics.Data
 			Namespace: "iota",
 			Subsystem: "database",
 			Name:      fmt.Sprintf("%s_compaction_count", name),
-			Help:      "The total amount of tangle database compactions.",
+			Help:      fmt.Sprintf("The total amount of %s database compactions.", name),
 		},
 	)
 

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -63,31 +63,34 @@ var (
 
 type dependencies struct {
 	dig.In
-	AppInfo          *app.AppInfo
-	NodeConfig       *configuration.Configuration `name:"nodeConfig"`
-	Database         *database.Database
-	DatabasePath     string `name:"databasePath"`
-	Storage          *storage.Storage
-	SyncManager      *syncmanager.SyncManager
-	ServerMetrics    *metrics.ServerMetrics
-	DatabaseMetrics  *metrics.DatabaseMetrics
-	StorageMetrics   *metrics.StorageMetrics
-	RestAPIMetrics   *metrics.RestAPIMetrics `optional:"true"`
-	GossipService    *gossip.Service
-	ReceiptService   *migrator.ReceiptService `optional:"true"`
-	Tangle           *tangle.Tangle
-	MigratorService  *migrator.MigratorService `optional:"true"`
-	PeeringManager   *p2p.Manager
-	RequestQueue     gossip.RequestQueue
-	MessageProcessor *gossip.MessageProcessor
-	TipSelector      *tipselect.TipSelector `optional:"true"`
-	SnapshotManager  *snapshot.SnapshotManager
-	Coordinator      *coordinator.Coordinator `optional:"true"`
+	AppInfo               *app.AppInfo
+	NodeConfig            *configuration.Configuration `name:"nodeConfig"`
+	SyncManager           *syncmanager.SyncManager
+	ServerMetrics         *metrics.ServerMetrics
+	Storage               *storage.Storage
+	StorageMetrics        *metrics.StorageMetrics
+	TangleDatabase        *database.Database       `name:"tangleDatabase"`
+	TangleDatabaseMetrics *metrics.DatabaseMetrics `name:"tangleDatabaseMetrics"`
+	UTXODatabase          *database.Database       `name:"utxoDatabase"`
+	UTXODatabaseMetrics   *metrics.DatabaseMetrics `name:"utxoDatabaseMetrics"`
+	RestAPIMetrics        *metrics.RestAPIMetrics  `optional:"true"`
+	GossipService         *gossip.Service
+	ReceiptService        *migrator.ReceiptService `optional:"true"`
+	Tangle                *tangle.Tangle
+	MigratorService       *migrator.MigratorService `optional:"true"`
+	PeeringManager        *p2p.Manager
+	RequestQueue          gossip.RequestQueue
+	MessageProcessor      *gossip.MessageProcessor
+	TipSelector           *tipselect.TipSelector `optional:"true"`
+	SnapshotManager       *snapshot.SnapshotManager
+	Coordinator           *coordinator.Coordinator `optional:"true"`
 }
 
 func configure() {
 	if deps.NodeConfig.Bool(CfgPrometheusDatabase) {
-		configureDatabase()
+		configureDatabase("tangle", deps.TangleDatabase, deps.TangleDatabaseMetrics)
+		configureDatabase("utxo", deps.UTXODatabase, deps.UTXODatabaseMetrics)
+		configureStorage(deps.Storage, deps.StorageMetrics)
 	}
 	if deps.NodeConfig.Bool(CfgPrometheusNode) {
 		configureNode()

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"time"
 
+	coreDatabase "github.com/gohornet/hornet/core/database"
+
 	"github.com/pkg/errors"
 
 	"github.com/labstack/echo/v4"
@@ -88,8 +90,8 @@ type dependencies struct {
 
 func configure() {
 	if deps.NodeConfig.Bool(CfgPrometheusDatabase) {
-		configureDatabase("tangle", deps.TangleDatabase, deps.TangleDatabaseMetrics)
-		configureDatabase("utxo", deps.UTXODatabase, deps.UTXODatabaseMetrics)
+		configureDatabase(coreDatabase.TangleDatabaseDirectoryName, deps.TangleDatabase, deps.TangleDatabaseMetrics)
+		configureDatabase(coreDatabase.UTXODatabaseDirectoryName, deps.UTXODatabase, deps.UTXODatabaseMetrics)
 		configureStorage(deps.Storage, deps.StorageMetrics)
 	}
 	if deps.NodeConfig.Bool(CfgPrometheusNode) {


### PR DESCRIPTION
This PR splits the database into two separate ones.
- Tangle database, containing everything related to messages
- UTXO database, containing just the ledger and the ledger diffs

This split moves each database into a separate subdirectory inside the database dir.

The database will be automatically split when starting the node if required.

A new tool `db-split` was added to manually migrate a legacy database to the split format.


**_Notes:_**
- Prometheus database metrics now have both `tangle` and `utxo` metrics
- Dashboard metrics now have access to `tangle`, `utxo` and `total` sizes. A dashboard change is needed if we want to show these values separately