### PR TITLE
Fix link in README.md to actual wiki documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ _Table of contents_
 
 ## Documentation
 
-Hornet documentation can be found here: https://hornet.docs.iota.org/
+Hornet documentation can be found here: https://wiki.iota.org/hornet/welcome
 
 ## Contributing
 


### PR DESCRIPTION
# Description

The link in the README.md file is broken. According to the Discord channel, i modified the url pointing to the correct location.

## Type of change

- [x] Documentation Fix

# How Has This Been Tested?

Just click on the link :-)

# Checklist:

- [x] I have selected the `develop` branch as the target branch
