### PR TITLE
Disable WebSocket compression

### DIFF
--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -129,9 +129,12 @@ func configure() {
 	}
 
 	upgrader = &websocket.Upgrader{
-		HandshakeTimeout:  webSocketWriteTimeout,
-		CheckOrigin:       func(r *http.Request) bool { return true }, // allow any origin for websocket connections
-		EnableCompression: true,
+		HandshakeTimeout: webSocketWriteTimeout,
+		CheckOrigin:      func(r *http.Request) bool { return true }, // allow any origin for websocket connections
+		// Disable compression due to incompatibilities with latest Safari browsers:
+		// https://github.com/tilt-dev/tilt/issues/4746
+		// https://github.com/gorilla/websocket/issues/731
+		EnableCompression: false,
 	}
 
 	hub = websockethub.NewHub(Plugin.Logger(), upgrader, broadcastQueueSize, clientSendChannelSize, maxWebsocketMessageSize)


### PR DESCRIPTION
Disable WebSocket compression due to incompatibilities between the latest Safari browsers and the gorilla WS implementation