### PR TITLE
Fixes #1150: Make docker multi arch builds possible for other platforms.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 # https://hub.docker.com/_/golang
-# golang 1.17.3-bullseye amd64
-FROM golang@sha256:3b27ac95762ce1340a4824dc3cab2dc9d63f194f0899a0a9887402c1b1463f41 AS build
+FROM golang:1.17.3-bullseye AS build
 
 ARG BUILD_TAGS=builtin_static,rocksdb
 
@@ -29,7 +28,7 @@ RUN go mod verify
 COPY . .
 
 # Build the binary
-RUN GOOS=linux GOARCH=amd64 go build \
+RUN go build \
       -tags="$BUILD_TAGS" \
       -ldflags='-w -s' -a \
       -o /go/bin/hornet
@@ -39,8 +38,7 @@ RUN GOOS=linux GOARCH=amd64 go build \
 ############################
 # https://console.cloud.google.com/gcr/images/distroless/global/cc-debian11
 # using distroless cc "nonroot" image, which includes everything in the base image (glibc, libssl and openssl)
-# gcr.io/distroless/cc-debian11:nonroot-amd64
-FROM gcr.io/distroless/cc-debian11@sha256:5d5ec54878d2b9db248c4ef302af44e784afa169eb831269f7f332bcf5021516
+FROM gcr.io/distroless/cc-debian11:nonroot
 
 EXPOSE 15600/tcp
 EXPOSE 14626/udp


### PR DESCRIPTION
# Description

This PR makes it possible to create multi arch docker files for docker hub. It also allows creating docker container on other platforms without changing the Dockerfile.

I created a multiarch hornet docker image and pushed it to dockerhub for testing purposes. You can find more informations at https://docs.docker.com/desktop/multi-arch/

Fixes #1150 

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

You can use following commands to generate a multi arch image on your preferred platform and push it to docker hub. Please change the docker tag.

```
docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
docker buildx create --name mybuilder
docker buildx use mybuilder
docker buildx inspect --bootstrap
docker login -u *** -p ***
docker buildx build --platform linux/amd64,linux/arm64 -f docker/Dockerfile . -t legacycode/hornet --push
docker buildx imagetools inspect legacycode/hornet

Name:      docker.io/legacycode/hornet:latest
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:7f41d9f456caf8a2a73374c0fb18c0885d5c081995885325087867ad72205ec1

Manifests:
  Name:      docker.io/legacycode/hornet:latest@sha256:794f402333ba1edcb1b5eb56dddc109568ebc37f038d8055391f778c7554d36c
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64

  Name:      docker.io/legacycode/hornet:latest@sha256:a6df726e5cf4b4e11fadbc49fc8e741cfde7631963399391061eeccc46dba111
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64

```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
