### PR TITLE
Added twitter bot notification on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
         run: goreleaser --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
 
   docker:
     name: Release Docker

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -188,6 +188,11 @@ snapshot:
 changelog:
   skip: true
 
+announce:
+  twitter:
+    enabled: true
+    message_template: "{{.ProjectName}}-{{.Version}} is out! Find all details at {{ .ReleaseURL }}! #IOTA #HORNET"
+
 # Release
 release:
   prerelease: auto


### PR DESCRIPTION
This PR adds the Twitter Bot option to the GoReleaser stage.
By enabling this option, the release pipeline will send a new tweet (GoHORNET Twitter account) as soon as a new release has been successfully built.