### PR TITLE
Print error message if loading file fails

### DIFF
--- a/core/app/config.go
+++ b/core/app/config.go
@@ -41,7 +41,7 @@ func loadCfg(flagSets map[string]*flag.FlagSet) error {
 			// if a file was explicitly specified, raise the error
 			return err
 		}
-		fmt.Printf("No config file found via '%s'. Loading default settings.", *nodeCfgFilePath)
+		fmt.Printf("Failed loading config with following error: '%s'. Loading default settings.", err)
 	}
 
 	if err := peeringConfig.LoadFile(*peeringCfgFilePath); err != nil {


### PR DESCRIPTION
# Description

I added a change that prints the error message if loading the config file fails.
Before you couldn't tell if you had a syntax error in your config or if it was missing completely.

I could also catch specific errors and change the error message depending on it, but I wasn't sure how you would like it. 
So just tell me if you want it changed :)

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
