### PR TITLE
Fix/faucet conflicting tx

### DIFF
--- a/pkg/model/faucet/faucet.go
+++ b/pkg/model/faucet/faucet.go
@@ -19,6 +19,8 @@ import (
 	"github.com/gohornet/hornet/pkg/model/utxo"
 	"github.com/gohornet/hornet/pkg/pow"
 	"github.com/gohornet/hornet/pkg/restapi"
+	"github.com/gohornet/hornet/pkg/whiteflag"
+	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/serializer"
@@ -35,6 +37,8 @@ type TipselFunc = func() (tips hornet.MessageIDs, err error)
 var (
 	// ErrNoTipsGiven is returned when no tips were given to issue a message.
 	ErrNoTipsGiven = errors.New("no tips given")
+	// ErrNothingToProcess is returned when there is no need to sweep or send funds.
+	ErrNothingToProcess = errors.New("nothing to process")
 )
 
 // Events are the events issued by the faucet.
@@ -50,6 +54,12 @@ type queueItem struct {
 	Bech32         string
 	Amount         uint64
 	Ed25519Address *iotago.Ed25519Address
+}
+
+// pendingTransaction holds info about a sent transaction that is pending.
+type pendingTransaction struct {
+	MessageID   hornet.MessageID
+	QueuedItems []*queueItem
 }
 
 // FaucetInfoResponse defines the response of a GET RouteFaucetInfo REST API call.
@@ -72,6 +82,8 @@ type FaucetEnqueueResponse struct {
 type Faucet struct {
 	syncutils.Mutex
 
+	// used to access the global daemon.
+	daemon daemon.Daemon
 	// used to access the node storage.
 	storage *storage.Storage
 	// used to determine the sync status of the node.
@@ -99,12 +111,21 @@ type Faucet struct {
 	// events of the faucet.
 	Events *Events
 
-	// the message ID of the last sent faucet message.
-	lastMessageID hornet.MessageID
-	// map with all queued requests per address.
-	queueMap map[string]*queueItem
+	// faucetBalance is the remaining balance of the faucet if all requests would be processed.
+	faucetBalance uint64
 	// queue of new requests.
 	queue chan *queueItem
+	// map with all queued requests per address (bech32).
+	queueMap map[string]*queueItem
+	// flushQueue is used to signal to stop an ongoing batching of faucet requests.
+	flushQueue chan struct{}
+	// pendingTransactionsMap is a map of sent transactions that are pending.
+	pendingTransactionsMap map[string]*pendingTransaction
+	// the message ID of the last sent faucet message.
+	lastMessageID hornet.MessageID
+	// the latest unused UTXO output that may not be confirmed yet but can be reused in new transactions.
+	// this is used to issue multiple transactions without waiting for the confirmation by milestones.
+	lastRemainderOutput *utxo.Output
 }
 
 // the default options applied to the faucet.
@@ -183,6 +204,9 @@ func WithMaxOutputCount(maxOutputCount int) Option {
 		if maxOutputCount > iotago.MaxOutputsCount {
 			maxOutputCount = iotago.MaxOutputsCount
 		}
+		if maxOutputCount < 2 {
+			maxOutputCount = 2
+		}
 		opts.maxOutputCount = maxOutputCount
 	}
 }
@@ -222,6 +246,7 @@ type Option func(opts *Options)
 
 // New creates a new faucet instance.
 func New(
+	daemon daemon.Daemon,
 	dbStorage *storage.Storage,
 	syncManager *syncmanager.SyncManager,
 	networkID uint64,
@@ -239,6 +264,7 @@ func New(
 	options.apply(opts...)
 
 	faucet := &Faucet{
+		daemon:          daemon,
 		storage:         dbStorage,
 		syncManager:     syncManager,
 		networkID:       networkID,
@@ -252,7 +278,7 @@ func New(
 		opts:            options,
 
 		Events: &Events{
-			IssuedMessage: events.NewEvent(events.VoidCaller),
+			IssuedMessage: events.NewEvent(storage.MessageIDCaller),
 			SoftError:     events.NewEvent(events.ErrorCaller),
 		},
 	}
@@ -262,9 +288,13 @@ func New(
 }
 
 func (f *Faucet) init() {
+	f.faucetBalance = 0
 	f.queue = make(chan *queueItem, 5000)
 	f.queueMap = make(map[string]*queueItem)
-	f.lastMessageID = hornet.NullMessageID()
+	f.flushQueue = make(chan struct{})
+	f.pendingTransactionsMap = make(map[string]*pendingTransaction)
+	f.lastMessageID = nil
+	f.lastRemainderOutput = nil
 }
 
 // NetworkPrefix returns the used network prefix.
@@ -274,14 +304,9 @@ func (f *Faucet) NetworkPrefix() iotago.NetworkPrefix {
 
 // Info returns the used faucet address and remaining balance.
 func (f *Faucet) Info() (*FaucetInfoResponse, error) {
-	balance, _, err := f.utxoManager.AddressBalanceWithoutLocking(f.address)
-	if err != nil {
-		return nil, err
-	}
-
 	return &FaucetInfoResponse{
 		Address: f.address.Bech32(f.opts.hrpNetworkPrefix),
-		Balance: balance,
+		Balance: f.faucetBalance,
 	}, nil
 }
 
@@ -291,6 +316,10 @@ func (f *Faucet) Enqueue(bech32Addr string) (*FaucetEnqueueResponse, error) {
 	ed25519Addr, err := f.parseBech32Address(bech32Addr)
 	if err != nil {
 		return nil, err
+	}
+
+	if !f.syncManager.IsNodeAlmostSynced() {
+		return nil, errors.WithMessage(echo.ErrInternalServerError, "Faucet node is not synchronized. Please try again later!")
 	}
 
 	f.Lock()
@@ -306,8 +335,12 @@ func (f *Faucet) Enqueue(bech32Addr string) (*FaucetEnqueueResponse, error) {
 		amount = f.opts.smallAmount
 
 		if balance >= f.opts.maxAddressBalance {
-			return nil, errors.WithMessage(restapi.ErrInvalidParameter, "You already have enough coins on your address.")
+			return nil, errors.WithMessage(restapi.ErrInvalidParameter, "You already have enough funds on your address.")
 		}
+	}
+
+	if amount > f.faucetBalance {
+		return nil, errors.WithMessage(echo.ErrInternalServerError, "Faucet does not have enough funds to process your request. Please try again later!")
 	}
 
 	request := &queueItem{
@@ -318,6 +351,7 @@ func (f *Faucet) Enqueue(bech32Addr string) (*FaucetEnqueueResponse, error) {
 
 	select {
 	case f.queue <- request:
+		f.faucetBalance -= amount
 		f.queueMap[bech32Addr] = request
 		return &FaucetEnqueueResponse{
 			Address:         bech32Addr,
@@ -328,6 +362,11 @@ func (f *Faucet) Enqueue(bech32Addr string) (*FaucetEnqueueResponse, error) {
 		// queue is full
 		return nil, errors.WithMessage(echo.ErrInternalServerError, "Faucet queue is full. Please try again later!")
 	}
+}
+
+// FlushRequests stops current batching of faucet requests.
+func (f *Faucet) FlushRequests() {
+	f.flushQueue <- struct{}{}
 }
 
 // parseBech32Address parses a bech32 address.
@@ -350,105 +389,63 @@ func (f *Faucet) parseBech32Address(bech32Addr string) (*iotago.Ed25519Address, 
 	}
 }
 
-// clearRequests clears the old requests from the map.
-// this is necessary to be able to send new requests to the same addresses.
-func (f *Faucet) clearRequests(batchedRequests []*queueItem) {
-	f.Lock()
-	defer f.Unlock()
+// clearRequestWithoutLocking clear the old request from the map.
+// this is necessary to be able to send a new request to the same address.
+// write lock must be acquired outside.
+func (f *Faucet) clearRequestWithoutLocking(request *queueItem) {
+	delete(f.queueMap, request.Bech32)
+}
 
+// clearRequestsWithoutLocking clears the old requests from the map.
+// this is necessary to be able to send new requests to the same addresses.
+// write lock must be acquired outside.
+func (f *Faucet) clearRequestsWithoutLocking(batchedRequests []*queueItem) {
 	for _, request := range batchedRequests {
-		delete(f.queueMap, request.Bech32)
+		f.clearRequestWithoutLocking(request)
 	}
 }
 
-// createMessage creates a new message and references the last faucet message (also reattaches if below max depth).
-func (f *Faucet) createMessage(ctx context.Context, txPayload serializer.Serializable) (*storage.Message, error) {
+// readdRequestsWithoutLocking adds old requests back to the queue.
+// write lock must be acquired outside.
+func (f *Faucet) readdRequestsWithoutLocking(batchedRequests []*queueItem) {
+	for _, request := range batchedRequests {
+		select {
+		case f.queue <- request:
+		default:
+			// queue full => no way to readd it, delete it from the map as well so user are able to send a new request
+			f.clearRequestWithoutLocking(request)
+		}
+	}
+}
+
+// addPendingTransactionWithoutLocking tracks a pending transaction.
+// write lock must be acquired outside.
+func (f *Faucet) addPendingTransactionWithoutLocking(pending *pendingTransaction) {
+	f.pendingTransactionsMap[pending.MessageID.ToMapKey()] = pending
+}
+
+// clearPendingTransactionWithoutLocking removes tracking of a pending transaction.
+// write lock must be acquired outside.
+func (f *Faucet) clearPendingTransactionWithoutLocking(msgID hornet.MessageID) {
+	delete(f.pendingTransactionsMap, msgID.ToMapKey())
+}
+
+// createMessage creates a new message and references the last faucet message.
+func (f *Faucet) createMessage(ctx context.Context, txPayload serializer.Serializable, tip ...hornet.MessageID) (*storage.Message, error) {
 
 	tips, err := f.tipselFunc()
 	if err != nil {
 		return nil, err
 	}
 
-	reattachMessage := func(messageID hornet.MessageID) (*storage.Message, error) {
-		cachedMsg := f.storage.CachedMessageOrNil(f.lastMessageID)
-		if cachedMsg == nil {
-			// message unknown
-			return nil, fmt.Errorf("message not found: %s", messageID.ToHex())
+	if len(tip) > 0 {
+		// if a tip was passed, use that one
+		if len(tips) < iotago.MaxParentsInAMessage {
+			tips = append(tips, tip[0])
+		} else {
+			tips[0] = tip[0]
 		}
-		defer cachedMsg.Release(true)
-
-		tips, err := f.tipselFunc()
-		if err != nil {
-			return nil, err
-		}
-
-		iotaMsg := &iotago.Message{
-			NetworkID: f.networkID,
-			Parents:   tips.ToSliceOfArrays(),
-			Payload:   cachedMsg.Message().Message().Payload,
-		}
-
-		if err := f.powHandler.DoPoW(ctx, iotaMsg, 1); err != nil {
-			return nil, err
-		}
-
-		msg, err := storage.NewMessage(iotaMsg, serializer.DeSeriModePerformValidation)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := f.sendMessageFunc(msg); err != nil {
-			return nil, err
-		}
-
-		return msg, nil
-	}
-
-	// check if the last faucet message was already confirmed.
-	// if not, check if it is already below max depth and reattach in case.
-	// we need to check for the last faucet message, because we reference the last message as a tip
-	// to be sure the tangle consumes our UTXOs in the correct order.
-	if err = func() error {
-		if bytes.Equal(f.lastMessageID, hornet.NullMessageID()) {
-			// do not reference NullMessage
-			return nil
-		}
-
-		cachedMsgMeta := f.storage.CachedMessageMetadataOrNil(f.lastMessageID)
-		if cachedMsgMeta == nil {
-			// message unknown
-			return nil
-		}
-		defer cachedMsgMeta.Release(true)
-
-		if cachedMsgMeta.Metadata().IsReferenced() {
-			// message is already confirmed, no need to reference
-			return nil
-		}
-
-		_, ocri, err := dag.ConeRootIndexes(ctx, f.storage, cachedMsgMeta.Retain(), f.syncManager.ConfirmedMilestoneIndex()) // meta +
-		if err != nil {
-			return err
-		}
-
-		if (f.syncManager.LatestMilestoneIndex() - ocri) > f.belowMaxDepth {
-			// the last faucet message is not confirmed yet, but it is already below max depth
-			// we need to reattach it
-			msg, err := reattachMessage(f.lastMessageID)
-			if err != nil {
-				return common.CriticalError(fmt.Errorf("faucet message was below max depth and couldn't be reattached: %w", err))
-			}
-
-			// update the lastMessasgeID because we reattached the message
-			f.lastMessageID = msg.MessageID()
-		}
-
-		tips[0] = f.lastMessageID
 		tips = tips.RemoveDupsAndSortByLexicalOrder()
-
-		return nil
-	}(); err != nil {
-		return nil, err
 	}
 
 	// create the message
@@ -490,7 +487,7 @@ func (f *Faucet) buildTransactionPayload(unspentOutputs []*utxo.Output, batchedR
 	for _, req := range batchedRequests {
 		outputCount++
 
-		if outputCount >= f.opts.maxOutputCount {
+		if outputCount >= f.opts.maxOutputCount-1 {
 			// do not collect further requests
 			// the last slot is for the remainder
 			break
@@ -556,28 +553,37 @@ func (f *Faucet) buildTransactionPayload(unspentOutputs []*utxo.Output, batchedR
 	return txPayload, remainderOutput, uint64(remainderAmount), nil
 }
 
-// sendFaucetMessage creates a faucet transaction payload and remembers the last sent messageID.
-func (f *Faucet) sendFaucetMessage(ctx context.Context, unspentOutputs []*utxo.Output, batchedRequests []*queueItem) (*utxo.Output, error) {
+// sendFaucetMessage creates a faucet transaction payload and remembers the last sent messageID and the lastRemainderOutput.
+func (f *Faucet) sendFaucetMessage(ctx context.Context, unspentOutputs []*utxo.Output, batchedRequests []*queueItem, tip ...hornet.MessageID) error {
 
 	txPayload, remainderIotaGoOutput, remainderAmount, err := f.buildTransactionPayload(unspentOutputs, batchedRequests)
 	if err != nil {
-		return nil, fmt.Errorf("build transaction payload failed, error: %w", err)
+		return fmt.Errorf("build transaction payload failed, error: %w", err)
 	}
 
-	msg, err := f.createMessage(ctx, txPayload)
+	msg, err := f.createMessage(ctx, txPayload, tip...)
 	if err != nil {
-		return nil, fmt.Errorf("build faucet message failed, error: %w", err)
+		return fmt.Errorf("build faucet message failed, error: %w", err)
 	}
 
 	if err := f.sendMessageFunc(msg); err != nil {
-		return nil, fmt.Errorf("send faucet message failed, error: %w", err)
+		return fmt.Errorf("send faucet message failed, error: %w", err)
 	}
 
+	f.Lock()
 	f.lastMessageID = msg.MessageID()
-	remainderIotaGoOutputID := remainderIotaGoOutput.ID()
-	remainderOutput := utxo.CreateOutput(&remainderIotaGoOutputID, msg.MessageID(), iotago.OutputSigLockedSingleOutput, f.address, uint64(remainderAmount))
+	f.addPendingTransactionWithoutLocking(&pendingTransaction{MessageID: msg.MessageID(), QueuedItems: batchedRequests})
+	if remainderIotaGoOutput != nil {
+		remainderIotaGoOutputID := remainderIotaGoOutput.ID()
+		f.lastRemainderOutput = utxo.CreateOutput(&remainderIotaGoOutputID, msg.MessageID(), iotago.OutputSigLockedSingleOutput, f.address, uint64(remainderAmount))
+	} else {
+		f.lastRemainderOutput = nil
+	}
+	f.Unlock()
 
-	return remainderOutput, nil
+	f.Events.IssuedMessage.Trigger(msg.MessageID())
+
+	return nil
 }
 
 // logSoftError logs a soft error and triggers the event.
@@ -588,10 +594,101 @@ func (f *Faucet) logSoftError(err error) {
 	f.Events.SoftError.Trigger(err)
 }
 
-// RunFaucetLoop collects unspent outputs on the faucet address and batches the requests from the queue.
-func (f *Faucet) RunFaucetLoop(ctx context.Context) error {
+// collectRequests collects faucet requests until the maximum amount or a timeout is reached.
+// locking not required.
+func (f *Faucet) collectRequests(ctx context.Context) ([]*queueItem, error) {
 
-	var lastRemainderOutput *utxo.Output
+	batchedRequests := []*queueItem{}
+	collectedRequestsCounter := 0
+
+CollectValues:
+	for collectedRequestsCounter < f.opts.maxOutputCount {
+		select {
+		case <-ctx.Done():
+			// faucet was stopped
+			return nil, common.ErrOperationAborted
+
+		case <-time.After(f.opts.batchTimeout):
+			// timeout was reached => stop collecting requests
+			break CollectValues
+
+		case <-f.flushQueue:
+			// flush signal => stop collecting requests
+			for collectedRequestsCounter < f.opts.maxOutputCount {
+				// collect all pending requests
+				select {
+				case request := <-f.queue:
+					batchedRequests = append(batchedRequests, request)
+					collectedRequestsCounter++
+
+				default:
+					// no pending requests
+					break CollectValues
+				}
+			}
+			break CollectValues
+
+		case request := <-f.queue:
+			batchedRequests = append(batchedRequests, request)
+			collectedRequestsCounter++
+		}
+	}
+
+	return batchedRequests, nil
+}
+
+// processRequestsWithoutLocking processes all possible requests considering the maximum transaction size and the remaining funds of the faucet.
+// write lock must be acquired outside.
+func (f *Faucet) processRequestsWithoutLocking(collectedRequestsCounter int, amount uint64, batchedRequests []*queueItem) []*queueItem {
+	processedBatchedRequests := []*queueItem{}
+	unprocessedBatchedRequests := []*queueItem{}
+	nodeAlmostSynced := f.syncManager.IsNodeAlmostSynced()
+
+	for i := 0; i < len(batchedRequests); i++ {
+		request := batchedRequests[i]
+
+		if !nodeAlmostSynced {
+			// request can't be processed because the node is not synchronized => re-add it to the queue
+			unprocessedBatchedRequests = append(unprocessedBatchedRequests, request)
+			continue
+		}
+
+		if collectedRequestsCounter >= f.opts.maxOutputCount-1 {
+			// request can't be processed in this transaction => re-add it to the queue
+			unprocessedBatchedRequests = append(unprocessedBatchedRequests, request)
+			continue
+		}
+
+		if amount < request.Amount {
+			// not enough funds to process this request => ignore the request
+			f.clearRequestWithoutLocking(request)
+			continue
+		}
+
+		// request can be processed in this transaction
+		amount -= request.Amount
+		collectedRequestsCounter++
+		processedBatchedRequests = append(processedBatchedRequests, request)
+	}
+
+	f.readdRequestsWithoutLocking(unprocessedBatchedRequests)
+
+	return processedBatchedRequests
+}
+
+// RunFaucetLoop collects unspent outputs on the faucet address and batches the requests from the queue.
+func (f *Faucet) RunFaucetLoop(ctx context.Context, initDoneCallback func()) error {
+
+	// set initial faucet balance
+	faucetBalance, _, err := f.utxoManager.AddressBalanceWithoutLocking(f.address)
+	if err != nil {
+		return common.CriticalError(fmt.Errorf("reading faucet address balance failed: %s, error: %s", f.address.Bech32(f.opts.hrpNetworkPrefix), err))
+	}
+	f.faucetBalance = faucetBalance
+
+	if initDoneCallback != nil {
+		initDoneCallback()
+	}
 
 	for {
 		select {
@@ -600,87 +697,223 @@ func (f *Faucet) RunFaucetLoop(ctx context.Context) error {
 			return nil
 
 		default:
-
-			// only collect unspent outputs if the lastRemainderOutput is not pending
-			shouldCollectUnspentOutputs := func() bool {
-				if lastRemainderOutput == nil {
-					return true
-				}
-
-				if _, err := f.utxoManager.ReadOutputByOutputIDWithoutLocking(lastRemainderOutput.OutputID()); err != nil {
-					return false
-				}
-
-				return true
-			}
-
-			var err error
-			unspentOutputs := []*utxo.Output{}
-			if shouldCollectUnspentOutputs() {
-				unspentOutputs, err = f.utxoManager.UnspentOutputs(utxo.FilterAddress(f.address), utxo.ReadLockLedger(false), utxo.MaxResultCount(f.opts.maxOutputCount-2), utxo.FilterOutputType(iotago.OutputSigLockedSingleOutput))
-				if err != nil {
-					return fmt.Errorf("reading unspent outputs failed: %s, error: %w", f.address.Bech32(f.opts.hrpNetworkPrefix), err)
-				}
-			} else {
-				unspentOutputs = append(unspentOutputs, lastRemainderOutput)
-			}
-
-			var amount uint64 = 0
-			found := false
-			for _, unspentOutput := range unspentOutputs {
-				amount += unspentOutput.Amount()
-				if lastRemainderOutput != nil && bytes.Equal(unspentOutput.OutputID()[:], lastRemainderOutput.OutputID()[:]) {
-					found = true
-				}
-			}
-
-			if lastRemainderOutput != nil && !found {
-				unspentOutputs = append(unspentOutputs, lastRemainderOutput)
-				amount += lastRemainderOutput.Amount()
-			}
-
-			collectedRequestsCounter := len(unspentOutputs)
-			batchWriterTimeoutChan := time.After(f.opts.batchTimeout)
-			batchedRequests := []*queueItem{}
-
-		CollectValues:
-			for collectedRequestsCounter < f.opts.maxOutputCount-1 && amount > f.opts.amount {
-				select {
-				case <-ctx.Done():
-					// faucet was stopped
-					return nil
-
-				case <-batchWriterTimeoutChan:
-					// timeout was reached => stop collecting requests
-					break CollectValues
-
-				case request := <-f.queue:
-					batchedRequests = append(batchedRequests, request)
-					collectedRequestsCounter++
-					amount -= request.Amount
-				}
-			}
-
-			f.clearRequests(batchedRequests)
-
-			if len(unspentOutputs) < 2 && len(batchedRequests) == 0 {
-				// no need to sweep or send funds
-				continue
-			}
-
-			remainderOutput, err := f.sendFaucetMessage(ctx, unspentOutputs, batchedRequests)
+			// first collect requests
+			batchedRequests, err := f.collectRequests(ctx)
 			if err != nil {
+				if err == common.ErrOperationAborted {
+					return nil
+				}
 				if common.IsCriticalError(err) != nil {
 					// error is a critical error
 					// => stop the faucet
 					return err
 				}
-
 				f.logSoftError(err)
 				continue
 			}
 
-			lastRemainderOutput = remainderOutput
+			collectUnspentOutputsWithoutLocking := func() ([]*utxo.Output, uint64, error) {
+				if f.lastRemainderOutput != nil {
+					// the lastRemainderOutput is reused as input in the next transaction, even if it was not yet referenced by a milestone.
+					// this is done to increase the throughput of the faucet in high load situations.
+					// we can't collect unspent outputs, as long as the lastRemainderOutput was not confirmed,
+					// since it's creating transaction could also have consumed the same UTXOs.
+					return []*utxo.Output{f.lastRemainderOutput}, f.lastRemainderOutput.Amount(), nil
+				}
+
+				unspentOutputs, err := f.utxoManager.UnspentOutputs(utxo.FilterAddress(f.address), utxo.ReadLockLedger(false), utxo.MaxResultCount(f.opts.maxOutputCount-2), utxo.FilterOutputType(iotago.OutputSigLockedSingleOutput))
+				if err != nil {
+					return nil, 0, common.CriticalError(fmt.Errorf("reading unspent outputs failed: %s, error: %w", f.address.Bech32(f.opts.hrpNetworkPrefix), err))
+				}
+
+				var amount uint64 = 0
+				for _, unspentOutput := range unspentOutputs {
+					amount += unspentOutput.Amount()
+				}
+				return unspentOutputs, amount, nil
+			}
+
+			processRequests := func() ([]*utxo.Output, []*queueItem, hornet.MessageIDs, error) {
+				// first we need to read lock the ledger, to be sure that there is no confirmation ongoing
+				f.utxoManager.ReadLockLedger()
+				defer f.utxoManager.ReadUnlockLedger()
+
+				// there must be a lock between collectUnspentOutputsWithoutLocking and "tipselection", otherwise the chaining may fail
+				f.Lock()
+				defer f.Unlock()
+
+				unspentOutputs, amount, err := collectUnspentOutputsWithoutLocking()
+				if err != nil {
+					return nil, nil, nil, err
+				}
+
+				if len(unspentOutputs) < 2 && len(batchedRequests) == 0 {
+					// no need to sweep or send funds
+					return nil, nil, nil, ErrNothingToProcess
+				}
+
+				// if a lastMessageID exists, we need to reference it to chain the transactions in the correct order for whiteflag.
+				// lastMessageID is reset by ApplyConfirmation in case the last faucet message is not confirmed and below max depth.
+				var tips hornet.MessageIDs
+				if f.lastMessageID != nil {
+					tip := make(hornet.MessageID, len(f.lastMessageID))
+					copy(tip, f.lastMessageID)
+					tips = append(tips, tip)
+				}
+
+				processableRequests := f.processRequestsWithoutLocking(len(unspentOutputs), amount, batchedRequests)
+
+				return unspentOutputs, processableRequests, tips, nil
+			}
+
+			unspentOutputs, processableRequests, tips, err := processRequests()
+			if err != nil {
+				if err != ErrNothingToProcess {
+					if common.IsCriticalError(err) != nil {
+						// error is a critical error
+						// => stop the faucet
+						return err
+					}
+					f.logSoftError(err)
+				}
+				continue
+			}
+
+			if err := f.sendFaucetMessage(ctx, unspentOutputs, processableRequests, tips...); err != nil {
+				if common.IsCriticalError(err) != nil {
+					// error is a critical error
+					// => stop the faucet
+					return err
+				}
+				f.readdRequestsWithoutLocking(processableRequests)
+				f.logSoftError(err)
+				continue
+			}
 		}
 	}
+}
+
+// ApplyConfirmation applies new milestone confirmations to the faucet.
+// Pending transactions are checked for their current state and either removed, readded, or left pending.
+// If a conflict is found, all remaining pending transactions are readded to the queue.
+// no need to ReadLockLedger, because this function should be called from milestone confirmation event anyway.
+func (f *Faucet) ApplyConfirmation(confirmation *whiteflag.Confirmation) error {
+	if confirmation == nil {
+		return nil
+	}
+
+	f.Lock()
+	defer f.Unlock()
+
+	conflicting := false
+	cmi := confirmation.MilestoneIndex
+
+	// check pending transactions for confirmation
+	for _, msgID := range confirmation.Mutations.MessagesIncludedWithTransactions {
+		if pendingTx, pending := f.pendingTransactionsMap[msgID.ToMapKey()]; pending {
+			// transaction was confirmed => delete the requests and the pending transaction
+			f.clearRequestsWithoutLocking(pendingTx.QueuedItems)
+			f.clearPendingTransactionWithoutLocking(msgID)
+
+			if f.lastRemainderOutput != nil && bytes.Equal(f.lastRemainderOutput.MessageID()[:], msgID[:]) {
+				// the latest transaction got confirmed, reset the lastRemainderOutput
+				f.lastRemainderOutput = nil
+			}
+		}
+	}
+
+	// check pending transactions for conflicts
+	for _, conflict := range confirmation.Mutations.MessagesExcludedWithConflictingTransactions {
+		if pendingTx, pending := f.pendingTransactionsMap[conflict.MessageID.ToMapKey()]; pending {
+			// transaction was conflicting => readd the items to the queue and delete the pending transaction
+			conflicting = true
+			f.readdRequestsWithoutLocking(pendingTx.QueuedItems)
+			f.clearPendingTransactionWithoutLocking(conflict.MessageID)
+		}
+	}
+
+	checkPendingMessageMetadata := func(pendingTx *pendingTransaction) {
+		msgID := pendingTx.MessageID
+
+		cachedMsgMeta := f.storage.CachedMessageMetadataOrNil(msgID) // meta +1
+		if cachedMsgMeta == nil {
+			// message unknown => delete the requests and the pending transaction
+			conflicting = true
+			f.clearRequestsWithoutLocking(pendingTx.QueuedItems)
+			f.clearPendingTransactionWithoutLocking(msgID)
+			return
+		}
+		defer cachedMsgMeta.Release(true)
+
+		metadata := cachedMsgMeta.Metadata()
+		if metadata.IsReferenced() {
+			if metadata.IsConflictingTx() {
+				// transaction was conflicting => readd the items to the queue and delete the pending transaction
+				conflicting = true
+				f.readdRequestsWithoutLocking(pendingTx.QueuedItems)
+				f.clearPendingTransactionWithoutLocking(msgID)
+				return
+			}
+
+			// transaction was confirmed => delete the requests and the pending transaction
+			f.clearRequestsWithoutLocking(pendingTx.QueuedItems)
+			f.clearPendingTransactionWithoutLocking(msgID)
+			return
+		}
+
+		// check if message is "below max depth"
+		_, ocri, err := dag.ConeRootIndexes(f.daemon.ContextStopped(), f.storage, cachedMsgMeta.Retain(), cmi)
+		if err != nil {
+			// an error occured => readd the items to the queue and delete the pending transaction
+			conflicting = true
+			f.readdRequestsWithoutLocking(pendingTx.QueuedItems)
+			f.clearPendingTransactionWithoutLocking(msgID)
+			return
+		}
+
+		if (cmi - ocri) > milestone.Index(f.belowMaxDepth) {
+			// below max depth => readd the items to the queue and delete the pending transaction
+			conflicting = true
+			f.readdRequestsWithoutLocking(pendingTx.QueuedItems)
+			f.clearPendingTransactionWithoutLocking(msgID)
+		}
+	}
+
+	// check all remaining pending transactions
+	for _, pendingTx := range f.pendingTransactionsMap {
+		checkPendingMessageMetadata(pendingTx)
+	}
+
+	if conflicting {
+		// there was a conflict in the chain
+		// => reset the lastMessageID and lastRemainderOutput to collect outputs and reissue all pending transactions
+		f.lastMessageID = nil
+		f.lastRemainderOutput = nil
+
+		for _, pendingTx := range f.pendingTransactionsMap {
+			f.readdRequestsWithoutLocking(pendingTx.QueuedItems)
+			f.clearPendingTransactionWithoutLocking(pendingTx.MessageID)
+		}
+	}
+
+	// calculate total balance of all pending requests
+	var pendingRequestsBalance uint64 = 0
+	for _, pendingRequest := range f.queueMap {
+		pendingRequestsBalance += pendingRequest.Amount
+	}
+
+	// recalculate the current faucet balance
+	// no need to lock since we are in the milestone confirmation anyway
+	faucetBalance, _, err := f.utxoManager.AddressBalanceWithoutLocking(f.address)
+	if err != nil {
+		return common.CriticalError(fmt.Errorf("reading faucet address balance failed: %s, error: %s", f.address.Bech32(f.opts.hrpNetworkPrefix), err))
+	}
+
+	if faucetBalance < pendingRequestsBalance {
+		f.faucetBalance = 0
+		return nil
+	}
+
+	f.faucetBalance = faucetBalance - pendingRequestsBalance
+	return nil
 }

--- a/pkg/model/faucet/faucet.go
+++ b/pkg/model/faucet/faucet.go
@@ -864,7 +864,7 @@ func (f *Faucet) ApplyConfirmation(confirmation *whiteflag.Confirmation) error {
 		// check if message is "below max depth"
 		_, ocri, err := dag.ConeRootIndexes(f.daemon.ContextStopped(), f.storage, cachedMsgMeta.Retain(), cmi)
 		if err != nil {
-			// an error occured => readd the items to the queue and delete the pending transaction
+			// an error occurred => readd the items to the queue and delete the pending transaction
 			conflicting = true
 			f.readdRequestsWithoutLocking(pendingTx.QueuedItems)
 			f.clearPendingTransactionWithoutLocking(msgID)

--- a/pkg/model/faucet/faucet.go
+++ b/pkg/model/faucet/faucet.go
@@ -644,7 +644,7 @@ func (f *Faucet) processRequestsWithoutLocking(collectedRequestsCounter int, amo
 	unprocessedBatchedRequests := []*queueItem{}
 	nodeAlmostSynced := f.syncManager.IsNodeAlmostSynced()
 
-	for i := 0; i < len(batchedRequests); i++ {
+	for i := range batchedRequests {
 		request := batchedRequests[i]
 
 		if !nodeAlmostSynced {

--- a/pkg/model/faucet/faucet_test.go
+++ b/pkg/model/faucet/faucet_test.go
@@ -1,0 +1,425 @@
+package faucet_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	iotago "github.com/iotaledger/iota.go/v2"
+
+	"github.com/gohornet/hornet/pkg/model/faucet/test"
+	"github.com/gohornet/hornet/pkg/model/hornet"
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	"github.com/gohornet/hornet/pkg/testsuite/utils"
+)
+
+func TestSingleRequest(t *testing.T) {
+	// requests to a single address
+
+	var faucetBalance uint64 = 1000000000         //  1 Gi
+	var wallet1Balance uint64 = 0                 //  0  i
+	var wallet2Balance uint64 = 0                 //  0  i
+	var wallet3Balance uint64 = 0                 //  0  i
+	var faucetAmount uint64 = 10000000            // 10 Mi
+	var faucetSmallAmount uint64 = 1000000        // 1  Mi
+	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+
+	env := test.NewFaucetTestEnv(t,
+		faucetBalance,
+		wallet1Balance,
+		wallet2Balance,
+		wallet3Balance,
+		faucetAmount,
+		faucetSmallAmount,
+		faucetMaxAddressBalance,
+		false)
+	defer env.Cleanup()
+	require.NotNil(t, env)
+
+	confirmedMilestoneIndex := env.ConfirmedMilestoneIndex() // 4
+	require.Equal(t, milestone.Index(4), confirmedMilestoneIndex)
+
+	// Verify balances
+	genesisBalance := iotago.TokenSupply - faucetBalance - wallet1Balance - wallet2Balance - wallet3Balance
+
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.GenesisWallet, genesisBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, wallet1Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet2, wallet2Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
+
+	err := env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+	require.NoError(t, err)
+
+	faucetBalance -= faucetAmount
+	calculatedWallet1Balance := wallet1Balance + faucetAmount
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, calculatedWallet1Balance)
+
+	// small amount
+	for calculatedWallet1Balance < faucetMaxAddressBalance {
+		err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+		require.NoError(t, err)
+
+		faucetBalance -= faucetSmallAmount
+		calculatedWallet1Balance += faucetSmallAmount
+		env.AssertFaucetBalance(faucetBalance)
+		env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+		env.TestEnv.AssertLedgerBalance(env.Wallet1, calculatedWallet1Balance)
+	}
+
+	// max reached
+	err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+	require.Error(t, err)
+}
+
+func TestMultipleRequests(t *testing.T) {
+	// requests to multiple addresses
+
+	var faucetBalance uint64 = 1000000000         //  1 Gi
+	var wallet1Balance uint64 = 0                 //  0  i
+	var wallet2Balance uint64 = 0                 //  0  i
+	var wallet3Balance uint64 = 0                 //  0  i
+	var faucetAmount uint64 = 10000000            // 10 Mi
+	var faucetSmallAmount uint64 = 1000000        // 1  Mi
+	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+
+	env := test.NewFaucetTestEnv(t,
+		faucetBalance,
+		wallet1Balance,
+		wallet2Balance,
+		wallet3Balance,
+		faucetAmount,
+		faucetSmallAmount,
+		faucetMaxAddressBalance,
+		false)
+	defer env.Cleanup()
+	require.NotNil(t, env)
+
+	confirmedMilestoneIndex := env.ConfirmedMilestoneIndex() // 4
+	require.Equal(t, milestone.Index(4), confirmedMilestoneIndex)
+
+	// Verify balances
+	genesisBalance := iotago.TokenSupply - faucetBalance - wallet1Balance - wallet2Balance - wallet3Balance
+
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.GenesisWallet, genesisBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, wallet1Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet2, wallet2Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
+
+	// multiple target addresses in single messages
+	tips1, err := env.RequestFunds([]*utils.HDWallet{env.Wallet1})
+	require.NoError(t, err)
+
+	tips2, err := env.RequestFunds([]*utils.HDWallet{env.Wallet2})
+	require.NoError(t, err)
+
+	tips3, err := env.RequestFunds([]*utils.HDWallet{env.Wallet3})
+	require.NoError(t, err)
+
+	var tips hornet.MessageIDs
+	tips = append(tips, tips1...)
+	tips = append(tips, tips2...)
+	tips = append(tips, tips3...)
+	_, _ = env.IssueMilestone(tips...)
+
+	faucetBalance -= 3 * faucetAmount
+	calculatedWallet1Balance := wallet1Balance + faucetAmount
+	calculatedWallet2Balance := wallet2Balance + faucetAmount
+	calculatedWallet3Balance := wallet3Balance + faucetAmount
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, calculatedWallet1Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet2, calculatedWallet2Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet3, calculatedWallet3Balance)
+
+	// small amount
+	for calculatedWallet1Balance < faucetMaxAddressBalance {
+		// multiple target addresses in one message
+		err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1, env.Wallet2, env.Wallet3})
+		require.NoError(t, err)
+
+		faucetBalance -= 3 * faucetSmallAmount
+		calculatedWallet1Balance += faucetSmallAmount
+		calculatedWallet2Balance += faucetSmallAmount
+		calculatedWallet3Balance += faucetSmallAmount
+		env.AssertFaucetBalance(faucetBalance)
+		env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+		env.TestEnv.AssertLedgerBalance(env.Wallet1, calculatedWallet1Balance)
+		env.TestEnv.AssertLedgerBalance(env.Wallet2, calculatedWallet2Balance)
+		env.TestEnv.AssertLedgerBalance(env.Wallet3, calculatedWallet3Balance)
+	}
+
+	// max reached
+	err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1, env.Wallet2, env.Wallet3})
+	require.Error(t, err)
+}
+
+func TestDoubleSpent(t *testing.T) {
+	// reuse of the private key of the faucet (double spent)
+
+	var faucetBalance uint64 = 1000000000         //  1 Gi
+	var wallet1Balance uint64 = 0                 //  0  i
+	var wallet2Balance uint64 = 0                 //  0  i
+	var wallet3Balance uint64 = 0                 //  0  i
+	var faucetAmount uint64 = 10000000            // 10 Mi
+	var faucetSmallAmount uint64 = 1000000        // 1  Mi
+	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+
+	env := test.NewFaucetTestEnv(t,
+		faucetBalance,
+		wallet1Balance,
+		wallet2Balance,
+		wallet3Balance,
+		faucetAmount,
+		faucetSmallAmount,
+		faucetMaxAddressBalance,
+		false)
+	defer env.Cleanup()
+	require.NotNil(t, env)
+
+	confirmedMilestoneIndex := env.ConfirmedMilestoneIndex() // 4
+	require.Equal(t, milestone.Index(4), confirmedMilestoneIndex)
+
+	// Verify balances
+	genesisBalance := iotago.TokenSupply - faucetBalance - wallet1Balance - wallet2Balance - wallet3Balance
+
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.GenesisWallet, genesisBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, wallet1Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet2, wallet2Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
+
+	// create a conflicting transaction that gets confirmed instead of the faucet message
+	message := env.TestEnv.NewMessageBuilder().
+		LatestMilestonesAsParents().
+		FromWallet(env.FaucetWallet).
+		ToWallet(env.GenesisWallet).
+		Amount(faucetAmount).
+		Build().
+		Store().
+		BookOnWallets()
+
+	// create the confliction message in the faucet
+	tips, err := env.RequestFunds([]*utils.HDWallet{env.Wallet1})
+	require.NoError(t, err)
+
+	// Confirming milestone at message
+	_, _ = env.IssueMilestone(hornet.MessageIDs{message.StoredMessageID()}...)
+
+	genesisBalance += faucetAmount
+	faucetBalance -= faucetAmount                         // we stole some funds from the faucet
+	env.AssertFaucetBalance(faucetBalance - faucetAmount) // pending request is also taken into account
+	env.TestEnv.AssertLedgerBalance(env.GenesisWallet, genesisBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+
+	// Confirming milestone at message (double spent)
+	_, _ = env.IssueMilestone(tips...)
+
+	env.AssertFaucetBalance(faucetBalance - faucetAmount) // request is still pending
+	env.TestEnv.AssertLedgerBalance(env.GenesisWallet, genesisBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+
+	err = env.FlushRequestsAndConfirmNewFaucetMessage()
+	require.NoError(t, err)
+
+	faucetBalance -= faucetAmount // now the request is booked
+	calculatedWallet1Balance := wallet1Balance + faucetAmount
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.GenesisWallet, genesisBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, calculatedWallet1Balance)
+}
+
+func TestBelowMaxDepth(t *testing.T) {
+	// faucet message is below max depth and never confirmed
+
+	var faucetBalance uint64 = 1000000000         //  1 Gi
+	var wallet1Balance uint64 = 0                 //  0  i
+	var wallet2Balance uint64 = 0                 //  0  i
+	var wallet3Balance uint64 = 0                 //  0  i
+	var faucetAmount uint64 = 10000000            // 10 Mi
+	var faucetSmallAmount uint64 = 1000000        // 1  Mi
+	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+
+	env := test.NewFaucetTestEnv(t,
+		faucetBalance,
+		wallet1Balance,
+		wallet2Balance,
+		wallet3Balance,
+		faucetAmount,
+		faucetSmallAmount,
+		faucetMaxAddressBalance,
+		false)
+	defer env.Cleanup()
+	require.NotNil(t, env)
+
+	confirmedMilestoneIndex := env.ConfirmedMilestoneIndex() // 4
+	require.Equal(t, milestone.Index(4), confirmedMilestoneIndex)
+
+	// Verify balances
+	genesisBalance := iotago.TokenSupply - faucetBalance - wallet1Balance - wallet2Balance - wallet3Balance
+
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.GenesisWallet, genesisBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, wallet1Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet2, wallet2Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
+
+	// create a request that doesn't get confirmed
+	_, err := env.RequestFunds([]*utils.HDWallet{env.Wallet1})
+	require.NoError(t, err)
+
+	// issue several milestones, so that the faucet message gets below max depth
+	for i := 0; i <= test.BelowMaxDepth; i++ {
+		_, _ = env.IssueMilestone()
+	}
+
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, wallet1Balance)
+
+	// flushing requests should reissue the requests that were in the below max depth message
+	err = env.FlushRequestsAndConfirmNewFaucetMessage()
+	require.NoError(t, err)
+
+	calculatedWallet1Balance := wallet1Balance + faucetAmount
+	faucetBalance -= faucetAmount
+	env.AssertFaucetBalance(faucetBalance)
+
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, calculatedWallet1Balance)
+}
+
+func TestNotEnoughFaucetFunds(t *testing.T) {
+	// check if faucet returns an error if not enough funds available
+
+	var faucetBalance uint64 = 29000000           // 29 Mi
+	var wallet1Balance uint64 = 0                 //  0  i
+	var wallet2Balance uint64 = 0                 //  0  i
+	var wallet3Balance uint64 = 0                 //  0  i
+	var faucetAmount uint64 = 10000000            // 10 Mi
+	var faucetSmallAmount uint64 = 1000000        // 1  Mi
+	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+
+	env := test.NewFaucetTestEnv(t,
+		faucetBalance,
+		wallet1Balance,
+		wallet2Balance,
+		wallet3Balance,
+		faucetAmount,
+		faucetSmallAmount,
+		faucetMaxAddressBalance,
+		false)
+	defer env.Cleanup()
+	require.NotNil(t, env)
+
+	// Verify balances
+	genesisBalance := iotago.TokenSupply - faucetBalance - wallet1Balance - wallet2Balance - wallet3Balance
+
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.GenesisWallet, genesisBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, wallet1Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet2, wallet2Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
+
+	// 29 Mi - 10 Mi = 19 Mi
+	err := env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+	require.NoError(t, err)
+
+	faucetBalance -= faucetAmount
+	env.AssertFaucetBalance(faucetBalance)
+
+	// 19 Mi - 10 Mi = 9 Mi
+	err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet2})
+	require.NoError(t, err)
+
+	faucetBalance -= faucetAmount
+	env.AssertFaucetBalance(faucetBalance)
+
+	// 9 Mi - 10 Mi = error
+	err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet3})
+	require.Error(t, err)
+
+	env.AssertFaucetBalance(faucetBalance)
+}
+
+func TestCollectFaucetFunds(t *testing.T) {
+	// check if faucet collects funds if no requests left
+
+	var faucetBalance uint64 = 1000000000         //  1 Gi
+	var wallet1Balance uint64 = 0                 //  0  i
+	var wallet2Balance uint64 = 0                 //  0  i
+	var wallet3Balance uint64 = 0                 //  0  i
+	var faucetAmount uint64 = 10000000            // 10 Mi
+	var faucetSmallAmount uint64 = 1000000        // 1  Mi
+	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+
+	env := test.NewFaucetTestEnv(t,
+		faucetBalance,
+		wallet1Balance,
+		wallet2Balance,
+		wallet3Balance,
+		faucetAmount,
+		faucetSmallAmount,
+		faucetMaxAddressBalance,
+		false)
+	defer env.Cleanup()
+	require.NotNil(t, env)
+
+	confirmedMilestoneIndex := env.ConfirmedMilestoneIndex() // 4
+	require.Equal(t, milestone.Index(4), confirmedMilestoneIndex)
+
+	// Verify balances
+	genesisBalance := iotago.TokenSupply - faucetBalance - wallet1Balance - wallet2Balance - wallet3Balance
+
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.GenesisWallet, genesisBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, wallet1Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet2, wallet2Balance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
+
+	env.AssertAddressUTXOCount(env.FaucetWallet.Address(), 1)
+
+	err := env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+	require.NoError(t, err)
+
+	env.AssertAddressUTXOCount(env.FaucetWallet.Address(), 1)
+
+	faucetBalance -= faucetAmount
+	calculatedWallet1Balance := wallet1Balance + faucetAmount
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.Wallet1, calculatedWallet1Balance)
+
+	message := env.TestEnv.NewMessageBuilder().
+		LatestMilestonesAsParents().
+		FromWallet(env.GenesisWallet).
+		ToWallet(env.FaucetWallet).
+		Amount(faucetAmount).
+		Build().
+		Store().
+		BookOnWallets()
+
+	// Confirming milestone at message
+	_, _ = env.IssueMilestone(hornet.MessageIDs{message.StoredMessageID()}...)
+
+	faucetBalance += faucetAmount
+	env.AssertFaucetBalance(faucetBalance)
+	env.TestEnv.AssertLedgerBalance(env.FaucetWallet, faucetBalance)
+
+	env.AssertAddressUTXOCount(env.FaucetWallet.Address(), 2)
+
+	// Flushing requests should collect all outputs
+	err = env.FlushRequestsAndConfirmNewFaucetMessage()
+	require.NoError(t, err)
+
+	env.AssertAddressUTXOCount(env.FaucetWallet.Address(), 1)
+}

--- a/pkg/model/faucet/faucet_test.go
+++ b/pkg/model/faucet/faucet_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gohornet/hornet/pkg/model/faucet/test"
 	"github.com/gohornet/hornet/pkg/model/hornet"
 	"github.com/gohornet/hornet/pkg/model/milestone"
-	"github.com/gohornet/hornet/pkg/testsuite/utils"
 )
 
 func TestSingleRequest(t *testing.T) {
@@ -49,7 +48,7 @@ func TestSingleRequest(t *testing.T) {
 	env.TestEnv.AssertLedgerBalance(env.Wallet2, wallet2Balance)
 	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
 
-	err := env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+	err := env.RequestFundsAndIssueMilestone(env.Wallet1)
 	require.NoError(t, err)
 
 	faucetBalance -= faucetAmount
@@ -60,7 +59,7 @@ func TestSingleRequest(t *testing.T) {
 
 	// small amount
 	for calculatedWallet1Balance < faucetMaxAddressBalance {
-		err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+		err = env.RequestFundsAndIssueMilestone(env.Wallet1)
 		require.NoError(t, err)
 
 		faucetBalance -= faucetSmallAmount
@@ -71,7 +70,7 @@ func TestSingleRequest(t *testing.T) {
 	}
 
 	// max reached
-	err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+	err = env.RequestFundsAndIssueMilestone(env.Wallet1)
 	require.Error(t, err)
 }
 
@@ -112,13 +111,13 @@ func TestMultipleRequests(t *testing.T) {
 	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
 
 	// multiple target addresses in single messages
-	tips1, err := env.RequestFunds([]*utils.HDWallet{env.Wallet1})
+	tips1, err := env.RequestFunds(env.Wallet1)
 	require.NoError(t, err)
 
-	tips2, err := env.RequestFunds([]*utils.HDWallet{env.Wallet2})
+	tips2, err := env.RequestFunds(env.Wallet2)
 	require.NoError(t, err)
 
-	tips3, err := env.RequestFunds([]*utils.HDWallet{env.Wallet3})
+	tips3, err := env.RequestFunds(env.Wallet3)
 	require.NoError(t, err)
 
 	var tips hornet.MessageIDs
@@ -140,7 +139,7 @@ func TestMultipleRequests(t *testing.T) {
 	// small amount
 	for calculatedWallet1Balance < faucetMaxAddressBalance {
 		// multiple target addresses in one message
-		err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1, env.Wallet2, env.Wallet3})
+		err = env.RequestFundsAndIssueMilestone(env.Wallet1, env.Wallet2, env.Wallet3)
 		require.NoError(t, err)
 
 		faucetBalance -= 3 * faucetSmallAmount
@@ -155,7 +154,7 @@ func TestMultipleRequests(t *testing.T) {
 	}
 
 	// max reached
-	err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1, env.Wallet2, env.Wallet3})
+	err = env.RequestFundsAndIssueMilestone(env.Wallet1, env.Wallet2, env.Wallet3)
 	require.Error(t, err)
 }
 
@@ -206,11 +205,11 @@ func TestDoubleSpent(t *testing.T) {
 		BookOnWallets()
 
 	// create the confliction message in the faucet
-	tips, err := env.RequestFunds([]*utils.HDWallet{env.Wallet1})
+	tips, err := env.RequestFunds(env.Wallet1)
 	require.NoError(t, err)
 
 	// Confirming milestone at message
-	_, _ = env.IssueMilestone(hornet.MessageIDs{message.StoredMessageID()}...)
+	_, _ = env.IssueMilestone(message.StoredMessageID())
 
 	genesisBalance += faucetAmount
 	faucetBalance -= faucetAmount                         // we stole some funds from the faucet
@@ -273,7 +272,7 @@ func TestBelowMaxDepth(t *testing.T) {
 	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
 
 	// create a request that doesn't get confirmed
-	_, err := env.RequestFunds([]*utils.HDWallet{env.Wallet1})
+	_, err := env.RequestFunds(env.Wallet1)
 	require.NoError(t, err)
 
 	// issue several milestones, so that the faucet message gets below max depth
@@ -330,21 +329,21 @@ func TestNotEnoughFaucetFunds(t *testing.T) {
 	env.TestEnv.AssertLedgerBalance(env.Wallet3, wallet3Balance)
 
 	// 29 Mi - 10 Mi = 19 Mi
-	err := env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+	err := env.RequestFundsAndIssueMilestone(env.Wallet1)
 	require.NoError(t, err)
 
 	faucetBalance -= faucetAmount
 	env.AssertFaucetBalance(faucetBalance)
 
 	// 19 Mi - 10 Mi = 9 Mi
-	err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet2})
+	err = env.RequestFundsAndIssueMilestone(env.Wallet2)
 	require.NoError(t, err)
 
 	faucetBalance -= faucetAmount
 	env.AssertFaucetBalance(faucetBalance)
 
 	// 9 Mi - 10 Mi = error
-	err = env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet3})
+	err = env.RequestFundsAndIssueMilestone(env.Wallet3)
 	require.Error(t, err)
 
 	env.AssertFaucetBalance(faucetBalance)
@@ -388,7 +387,7 @@ func TestCollectFaucetFunds(t *testing.T) {
 
 	env.AssertAddressUTXOCount(env.FaucetWallet.Address(), 1)
 
-	err := env.RequestFundsAndIssueMilestone([]*utils.HDWallet{env.Wallet1})
+	err := env.RequestFundsAndIssueMilestone(env.Wallet1)
 	require.NoError(t, err)
 
 	env.AssertAddressUTXOCount(env.FaucetWallet.Address(), 1)
@@ -409,7 +408,7 @@ func TestCollectFaucetFunds(t *testing.T) {
 		BookOnWallets()
 
 	// Confirming milestone at message
-	_, _ = env.IssueMilestone(hornet.MessageIDs{message.StoredMessageID()}...)
+	_, _ = env.IssueMilestone(message.StoredMessageID())
 
 	faucetBalance += faucetAmount
 	env.AssertFaucetBalance(faucetBalance)

--- a/pkg/model/faucet/faucet_test.go
+++ b/pkg/model/faucet/faucet_test.go
@@ -16,13 +16,13 @@ import (
 func TestSingleRequest(t *testing.T) {
 	// requests to a single address
 
-	var faucetBalance uint64 = 1000000000         //  1 Gi
-	var wallet1Balance uint64 = 0                 //  0  i
-	var wallet2Balance uint64 = 0                 //  0  i
-	var wallet3Balance uint64 = 0                 //  0  i
-	var faucetAmount uint64 = 10000000            // 10 Mi
-	var faucetSmallAmount uint64 = 1000000        // 1  Mi
-	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+	var faucetBalance uint64 = 1_000_000_000        //  1 Gi
+	var wallet1Balance uint64 = 0                   //  0  i
+	var wallet2Balance uint64 = 0                   //  0  i
+	var wallet3Balance uint64 = 0                   //  0  i
+	var faucetAmount uint64 = 10_000_000            // 10 Mi
+	var faucetSmallAmount uint64 = 1_000_000        //  1 Mi
+	var faucetMaxAddressBalance uint64 = 20_000_000 // 20 Mi
 
 	env := test.NewFaucetTestEnv(t,
 		faucetBalance,
@@ -78,13 +78,13 @@ func TestSingleRequest(t *testing.T) {
 func TestMultipleRequests(t *testing.T) {
 	// requests to multiple addresses
 
-	var faucetBalance uint64 = 1000000000         //  1 Gi
-	var wallet1Balance uint64 = 0                 //  0  i
-	var wallet2Balance uint64 = 0                 //  0  i
-	var wallet3Balance uint64 = 0                 //  0  i
-	var faucetAmount uint64 = 10000000            // 10 Mi
-	var faucetSmallAmount uint64 = 1000000        // 1  Mi
-	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+	var faucetBalance uint64 = 1_000_000_000        //  1 Gi
+	var wallet1Balance uint64 = 0                   //  0  i
+	var wallet2Balance uint64 = 0                   //  0  i
+	var wallet3Balance uint64 = 0                   //  0  i
+	var faucetAmount uint64 = 10_000_000            // 10 Mi
+	var faucetSmallAmount uint64 = 1_000_000        //  1 Mi
+	var faucetMaxAddressBalance uint64 = 20_000_000 // 20 Mi
 
 	env := test.NewFaucetTestEnv(t,
 		faucetBalance,
@@ -162,13 +162,13 @@ func TestMultipleRequests(t *testing.T) {
 func TestDoubleSpent(t *testing.T) {
 	// reuse of the private key of the faucet (double spent)
 
-	var faucetBalance uint64 = 1000000000         //  1 Gi
-	var wallet1Balance uint64 = 0                 //  0  i
-	var wallet2Balance uint64 = 0                 //  0  i
-	var wallet3Balance uint64 = 0                 //  0  i
-	var faucetAmount uint64 = 10000000            // 10 Mi
-	var faucetSmallAmount uint64 = 1000000        // 1  Mi
-	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+	var faucetBalance uint64 = 1_000_000_000        //  1 Gi
+	var wallet1Balance uint64 = 0                   //  0  i
+	var wallet2Balance uint64 = 0                   //  0  i
+	var wallet3Balance uint64 = 0                   //  0  i
+	var faucetAmount uint64 = 10_000_000            // 10 Mi
+	var faucetSmallAmount uint64 = 1_000_000        //  1 Mi
+	var faucetMaxAddressBalance uint64 = 20_000_000 // 20 Mi
 
 	env := test.NewFaucetTestEnv(t,
 		faucetBalance,
@@ -239,13 +239,13 @@ func TestDoubleSpent(t *testing.T) {
 func TestBelowMaxDepth(t *testing.T) {
 	// faucet message is below max depth and never confirmed
 
-	var faucetBalance uint64 = 1000000000         //  1 Gi
-	var wallet1Balance uint64 = 0                 //  0  i
-	var wallet2Balance uint64 = 0                 //  0  i
-	var wallet3Balance uint64 = 0                 //  0  i
-	var faucetAmount uint64 = 10000000            // 10 Mi
-	var faucetSmallAmount uint64 = 1000000        // 1  Mi
-	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+	var faucetBalance uint64 = 1_000_000_000        //  1 Gi
+	var wallet1Balance uint64 = 0                   //  0  i
+	var wallet2Balance uint64 = 0                   //  0  i
+	var wallet3Balance uint64 = 0                   //  0  i
+	var faucetAmount uint64 = 10_000_000            // 10 Mi
+	var faucetSmallAmount uint64 = 1_000_000        //  1 Mi
+	var faucetMaxAddressBalance uint64 = 20_000_000 // 20 Mi
 
 	env := test.NewFaucetTestEnv(t,
 		faucetBalance,
@@ -299,13 +299,13 @@ func TestBelowMaxDepth(t *testing.T) {
 func TestNotEnoughFaucetFunds(t *testing.T) {
 	// check if faucet returns an error if not enough funds available
 
-	var faucetBalance uint64 = 29000000           // 29 Mi
-	var wallet1Balance uint64 = 0                 //  0  i
-	var wallet2Balance uint64 = 0                 //  0  i
-	var wallet3Balance uint64 = 0                 //  0  i
-	var faucetAmount uint64 = 10000000            // 10 Mi
-	var faucetSmallAmount uint64 = 1000000        // 1  Mi
-	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+	var faucetBalance uint64 = 29000000             // 29 Mi
+	var wallet1Balance uint64 = 0                   //  0  i
+	var wallet2Balance uint64 = 0                   //  0  i
+	var wallet3Balance uint64 = 0                   //  0  i
+	var faucetAmount uint64 = 10_000_000            // 10 Mi
+	var faucetSmallAmount uint64 = 1_000_000        //  1 Mi
+	var faucetMaxAddressBalance uint64 = 20_000_000 // 20 Mi
 
 	env := test.NewFaucetTestEnv(t,
 		faucetBalance,
@@ -353,13 +353,13 @@ func TestNotEnoughFaucetFunds(t *testing.T) {
 func TestCollectFaucetFunds(t *testing.T) {
 	// check if faucet collects funds if no requests left
 
-	var faucetBalance uint64 = 1000000000         //  1 Gi
-	var wallet1Balance uint64 = 0                 //  0  i
-	var wallet2Balance uint64 = 0                 //  0  i
-	var wallet3Balance uint64 = 0                 //  0  i
-	var faucetAmount uint64 = 10000000            // 10 Mi
-	var faucetSmallAmount uint64 = 1000000        // 1  Mi
-	var faucetMaxAddressBalance uint64 = 20000000 // 20 Mi
+	var faucetBalance uint64 = 1_000_000_000        //  1 Gi
+	var wallet1Balance uint64 = 0                   //  0  i
+	var wallet2Balance uint64 = 0                   //  0  i
+	var wallet3Balance uint64 = 0                   //  0  i
+	var faucetAmount uint64 = 10_000_000            // 10 Mi
+	var faucetSmallAmount uint64 = 1_000_000        //  1 Mi
+	var faucetMaxAddressBalance uint64 = 20_000_000 // 20 Mi
 
 	env := test.NewFaucetTestEnv(t,
 		faucetBalance,

--- a/pkg/model/faucet/test/testenv.go
+++ b/pkg/model/faucet/test/testenv.go
@@ -285,7 +285,9 @@ func (env *FaucetTestEnv) processFaucetRequests(preFlushFunc func() error) (horn
 }
 
 // RequestFunds sends requests to the faucet and waits until the next faucet message is issued.
-func (env *FaucetTestEnv) RequestFunds(wallets []*utils.HDWallet) (hornet.MessageIDs, error) {
+func (env *FaucetTestEnv) RequestFunds(wallets ...*utils.HDWallet) (hornet.MessageIDs, error) {
+
+	require.Greater(env.t, len(wallets), 0)
 
 	tips, err := env.processFaucetRequests(func() error {
 		for _, wallet := range wallets {
@@ -304,9 +306,9 @@ func (env *FaucetTestEnv) RequestFunds(wallets []*utils.HDWallet) (hornet.Messag
 
 // RequestFundsAndIssueMilestone sends requests to the faucet, waits until the next faucet message is issued and
 // issues a milestone on top of it.
-func (env *FaucetTestEnv) RequestFundsAndIssueMilestone(wallets []*utils.HDWallet) error {
+func (env *FaucetTestEnv) RequestFundsAndIssueMilestone(wallets ...*utils.HDWallet) error {
 
-	tips, err := env.RequestFunds(wallets)
+	tips, err := env.RequestFunds(wallets...)
 	if err != nil {
 		return err
 	}

--- a/pkg/model/faucet/test/testenv.go
+++ b/pkg/model/faucet/test/testenv.go
@@ -1,0 +1,353 @@
+package test
+
+import (
+	"context"
+	"encoding/hex"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gohornet/hornet/pkg/common"
+	"github.com/gohornet/hornet/pkg/model/faucet"
+	"github.com/gohornet/hornet/pkg/model/hornet"
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	"github.com/gohornet/hornet/pkg/model/storage"
+	"github.com/gohornet/hornet/pkg/model/utxo"
+	"github.com/gohornet/hornet/pkg/testsuite"
+	"github.com/gohornet/hornet/pkg/testsuite/utils"
+	"github.com/gohornet/hornet/pkg/whiteflag"
+	"github.com/iotaledger/hive.go/daemon"
+	"github.com/iotaledger/hive.go/events"
+	iotago "github.com/iotaledger/iota.go/v2"
+)
+
+const (
+	faucetMaxOutputCount    = iotago.MaxOutputsCount
+	faucetIndexationMessage = "FAUCET"
+	faucetPowWorkerCount    = 0
+	faucetBatchTimeout      = 2 * time.Second
+)
+
+var (
+	genesisSeed, _ = hex.DecodeString("2f54b071657e6644629a40518ba6554de4eee89f0757713005ad26137d80968d05e1ca1bca555d8b4b85a3f4fcf11a6a48d3d628d1ace40f48009704472fc8f9")
+	faucetSeed, _  = hex.DecodeString("96d9ff7a79e4b0a5f3e5848ae7867064402da92a62eabb4ebbe463f12d1f3b1aace1775488f51cb1e3a80732a03ef60b111d6833ab605aa9f8faebeb33bbe3d9")
+	seed1, _       = hex.DecodeString("b15209ddc93cbdb600137ea6a8f88cdd7c5d480d5815c9352a0fb5c4e4b86f7151dcb44c2ba635657a2df5a8fd48cb9bab674a9eceea527dbbb254ef8c9f9cd7")
+	seed2, _       = hex.DecodeString("d5353ceeed380ab89a0f6abe4630c2091acc82617c0edd4ff10bd60bba89e2ed30805ef095b989c2bf208a474f8748d11d954aade374380422d4d812b6f1da90")
+	seed3, _       = hex.DecodeString("bd6fe09d8a309ca309c5db7b63513240490109cd0ac6b123551e9da0d5c8916c4a5a4f817e4b4e9df89885ce1af0986da9f1e56b65153c2af1e87ab3b11dabb4")
+
+	MinPoWScore   = 10.0
+	BelowMaxDepth = 15
+)
+
+type FaucetTestEnv struct {
+	t       *testing.T
+	TestEnv *testsuite.TestEnvironment
+
+	GenesisWallet *utils.HDWallet
+	FaucetWallet  *utils.HDWallet
+	Wallet1       *utils.HDWallet
+	Wallet2       *utils.HDWallet
+	Wallet3       *utils.HDWallet
+
+	Faucet *faucet.Faucet
+
+	faucetCtxCancel context.CancelFunc
+}
+
+func NewFaucetTestEnv(t *testing.T,
+	faucetBalance uint64,
+	wallet1Balance uint64,
+	wallet2Balance uint64,
+	wallet3Balance uint64,
+	faucetAmount uint64,
+	faucetSmallAmount uint64,
+	faucetMaxAddressBalance uint64,
+	assertSteps bool) *FaucetTestEnv {
+
+	genesisWallet := utils.NewHDWallet("Genesis", genesisSeed, 0)
+	faucetWallet := utils.NewHDWallet("Faucet", faucetSeed, 0)
+	seed1Wallet := utils.NewHDWallet("Seed1", seed1, 0)
+	seed2Wallet := utils.NewHDWallet("Seed2", seed2, 0)
+	seed3Wallet := utils.NewHDWallet("Seed3", seed3, 0)
+
+	genesisAddress := genesisWallet.Address()
+
+	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, BelowMaxDepth, MinPoWScore, false)
+
+	// Add token supply to our local HDWallet
+	genesisWallet.BookOutput(te.GenesisOutput)
+	if assertSteps {
+		te.AssertWalletBalance(genesisWallet, iotago.TokenSupply)
+	}
+
+	lastMessageID := te.Milestones[0].Milestone().MessageID
+	messagesCount := 0
+
+	// Fund Faucet
+	if faucetBalance > 0 {
+		messageA := te.NewMessageBuilder("A").
+			Parents(hornet.MessageIDs{lastMessageID, te.Milestones[1].Milestone().MessageID}).
+			FromWallet(genesisWallet).
+			ToWallet(faucetWallet).
+			Amount(faucetBalance).
+			Build().
+			Store().
+			BookOnWallets()
+
+		messagesCount++
+		lastMessageID = messageA.StoredMessageID()
+	}
+
+	// Fund Wallet1
+	if wallet1Balance > 0 {
+		messageB := te.NewMessageBuilder("B").
+			Parents(hornet.MessageIDs{lastMessageID, te.Milestones[1].Milestone().MessageID}).
+			FromWallet(genesisWallet).
+			ToWallet(seed1Wallet).
+			Amount(wallet1Balance).
+			Build().
+			Store().
+			BookOnWallets()
+
+		messagesCount++
+		lastMessageID = messageB.StoredMessageID()
+	}
+
+	// Fund Wallet2
+	if wallet2Balance > 0 {
+		messageC := te.NewMessageBuilder("C").
+			Parents(hornet.MessageIDs{lastMessageID, te.Milestones[1].Milestone().MessageID}).
+			FromWallet(genesisWallet).
+			ToWallet(seed2Wallet).
+			Amount(wallet2Balance).
+			Build().
+			Store().
+			BookOnWallets()
+
+		messagesCount++
+		lastMessageID = messageC.StoredMessageID()
+
+	}
+
+	// Fund Wallet3
+	if wallet3Balance > 0 {
+		messageD := te.NewMessageBuilder("D").
+			Parents(hornet.MessageIDs{lastMessageID, te.Milestones[1].Milestone().MessageID}).
+			FromWallet(genesisWallet).
+			ToWallet(seed3Wallet).
+			Amount(wallet3Balance).
+			Build().
+			Store().
+			BookOnWallets()
+
+		messagesCount++
+		lastMessageID = messageD.StoredMessageID()
+
+	}
+
+	// Confirming milestone at message D
+	_, confStats := te.IssueAndConfirmMilestoneOnTips(hornet.MessageIDs{lastMessageID}, false)
+	if assertSteps {
+
+		require.Equal(t, messagesCount+1, confStats.MessagesReferenced) // messagesCount + milestone itself
+		require.Equal(t, messagesCount, confStats.MessagesIncludedWithTransactions)
+		require.Equal(t, 0, confStats.MessagesExcludedWithConflictingTransactions)
+		require.Equal(t, 1, confStats.MessagesExcludedWithoutTransactions) // the milestone
+
+		// Verify balances
+		te.AssertWalletBalance(genesisWallet, iotago.TokenSupply-faucetBalance-wallet1Balance-wallet2Balance-wallet3Balance)
+		te.AssertWalletBalance(faucetWallet, faucetBalance)
+		te.AssertWalletBalance(seed1Wallet, wallet1Balance)
+		te.AssertWalletBalance(seed2Wallet, wallet2Balance)
+		te.AssertWalletBalance(seed3Wallet, wallet3Balance)
+	}
+
+	defaultDaemon := daemon.New()
+	defaultDaemon.Start()
+
+	var tipselFunc faucet.TipselFunc = func() (tips hornet.MessageIDs, err error) {
+		// issue all faucet messages on the latest milestone
+		return hornet.MessageIDs{te.LastMilestoneMessageID}, nil
+	}
+
+	storeMessageFunc := func(msg *storage.Message) error {
+		_ = te.StoreMessage(msg) // no need to release, since we remember all the messages for later cleanup
+		return nil
+	}
+
+	f := faucet.New(
+		defaultDaemon,
+		te.Storage(),
+		te.SyncManager(),
+		te.NetworkID(),
+		int(te.BelowMaxDepth()),
+		te.UTXOManager(),
+		faucetWallet.Address(),
+		faucetWallet.AddressSigner(),
+		tipselFunc,
+		te.PoWHandler,
+		storeMessageFunc,
+		faucet.WithHRPNetworkPrefix(iotago.PrefixTestnet),
+		faucet.WithAmount(faucetAmount),
+		faucet.WithSmallAmount(faucetSmallAmount),
+		faucet.WithMaxAddressBalance(faucetMaxAddressBalance),
+		faucet.WithMaxOutputCount(faucetMaxOutputCount),
+		faucet.WithIndexationMessage(faucetIndexationMessage),
+		faucet.WithBatchTimeout(faucetBatchTimeout),
+		faucet.WithPowWorkerCount(faucetPowWorkerCount),
+	)
+
+	faucetCtx, faucetCtxCancel := context.WithCancel(context.Background())
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		if err := f.RunFaucetLoop(faucetCtx, func() {
+			wg.Done()
+		}); err != nil && common.IsCriticalError(err) != nil {
+			require.NoError(t, err)
+		}
+	}()
+
+	// wait until faucet is initialized
+	wg.Wait()
+
+	// Connect the callbacks from the testsuite to the Faucet
+	te.ConfigureUTXOCallbacks(
+		nil,
+		nil,
+		func(confirmation *whiteflag.Confirmation) {
+			require.NoError(t, f.ApplyConfirmation(confirmation))
+		},
+		nil,
+	)
+
+	return &FaucetTestEnv{
+		t:               t,
+		TestEnv:         te,
+		GenesisWallet:   genesisWallet,
+		FaucetWallet:    faucetWallet,
+		Wallet1:         seed1Wallet,
+		Wallet2:         seed2Wallet,
+		Wallet3:         seed3Wallet,
+		Faucet:          f,
+		faucetCtxCancel: faucetCtxCancel,
+	}
+}
+
+func (env *FaucetTestEnv) ConfirmedMilestoneIndex() milestone.Index {
+	return env.TestEnv.SyncManager().ConfirmedMilestoneIndex()
+}
+
+func (env *FaucetTestEnv) Cleanup() {
+	if env.faucetCtxCancel != nil {
+		env.faucetCtxCancel()
+	}
+	env.TestEnv.CleanupTestEnvironment(true)
+}
+
+func (env *FaucetTestEnv) processFaucetRequests(preFlushFunc func() error) (hornet.MessageIDs, error) {
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	var tips hornet.MessageIDs
+	onFaucetIssuedMessage := events.NewClosure(func(messageID hornet.MessageID) {
+		tips = append(tips, messageID)
+		wg.Done()
+	})
+	env.Faucet.Events.IssuedMessage.Attach(onFaucetIssuedMessage)
+	defer env.Faucet.Events.IssuedMessage.Detach(onFaucetIssuedMessage)
+
+	if preFlushFunc != nil {
+		if err := preFlushFunc(); err != nil {
+			return nil, err
+		}
+	}
+
+	env.Faucet.FlushRequests()
+
+	chanDone := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(chanDone)
+	}()
+
+	select {
+	case <-chanDone:
+	case <-time.After(1 * time.Second):
+		env.t.Error("attachment of faucet message took too long")
+	}
+
+	return tips, nil
+}
+
+// RequestFunds sends requests to the faucet and waits until the next faucet message is issued.
+func (env *FaucetTestEnv) RequestFunds(wallets []*utils.HDWallet) (hornet.MessageIDs, error) {
+
+	tips, err := env.processFaucetRequests(func() error {
+		for _, wallet := range wallets {
+			if _, err := env.Faucet.Enqueue(wallet.Address().Bech32(iotago.PrefixTestnet)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return tips, nil
+}
+
+// RequestFundsAndIssueMilestone sends requests to the faucet, waits until the next faucet message is issued and
+// issues a milestone on top of it.
+func (env *FaucetTestEnv) RequestFundsAndIssueMilestone(wallets []*utils.HDWallet) error {
+
+	tips, err := env.RequestFunds(wallets)
+	if err != nil {
+		return err
+	}
+
+	// issue milestone on top of new faucet message
+	_, _ = env.IssueMilestone(tips...)
+	return nil
+}
+
+// FlushRequestsAndConfirmNewFaucetMessage flushes pending faucet requests, waits until the next faucet message is issued and
+// issues a milestone on top of it.
+func (env *FaucetTestEnv) FlushRequestsAndConfirmNewFaucetMessage() error {
+
+	tips, err := env.processFaucetRequests(nil)
+	if err != nil {
+		return err
+	}
+
+	// issue milestone on top of new faucet message
+	_, _ = env.IssueMilestone(tips...)
+	return nil
+}
+
+func (env *FaucetTestEnv) IssueMilestone(onTips ...hornet.MessageID) (*whiteflag.Confirmation, *whiteflag.ConfirmedMilestoneStats) {
+	if len(onTips) == 0 {
+		return env.TestEnv.IssueAndConfirmMilestoneOnTips(hornet.MessageIDs{env.TestEnv.LastMilestoneMessageID}, false)
+	}
+	return env.TestEnv.IssueAndConfirmMilestoneOnTips(onTips, false)
+}
+
+func (env *FaucetTestEnv) AssertFaucetBalance(expected uint64) {
+	faucetInfo, err := env.Faucet.Info()
+	require.NoError(env.t, err)
+	require.Equal(env.t, expected, faucetInfo.Balance)
+}
+
+func (env *FaucetTestEnv) AssertAddressUTXOCount(address iotago.Address, expected int) {
+	utxoCount := 0
+	env.TestEnv.UTXOManager().ForEachUnspentOutput(func(output *utxo.Output) bool {
+		utxoCount++
+		return true
+	}, utxo.FilterAddress(address))
+	require.Equal(env.t, utxoCount, expected)
+}

--- a/pkg/model/faucet/test/testenv_test.go
+++ b/pkg/model/faucet/test/testenv_test.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFaucetTestEnv verifies that our FaucetTestEnv is sane. This allows us to skip the assertions on the other tests to speed them up
+func TestFaucetTestEnv(t *testing.T) {
+
+	randomBalance := func() uint64 {
+		return uint64(rand.Intn(256)) * 1_000_000
+	}
+
+	env := NewFaucetTestEnv(t,
+		randomBalance(), // faucetBalance
+		randomBalance(), // wallet1Balance
+		randomBalance(), // wallet2Balance
+		randomBalance(), // wallet3Balance
+		10000000,        // faucetAmount:				10 Mi
+		1000000,         // faucetSmallAmount: 		 	 1 Mi
+		20000000,        // faucetMaxAddressBalance:	20 Mi
+		true)
+	defer env.Cleanup()
+	require.NotNil(t, env)
+}

--- a/pkg/model/faucet/test/testenv_test.go
+++ b/pkg/model/faucet/test/testenv_test.go
@@ -19,9 +19,9 @@ func TestFaucetTestEnv(t *testing.T) {
 		randomBalance(), // wallet1Balance
 		randomBalance(), // wallet2Balance
 		randomBalance(), // wallet3Balance
-		10000000,        // faucetAmount:				10 Mi
-		1000000,         // faucetSmallAmount: 		 	 1 Mi
-		20000000,        // faucetMaxAddressBalance:	20 Mi
+		10_000_000,      // faucetAmount:				10 Mi
+		1_000_000,       // faucetSmallAmount: 		 	 1 Mi
+		20_000_000,      // faucetMaxAddressBalance:	20 Mi
 		true)
 	defer env.Cleanup()
 	require.NotNil(t, env)

--- a/pkg/model/participation/test/testenv.go
+++ b/pkg/model/participation/test/testenv.go
@@ -65,7 +65,7 @@ func NewParticipationTestEnv(t *testing.T, wallet1Balance uint64, wallet2Balance
 	//Add token supply to our local HDWallet
 	genesisWallet.BookOutput(te.GenesisOutput)
 	if assertSteps {
-		te.AssertWalletBalance(genesisWallet, 2_779_530_283_277_761)
+		te.AssertWalletBalance(genesisWallet, iotago.TokenSupply)
 	}
 
 	// Fund Wallet1
@@ -117,8 +117,8 @@ func NewParticipationTestEnv(t *testing.T, wallet1Balance uint64, wallet2Balance
 		require.Equal(t, 0, confStats.MessagesExcludedWithConflictingTransactions)
 		require.Equal(t, 1, confStats.MessagesExcludedWithoutTransactions) // the milestone
 
-		//Verify balances
-		te.AssertWalletBalance(genesisWallet, 2_779_530_283_277_761-wallet1Balance-wallet2Balance-wallet3Balance-wallet4Balance)
+		// Verify balances
+		te.AssertWalletBalance(genesisWallet, iotago.TokenSupply-wallet1Balance-wallet2Balance-wallet3Balance-wallet4Balance)
 		te.AssertWalletBalance(seed1Wallet, wallet1Balance)
 		te.AssertWalletBalance(seed2Wallet, wallet2Balance)
 		te.AssertWalletBalance(seed3Wallet, wallet3Balance)
@@ -143,6 +143,7 @@ func NewParticipationTestEnv(t *testing.T, wallet1Balance uint64, wallet2Balance
 		func(index milestone.Index, spent *utxo.Spent) {
 			require.NoError(t, pm.ApplySpentUTXO(index, spent))
 		},
+		nil,
 		func(index milestone.Index) {
 			require.NoError(t, pm.ApplyNewConfirmedMilestoneIndex(index))
 		},

--- a/pkg/model/syncmanager/sync_manager.go
+++ b/pkg/model/syncmanager/sync_manager.go
@@ -15,7 +15,9 @@ const (
 )
 
 type SyncManager struct {
-	utxoManager   *utxo.Manager
+	utxoManager *utxo.Manager
+	// belowMaxDepth is the maximum allowed delta
+	// value between OCRI of a given message in relation to the current CMI before it gets lazy.
 	belowMaxDepth milestone.Index
 
 	// milestones

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -132,8 +132,11 @@ func (te *TestEnvironment) IssueAndConfirmMilestoneOnTips(tips hornet.MessageIDs
 			wfConf = confirmation
 			err = te.syncManager.SetConfirmedMilestoneIndex(confirmation.MilestoneIndex, true)
 			require.NoError(te.TestInterface, err)
-			if te.OnNewConfirmedMilestone != nil {
-				te.OnNewConfirmedMilestone(confirmation.MilestoneIndex)
+			if te.OnMilestoneConfirmed != nil {
+				te.OnMilestoneConfirmed(confirmation)
+			}
+			if te.OnConfirmedMilestoneIndexChanged != nil {
+				te.OnConfirmedMilestoneIndexChanged(confirmation.MilestoneIndex)
 			}
 		},
 		func(index milestone.Index, output *utxo.Output) {

--- a/pkg/testsuite/tangle.go
+++ b/pkg/testsuite/tangle.go
@@ -49,6 +49,24 @@ func (te *TestEnvironment) VerifyLMI(index milestone.Index) {
 	require.Equal(te.TestInterface, index, lmi)
 }
 
+// AssertLedgerBalance generates an address for the given seed and index and checks correct balance.
+func (te *TestEnvironment) AssertLedgerBalance(wallet *utils.HDWallet, expectedBalance uint64) {
+	addrBalance, _, _, err := te.storage.UTXOManager().AddressBalance(wallet.Address())
+	require.NoError(te.TestInterface, err)
+	computedAddrBalance, _, err := te.storage.UTXOManager().ComputeBalance(utxo.FilterAddress(wallet.Address()))
+	require.NoError(te.TestInterface, err)
+
+	var balanceStatus string
+	balanceStatus += fmt.Sprintf("Balance for %s:\n", wallet.Name())
+	balanceStatus += fmt.Sprintf("\tLedger:\t\t%d\n", computedAddrBalance)
+	balanceStatus += fmt.Sprintf("\tComputed:\t%d\n", computedAddrBalance)
+	balanceStatus += fmt.Sprintf("\tExpected:\t%d\n", expectedBalance)
+	fmt.Print(balanceStatus)
+
+	require.Exactly(te.TestInterface, expectedBalance, addrBalance)
+	require.Exactly(te.TestInterface, expectedBalance, computedAddrBalance)
+}
+
 // AssertWalletBalance generates an address for the given seed and index and checks correct balance.
 func (te *TestEnvironment) AssertWalletBalance(wallet *utils.HDWallet, expectedBalance uint64) {
 	addrBalance, _, _, err := te.storage.UTXOManager().AddressBalance(wallet.Address())

--- a/pkg/testsuite/utils/hdwallet.go
+++ b/pkg/testsuite/utils/hdwallet.go
@@ -87,6 +87,12 @@ func (hd *HDWallet) KeyPair() (ed25519.PrivateKey, ed25519.PublicKey) {
 	return ed25519.PrivateKey(privKey), ed25519.PublicKey(pubKey)
 }
 
+func (hd *HDWallet) AddressSigner() iotago.AddressSigner {
+	privKey, pubKey := hd.KeyPair()
+	address := iotago.AddressFromEd25519PubKey(pubKey)
+	return iotago.NewInMemoryAddressSigner(iotago.NewAddressKeysForEd25519Address(&address, privKey))
+}
+
 func (hd *HDWallet) Outputs() []*utxo.Output {
 	return hd.utxo
 }

--- a/pkg/toolset/benchmark.go
+++ b/pkg/toolset/benchmark.go
@@ -30,11 +30,11 @@ func benchmarkIO(_ *configuration.Configuration, args []string) error {
 
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [COUNT] [SIZE] [DB_ENGINE]", ToolBenchmarkIO))
+		println(fmt.Sprintf("   %s [COUNT] [SIZE] [DB_ENGINE]", ToolBenchmarkIO))
 		println()
-		println("	[COUNT] 	- objects count (optional)")
-		println("	[SIZE]  	- objects size  (optional)")
-		println("	[DB_ENGINE] - database engine (optional, values: pebble, rocksdb)")
+		println("   [COUNT]     - objects count (optional)")
+		println("   [SIZE]      - objects size  (optional)")
+		println("   [DB_ENGINE] - database engine (optional, values: pebble, rocksdb)")
 		println()
 		println(fmt.Sprintf("example: %s %d %d %s", ToolBenchmarkIO, 500000, 1000, "rocksdb"))
 	}
@@ -133,9 +133,9 @@ func benchmarkIO(_ *configuration.Configuration, args []string) error {
 func benchmarkCPU(_ *configuration.Configuration, args []string) error {
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [THREADS]", ToolBenchmarkCPU))
+		println(fmt.Sprintf("   %s [THREADS]", ToolBenchmarkCPU))
 		println()
-		println("	[THREADS]  	- thread count (optional)")
+		println("   [THREADS] - thread count (optional)")
 		println()
 		println(fmt.Sprintf("example: %s %d", ToolBenchmarkCPU, 2))
 	}

--- a/pkg/toolset/coordinator_fix_state.go
+++ b/pkg/toolset/coordinator_fix_state.go
@@ -18,7 +18,7 @@ import (
 func coordinatorFixStateFile(_ *configuration.Configuration, args []string) error {
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [DATABASE_PATH] [COO_STATE_FILE_PATH]", ToolCoordinatorFixStateFile))
+		println(fmt.Sprintf("   %s [DATABASE_PATH] [COO_STATE_FILE_PATH]", ToolCoordinatorFixStateFile))
 		println()
 		println("   [DATABASE_PATH]       - the path to the database")
 		println("   [COO_STATE_FILE_PATH] - the path to the coordinator state file")

--- a/pkg/toolset/database_hash.go
+++ b/pkg/toolset/database_hash.go
@@ -171,7 +171,7 @@ func calculateDatabaseLedgerHash(dbStorage *storage.Storage) error {
 func databaseLedgerHash(_ *configuration.Configuration, args []string) error {
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [DATABASE_PATH]", ToolDatabaseLedgerHash))
+		println(fmt.Sprintf("   %s [DATABASE_PATH]", ToolDatabaseLedgerHash))
 		println()
 		println("   [DATABASE_PATH] - the path to the database")
 		println()

--- a/pkg/toolset/database_migration.go
+++ b/pkg/toolset/database_migration.go
@@ -18,7 +18,7 @@ import (
 func databaseMigration(_ *configuration.Configuration, args []string) error {
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [SOURCE_DATABASE_PATH] [TARGET_DATABASE_PATH] [TARGET_DATABASE_ENGINE]", ToolDatabaseMigration))
+		println(fmt.Sprintf("   %s [SOURCE_DATABASE_PATH] [TARGET_DATABASE_PATH] [TARGET_DATABASE_ENGINE]", ToolDatabaseMigration))
 		println()
 		println("   [SOURCE_DATABASE_PATH]   - the path to the source database")
 		println("   [TARGET_DATABASE_PATH]   - the path to the target database")

--- a/pkg/toolset/p2p_identity_extract.go
+++ b/pkg/toolset/p2p_identity_extract.go
@@ -18,9 +18,9 @@ import (
 func extractP2PIdentity(nodeConfig *configuration.Configuration, args []string) error {
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [P2P_DATABASE_PATH]", ToolP2PExtractIdentity))
+		println(fmt.Sprintf("   %s [P2P_DATABASE_PATH]", ToolP2PExtractIdentity))
 		println()
-		println("	[P2P_DATABASE_PATH] - the path to the p2p database folder (optional)")
+		println("   [P2P_DATABASE_PATH] - the path to the p2p database folder (optional)")
 		println()
 		println(fmt.Sprintf("example: %s %s", ToolP2PExtractIdentity, "p2pstore"))
 	}

--- a/pkg/toolset/p2p_identity_gen.go
+++ b/pkg/toolset/p2p_identity_gen.go
@@ -21,10 +21,10 @@ func generateP2PIdentity(nodeConfig *configuration.Configuration, args []string)
 
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [P2P_DATABASE_PATH] [P2P_PRIVATE_KEY]", ToolP2PIdentityGen))
+		println(fmt.Sprintf("   %s [P2P_DATABASE_PATH] [P2P_PRIVATE_KEY]", ToolP2PIdentityGen))
 		println()
-		println("	[P2P_DATABASE_PATH] - the path to the p2p database folder (optional)")
-		println("	[P2P_PRIVATE_KEY]   - the p2p private key (optional)")
+		println("   [P2P_DATABASE_PATH] - the path to the p2p database folder (optional)")
+		println("   [P2P_PRIVATE_KEY]   - the p2p private key (optional)")
 		println()
 		println(fmt.Sprintf("example: %s %s", ToolP2PIdentityGen, "p2pstore"))
 	}

--- a/pkg/toolset/snap_gen.go
+++ b/pkg/toolset/snap_gen.go
@@ -21,12 +21,12 @@ func snapshotGen(_ *configuration.Configuration, args []string) error {
 
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [NETWORK_ID_STR] [MINT_ADDRESS] [TREASURY_ALLOCATION] [OUTPUT_FILE_PATH]", ToolSnapGen))
+		println(fmt.Sprintf("   %s [NETWORK_ID_STR] [MINT_ADDRESS] [TREASURY_ALLOCATION] [OUTPUT_FILE_PATH]", ToolSnapGen))
 		println()
-		println("	[NETWORK_ID_STR]		- the network ID for which this snapshot is meant for")
-		println("	[MINT_ADDRESS]			- the initial ed25519 address all the tokens will be minted to")
-		println("	[TREASURY_ALLOCATION]	- the amount of tokens to reside within the treasury, the delta from the supply will be allocated to MINT_ADDRESS")
-		println("	[OUTPUT_FILE_PATH]		- the file path to the generated snapshot file")
+		println("   [NETWORK_ID_STR]      - the network ID for which this snapshot is meant for")
+		println("   [MINT_ADDRESS]        - the initial ed25519 address all the tokens will be minted to")
+		println("   [TREASURY_ALLOCATION] - the amount of tokens to reside within the treasury, the delta from the supply will be allocated to MINT_ADDRESS")
+		println("   [OUTPUT_FILE_PATH]    - the file path to the generated snapshot file")
 		println()
 		println(fmt.Sprintf("example: %s %s %s %s %s", ToolSnapGen, "private_tangle@1", "6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92", "500000000", "snapshots/private_tangle/full_snapshot.bin"))
 	}

--- a/pkg/toolset/snap_hash.go
+++ b/pkg/toolset/snap_hash.go
@@ -19,10 +19,10 @@ import (
 func snapshotHash(_ *configuration.Configuration, args []string) error {
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [FULL_SNAPSHOT_PATH] [DELTA_SNAPSHOT_PATH]", ToolSnapHash))
+		println(fmt.Sprintf("   %s [FULL_SNAPSHOT_PATH] [DELTA_SNAPSHOT_PATH]", ToolSnapHash))
 		println()
-		println("	[FULL_SNAPSHOT_PATH]  - the path to the full snapshot file")
-		println("	[DELTA_SNAPSHOT_PATH] - the path to the delta snapshot file (optional)")
+		println("   [FULL_SNAPSHOT_PATH]  - the path to the full snapshot file")
+		println("   [DELTA_SNAPSHOT_PATH] - the path to the delta snapshot file (optional)")
 		println()
 		println(fmt.Sprintf("example: %s %s", ToolSnapHash, "./snapshot.bin"))
 	}

--- a/pkg/toolset/snap_info.go
+++ b/pkg/toolset/snap_info.go
@@ -10,9 +10,9 @@ import (
 func snapshotInfo(_ *configuration.Configuration, args []string) error {
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [SNAPSHOT_PATH]", ToolSnapInfo))
+		println(fmt.Sprintf("   %s [SNAPSHOT_PATH]", ToolSnapInfo))
 		println()
-		println("	[SNAPSHOT_PATH] - the path to the snapshot file")
+		println("   [SNAPSHOT_PATH] - the path to the snapshot file")
 		println()
 		println(fmt.Sprintf("example: %s %s", ToolSnapInfo, "./snapshot.bin"))
 	}

--- a/pkg/toolset/snap_merge.go
+++ b/pkg/toolset/snap_merge.go
@@ -13,11 +13,11 @@ func snapshotMerge(_ *configuration.Configuration, args []string) error {
 
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [FULL_SNAPSHOT_PATH] [DELTA_SNAPSHOT_PATH] [TARGET_SNAPSHOT_PATH]", ToolSnapMerge))
+		println(fmt.Sprintf("   %s [FULL_SNAPSHOT_PATH] [DELTA_SNAPSHOT_PATH] [TARGET_SNAPSHOT_PATH]", ToolSnapMerge))
 		println()
-		println("	[FULL_SNAPSHOT_PATH]	- the path to the full snapshot file")
-		println("	[DELTA_SNAPSHOT_PATH]	- the path to the delta snapshot file")
-		println("	[TARGET_SNAPSHOT_PATH]	- the path to the target/merged snapshot file")
+		println("   [FULL_SNAPSHOT_PATH]   - the path to the full snapshot file")
+		println("   [DELTA_SNAPSHOT_PATH]  - the path to the delta snapshot file")
+		println("   [TARGET_SNAPSHOT_PATH] - the path to the target/merged snapshot file")
 		println()
 		println(fmt.Sprintf("example: %s %s %s %s", ToolSnapMerge, "./full_snapshot.bin", "./delta_snapshot.bin", "./merged_snapshot.bin"))
 	}

--- a/pkg/whiteflag/test/white_flag_test.go
+++ b/pkg/whiteflag/test/white_flag_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/testsuite"
 	"github.com/gohornet/hornet/pkg/testsuite/utils"
+	iotago "github.com/iotaledger/iota.go/v2"
 )
 
 var (
@@ -37,7 +38,7 @@ func TestWhiteFlagSendAllCoins(t *testing.T) {
 
 	//Add token supply to our local HDWallet
 	seed1Wallet.BookOutput(te.GenesisOutput)
-	te.AssertWalletBalance(seed1Wallet, 2_779_530_283_277_761)
+	te.AssertWalletBalance(seed1Wallet, iotago.TokenSupply)
 
 	seed1Wallet.PrintStatus()
 	seed2Wallet.PrintStatus()
@@ -47,7 +48,7 @@ func TestWhiteFlagSendAllCoins(t *testing.T) {
 		Parents(hornet.MessageIDs{te.Milestones[0].Milestone().MessageID, te.Milestones[1].Milestone().MessageID}).
 		FromWallet(seed1Wallet).
 		ToWallet(seed2Wallet).
-		Amount(2_779_530_283_277_761).
+		Amount(iotago.TokenSupply).
 		Build().
 		Store().
 		BookOnWallets()
@@ -64,14 +65,14 @@ func TestWhiteFlagSendAllCoins(t *testing.T) {
 
 	// Verify balances
 	te.AssertWalletBalance(seed1Wallet, 0)
-	te.AssertWalletBalance(seed2Wallet, 2_779_530_283_277_761)
+	te.AssertWalletBalance(seed2Wallet, iotago.TokenSupply)
 
 	// Issue some transactions
 	messageB := te.NewMessageBuilder("B").
 		Parents(hornet.MessageIDs{messageA.StoredMessageID(), te.Milestones[2].Milestone().MessageID}).
 		FromWallet(seed2Wallet).
 		ToWallet(seed1Wallet).
-		Amount(2_779_530_283_277_761).
+		Amount(iotago.TokenSupply).
 		Build().
 		Store().
 		BookOnWallets()
@@ -84,7 +85,7 @@ func TestWhiteFlagSendAllCoins(t *testing.T) {
 	require.Equal(t, 1, confStats.MessagesExcludedWithoutTransactions) // the milestone
 
 	// Verify balances
-	te.AssertWalletBalance(seed1Wallet, 2_779_530_283_277_761)
+	te.AssertWalletBalance(seed1Wallet, iotago.TokenSupply)
 	te.AssertWalletBalance(seed2Wallet, 0)
 }
 
@@ -102,13 +103,13 @@ func TestWhiteFlagWithMultipleConflicting(t *testing.T) {
 
 	//Add token supply to our local HDWallet
 	seed1Wallet.BookOutput(te.GenesisOutput)
-	te.AssertWalletBalance(seed1Wallet, 2_779_530_283_277_761)
+	te.AssertWalletBalance(seed1Wallet, iotago.TokenSupply)
 
 	seed1Wallet.PrintStatus()
 	seed2Wallet.PrintStatus()
 
 	// Issue some transactions
-	// Valid transfer from seed1 (2_779_530_283_277_761) with remainder seed1 (2_779_530_282_277_761) to seed2 (1_000_000)
+	// Valid transfer from seed1 (iotago.TokenSupply) with remainder seed1 (2_779_530_282_277_761) to seed2 (1_000_000)
 	messageA := te.NewMessageBuilder("A").
 		Parents(hornet.MessageIDs{te.Milestones[0].Milestone().MessageID, te.Milestones[1].Milestone().MessageID}).
 		FromWallet(seed1Wallet).
@@ -445,7 +446,7 @@ func TestWhiteFlagDustAllowanceWithLotsOfDust(t *testing.T) {
 	seed2Wallet.PrintStatus()
 
 	// Issue some transactions
-	// Valid transfer from seed1 (2_779_530_283_277_761) to seed2 (1_000_000)
+	// Valid transfer from seed1 (iotago.TokenSupply) to seed2 (1_000_000)
 	messageA := te.NewMessageBuilder("A").
 		Parents(hornet.MessageIDs{te.Milestones[0].Milestone().MessageID, te.Milestones[1].Milestone().MessageID}).
 		FromWallet(seed1Wallet).

--- a/plugins/faucet/faucet.go
+++ b/plugins/faucet/faucet.go
@@ -6,27 +6,7 @@ import (
 
 	"github.com/gohornet/hornet/pkg/model/faucet"
 	"github.com/gohornet/hornet/pkg/restapi"
-	iotago "github.com/iotaledger/iota.go/v2"
 )
-
-func parseBech32Address(addressParam string) (*iotago.Ed25519Address, error) {
-
-	hrp, bech32Address, err := iotago.ParseBech32(addressParam)
-	if err != nil {
-		return nil, errors.WithMessage(restapi.ErrInvalidParameter, "Invalid bech32 address provided!")
-	}
-
-	if hrp != deps.Faucet.NetworkPrefix() {
-		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "Invalid bech32 address provided! Address does not start with \"%s\".", deps.Faucet.NetworkPrefix())
-	}
-
-	switch address := bech32Address.(type) {
-	case *iotago.Ed25519Address:
-		return address, nil
-	default:
-		return nil, errors.WithMessage(restapi.ErrInvalidParameter, "Invalid bech32 address provided! Unknown address type.")
-	}
-}
 
 func getFaucetInfo(_ echo.Context) (*faucet.FaucetInfoResponse, error) {
 	return deps.Faucet.Info()
@@ -39,13 +19,7 @@ func addFaucetOutputToQueue(c echo.Context) (*faucet.FaucetEnqueueResponse, erro
 		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "Invalid Request! Error: %s", err)
 	}
 
-	bech32Addr := request.Address
-	ed25519Addr, err := parseBech32Address(bech32Addr)
-	if err != nil {
-		return nil, err
-	}
-
-	response, err := deps.Faucet.Enqueue(bech32Addr, ed25519Addr)
+	response, err := deps.Faucet.Enqueue(request.Address)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/participation-cli/main.go
+++ b/tools/participation-cli/main.go
@@ -200,11 +200,11 @@ func parseCfgFromArgs() (*cfg, error) {
 
 	printUsage := func() {
 		println("Usage:")
-		println(fmt.Sprintf("	%s [NODE_API_ADDRESS] [SENDER_PRIVATE_KEY] [PAYLOAD_FILE_PATH]", cmd))
+		println(fmt.Sprintf("   %s [NODE_API_ADDRESS] [SENDER_PRIVATE_KEY] [PAYLOAD_FILE_PATH]", cmd))
 		println()
-		println("	[NODE_API_ADDRESS]   - the API address of the node to use")
-		println("	[SENDER_PRIVATE_KEY] - the private key of the sender")
-		println("	[PAYLOAD_FILE_PATH]  - path of the participation payload json file to send")
+		println("   [NODE_API_ADDRESS]   - the API address of the node to use")
+		println("   [SENDER_PRIVATE_KEY] - the private key of the sender")
+		println("   [PAYLOAD_FILE_PATH]  - path of the participation payload json file to send")
 		println()
 	}
 


### PR DESCRIPTION
This PR fixes the broken faucet logic.

The transaction chaining logic, which is used to guarantee high throughput of the faucet, deadlocked in some edge cases, resulting in permanent double spents.

The new logic is based on the milestone ApplyConfirmation event.