### PR TITLE
Fix database splitting code in combination with docker

### DIFF
--- a/core/database/split.go
+++ b/core/database/split.go
@@ -17,26 +17,27 @@ const (
 	storePrefixUTXODeprecated   byte = 8
 )
 
-func NeedsSplitting(databasePath string) (bool, error) {
+func NeedsSplitting(dbPath string) (bool, error) {
 
-	exists, err := utils.PathExists(databasePath)
+	// check if the database exists
+	dbExists, err := database.DatabaseExists(dbPath)
 	if err != nil {
 		return false, err
 	}
-	if !exists {
-		// There is no database, so no need to even split
+	if !dbExists {
+		// there is no database, so no need to even split
 		return false, nil
 	}
 
-	tangleDatabasePath := filepath.Join(databasePath, TangleDatabaseDirectoryName)
-	utxoDatabasePath := filepath.Join(databasePath, UTXODatabaseDirectoryName)
+	tangleDatabasePath := filepath.Join(dbPath, TangleDatabaseDirectoryName)
+	utxoDatabasePath := filepath.Join(dbPath, UTXODatabaseDirectoryName)
 
-	tangleExists, err := utils.PathExists(tangleDatabasePath)
+	tangleExists, err := database.DatabaseExists(tangleDatabasePath)
 	if err != nil {
 		return false, err
 	}
 
-	utxoExists, err := utils.PathExists(utxoDatabasePath)
+	utxoExists, err := database.DatabaseExists(utxoDatabasePath)
 	if err != nil {
 		return false, err
 	}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # https://hub.docker.com/_/golang
-# golang 1.17.2-bullseye amd64
-FROM golang@sha256:26eb06358c4e5d36a304b74fa6af08d08a7943e6babadd8d1ba14491120cf62a AS build
+# golang 1.17.3-bullseye amd64
+FROM golang@sha256:3b27ac95762ce1340a4824dc3cab2dc9d63f194f0899a0a9887402c1b1463f41 AS build
 
 ARG BUILD_TAGS=builtin_static,rocksdb
 
@@ -37,10 +37,10 @@ RUN GOOS=linux GOARCH=amd64 go build \
 ############################
 # Image
 ############################
-# https://github.com/GoogleContainerTools/distroless/tree/master/cc
+# https://console.cloud.google.com/gcr/images/distroless/global/cc-debian11
 # using distroless cc "nonroot" image, which includes everything in the base image (glibc, libssl and openssl)
-# gcr.io/distroless/cc-debian11:latest
-FROM gcr.io/distroless/cc@sha256:53ae81ce96dfebf79d515e89af05c5cea25ad42618ceb77be7b6160a3e2d32da
+# gcr.io/distroless/cc-debian11:nonroot-amd64
+FROM gcr.io/distroless/cc-debian11@sha256:5d5ec54878d2b9db248c4ef302af44e784afa169eb831269f7f332bcf5021516
 
 EXPOSE 15600/tcp
 EXPOSE 14626/udp

--- a/pkg/database/engine.go
+++ b/pkg/database/engine.go
@@ -38,21 +38,17 @@ func DatabaseEngine(engine string) (Engine, error) {
 func CheckDatabaseEngine(dbPath string, createDatabaseIfNotExists bool, dbEngine ...Engine) (Engine, error) {
 
 	if createDatabaseIfNotExists && len(dbEngine) == 0 {
-		return EngineRocksDB, errors.New("the database engine must be specified if the database should be newly created")
+		return EngineUnknown, errors.New("the database engine must be specified if the database should be newly created")
 	}
 
 	// check if the database exists and if it should be created
-	_, err := os.Stat(dbPath)
+	dbExists, err := DatabaseExists(dbPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return EngineUnknown, fmt.Errorf("unable to check database path (%s): %w", dbPath, err)
-		}
+		return EngineUnknown, err
+	}
 
-		if !createDatabaseIfNotExists {
-			return EngineUnknown, fmt.Errorf("database not found (%s)", dbPath)
-		}
-
-		// database will be newly created
+	if !dbExists && !createDatabaseIfNotExists {
+		return EngineUnknown, fmt.Errorf("database not found (%s)", dbPath)
 	}
 
 	var targetEngine Engine

--- a/pkg/database/utils.go
+++ b/pkg/database/utils.go
@@ -1,0 +1,29 @@
+package database
+
+import (
+	"fmt"
+
+	"github.com/gohornet/hornet/pkg/utils"
+	hiveutils "github.com/iotaledger/hive.go/kvstore/utils"
+)
+
+// DatabaseExists checks if the database folder exists and is not empty.
+func DatabaseExists(dbPath string) (bool, error) {
+
+	dirExists, err := hiveutils.PathExists(dbPath)
+	if err != nil {
+		return false, fmt.Errorf("unable to check database path (%s): %w", dbPath, err)
+	}
+	if !dirExists {
+		return false, nil
+	}
+
+	// directory exists, but maybe database doesn't exist.
+	// check if the directory is empty (needed for example in docker environments)
+	dirEmpty, err := utils.DirectoryEmpty(dbPath)
+	if err != nil {
+		return false, fmt.Errorf("unable to check database path (%s): %w", dbPath, err)
+	}
+
+	return !dirEmpty, nil
+}


### PR DESCRIPTION
The database splitting logic checks if a database exists, based on the fact that the database folder exists.
In a docker environment that doesn't work correctly, since mounting the database folder as a volume already creates the folder.