### PR TITLE
Fix/mqtt memleak

### DIFF
--- a/config.json
+++ b/config.json
@@ -252,6 +252,7 @@
     "restAPIMetrics": true,
     "migrationMetrics": true,
     "coordinatorMetrics": true,
+    "mqttBrokerMetrics": true,
     "debugMetrics": false,
     "goMetrics": false,
     "processMetrics": false,

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -258,6 +258,7 @@
     "restAPIMetrics": true,
     "migrationMetrics": true,
     "coordinatorMetrics": true,
+    "mqttBrokerMetrics": true,
     "debugMetrics": false,
     "goMetrics": false,
     "processMetrics": false,

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -258,6 +258,7 @@
     "restAPIMetrics": true,
     "migrationMetrics": true,
     "coordinatorMetrics": true,
+    "mqttBrokerMetrics": true,
     "debugMetrics": false,
     "goMetrics": false,
     "processMetrics": false,

--- a/documentation/docs/post_installation/configuration.md
+++ b/documentation/docs/post_installation/configuration.md
@@ -29,21 +29,21 @@ hornet -h --full
 
 ## 1. REST API
 
-| Name                       | Description                                                                                      | Type             |
-| :------------------------- | :----------------------------------------------------------------------------------------------- | :--------------- |
-| bindAddress                | The bind address on which the REST API listens on                                                | string           |
-| [jwtAuth](#jwt-auth)       | Config for JWT auth                                                                              | object           |
-| publicRoutes               | the HTTP REST routes which can be called without authorization. Wildcards using * are allowed.   | array of strings |
-| protectedRoutes            | the HTTP REST routes which need to be called with authorization. Wildcards using * are allowed.  | array of strings |
-| powEnabled                 | Whether the node does PoW if messages are received via API                                       | bool             |
-| powWorkerCount             | The amount of workers used for calculating PoW when issuing messages via API                     | integer          |
-| [limits](#limits)          | Configuration for api limits                                                                     | object           |
+| Name                 | Description                                                                                     | Type             |
+| :------------------- | :---------------------------------------------------------------------------------------------- | :--------------- |
+| bindAddress          | The bind address on which the REST API listens on                                               | string           |
+| [jwtAuth](#jwt-auth) | Config for JWT auth                                                                             | object           |
+| publicRoutes         | the HTTP REST routes which can be called without authorization. Wildcards using * are allowed.  | array of strings |
+| protectedRoutes      | the HTTP REST routes which need to be called with authorization. Wildcards using * are allowed. | array of strings |
+| powEnabled           | Whether the node does PoW if messages are received via API                                      | bool             |
+| powWorkerCount       | The amount of workers used for calculating PoW when issuing messages via API                    | integer          |
+| [limits](#limits)    | Configuration for api limits                                                                    | object           |
 
 ### JWT Auth
 
-| Name    | Description                                                                                                                             | Type   |
-| :------ | :-------------------------------------------------------------------------------------------------------------------------------------- | :----- |
-| salt    | Salt used inside the JWT tokens for the REST API. Change this to a different value to invalidate JWT tokens not matching this new value | string |
+| Name | Description                                                                                                                             | Type   |
+| :--- | :-------------------------------------------------------------------------------------------------------------------------------------- | :----- |
+| salt | Salt used inside the JWT tokens for the REST API. Change this to a different value to invalidate JWT tokens not matching this new value | string |
 
 
 ### Limits
@@ -795,6 +795,7 @@ Example:
 | restAPIMetrics                                | Include restAPI metrics                                      | bool   |
 | migrationMetrics                              | Include migration metrics                                    | bool   |
 | coordinatorMetrics                            | Include coordinator metrics                                  | bool   |
+| mqttBrokerMetrics                             | Include MQTT broker metrics                                  | bool   |
 | debugMetrics                                  | Include debug metrics                                        | bool   |
 | goMetrics                                     | Include go metrics                                           | bool   |
 | processMetrics                                | Include process metrics                                      | bool   |
@@ -825,6 +826,7 @@ Example:
     "restAPIMetrics": true,
     "migrationMetrics": true,
     "coordinatorMetrics": true,
+    "mqttBrokerMetrics": true,
     "debugMetrics": false,
     "goMetrics": false,
     "processMetrics": false,

--- a/pkg/model/mselection/heaviest_test.go
+++ b/pkg/model/mselection/heaviest_test.go
@@ -146,7 +146,7 @@ func TestHeaviestSelector_SelectTipsChains(t *testing.T) {
 	assert.Len(t, hps.trackedMessages, 0)
 }
 
-func TestHeaviestSelector_SelectTipsCheckTresholds(t *testing.T) {
+func TestHeaviestSelector_SelectTipsCheckThresholds(t *testing.T) {
 	te, hps := initTest(t)
 	defer te.CleanupTestEnvironment(true)
 

--- a/pkg/mqtt/broker.go
+++ b/pkg/mqtt/broker.go
@@ -16,7 +16,7 @@ type Broker struct {
 }
 
 // NewBroker creates a new broker.
-func NewBroker(bindAddress string, wsPort int, wsPath string, workerCount int, onSubscribe OnSubscribeHandler, onUnsubscribe OnUnsubscribeHandler) (*Broker, error) {
+func NewBroker(bindAddress string, wsPort int, wsPath string, workerCount int, onSubscribe OnSubscribeHandler, onUnsubscribe OnUnsubscribeHandler, cleanupThreshold int) (*Broker, error) {
 
 	host, port, err := net.SplitHostPort(bindAddress)
 	if err != nil {
@@ -36,7 +36,7 @@ func NewBroker(bindAddress string, wsPort int, wsPath string, workerCount int, o
 		return nil, fmt.Errorf("configure broker config error: %w", err)
 	}
 
-	t := newTopicManager(onSubscribe, onUnsubscribe)
+	t := newTopicManager(onSubscribe, onUnsubscribe, cleanupThreshold)
 
 	b, err := broker.NewBroker(c)
 	if err != nil {
@@ -73,4 +73,9 @@ func (b *Broker) Send(topic string, payload []byte) {
 	packet.Payload = payload
 
 	b.broker.PublishMessage(packet)
+}
+
+// TopicsManagerSize returns the size of the underlying map of the topics manager.
+func (b *Broker) TopicsManagerSize() int {
+	return b.topicManager.Size()
 }

--- a/pkg/mqtt/topic_manager.go
+++ b/pkg/mqtt/topic_manager.go
@@ -15,8 +15,11 @@ type OnUnsubscribeHandler func(topic []byte)
 type topicManager struct {
 	mem topics.TopicsProvider
 
-	subscribedTopics     map[string]int
-	subscribedTopicsLock sync.RWMutex
+	subscribedTopics        map[string]int
+	subscribedTopicsLock    sync.RWMutex
+	subscribedTopicsDeleted int
+
+	cleanupThreshold int
 
 	onSubscribe   OnSubscribeHandler
 	onUnsubscribe OnUnsubscribeHandler
@@ -49,13 +52,13 @@ func (t *topicManager) Unsubscribe(topic []byte, subscriber interface{}) error {
 
 	err := t.mem.Unsubscribe(topic, subscriber)
 
-	//Ignore error here, always unsubscribe to be safe
+	// ignore error here, always unsubscribe to be safe
 
 	topicName := string(topic)
 	count, has := t.subscribedTopics[topicName]
 	if has {
 		if count <= 0 {
-			delete(t.subscribedTopics, topicName)
+			t.deleteTopic(topicName)
 		} else {
 			t.subscribedTopics[topicName] = count - 1
 		}
@@ -82,6 +85,14 @@ func (t *topicManager) Close() error {
 	return t.mem.Close()
 }
 
+// Size returns the size of the underlying map of the topics manager.
+func (t *topicManager) Size() int {
+	t.subscribedTopicsLock.RLock()
+	defer t.subscribedTopicsLock.RUnlock()
+
+	return len(t.subscribedTopics)
+}
+
 func (t *topicManager) hasSubscribers(topicName string) bool {
 	t.subscribedTopicsLock.RLock()
 	defer t.subscribedTopicsLock.RUnlock()
@@ -90,13 +101,35 @@ func (t *topicManager) hasSubscribers(topicName string) bool {
 	return has && count > 0
 }
 
-func newTopicManager(onSubscribe OnSubscribeHandler, onUnsubscribe OnUnsubscribeHandler) *topicManager {
+// cleanupWithoutLocking recreates the subscribedTopics map to release memory for the garbage collector.
+func (t *topicManager) cleanupWithoutLocking() {
+	subscribedTopics := make(map[string]int)
+	for topicName, count := range t.subscribedTopics {
+		subscribedTopics[topicName] = count
+	}
+	t.subscribedTopics = subscribedTopics
+	t.subscribedTopicsDeleted = 0
+}
+
+// deleteTopic deletes a topic from the manager.
+func (t *topicManager) deleteTopic(topicName string) {
+	delete(t.subscribedTopics, topicName)
+
+	// increase the deletion counter to trigger garbage collection
+	t.subscribedTopicsDeleted++
+	if t.cleanupThreshold != 0 && t.subscribedTopicsDeleted >= t.cleanupThreshold {
+		t.cleanupWithoutLocking()
+	}
+}
+
+func newTopicManager(onSubscribe OnSubscribeHandler, onUnsubscribe OnUnsubscribeHandler, cleanupThreshold int) *topicManager {
 
 	mgr := &topicManager{
 		mem:              topics.NewMemProvider(),
 		subscribedTopics: make(map[string]int),
 		onSubscribe:      onSubscribe,
 		onUnsubscribe:    onUnsubscribe,
+		cleanupThreshold: cleanupThreshold,
 	}
 
 	// The normal MQTT broker uses the `mem` topic manager internally, so first unregister the default one.

--- a/pkg/mqtt/topic_manager.go
+++ b/pkg/mqtt/topic_manager.go
@@ -57,7 +57,7 @@ func (t *topicManager) Unsubscribe(topic []byte, subscriber interface{}) error {
 	topicName := string(topic)
 	count, has := t.subscribedTopics[topicName]
 	if has {
-		if count <= 0 {
+		if count <= 1 {
 			t.deleteTopic(topicName)
 		} else {
 			t.subscribedTopics[topicName] = count - 1

--- a/pkg/protocol/gossip/service.go
+++ b/pkg/protocol/gossip/service.go
@@ -593,7 +593,7 @@ func (s *Service) registerLoggerOnEvents() {
 		s.LogInfof("canceled inbound protocol stream from %s: %s", remotePeer, reason)
 	}))
 	s.Events.Error.Attach(events.NewClosure(func(err error) {
-		s.LogError(err)
+		s.LogWarn(err)
 	}))
 }
 

--- a/plugins/mqtt/params.go
+++ b/plugins/mqtt/params.go
@@ -7,12 +7,14 @@ import (
 )
 
 const (
-	// the bind address on which the MQTT broker listens on
+	// the bind address on which the MQTT broker listens on.
 	CfgMQTTBindAddress = "mqtt.bindAddress"
-	// the port of the WebSocket MQTT broker
+	// the port of the WebSocket MQTT broker.
 	CfgMQTTWSPort = "mqtt.wsPort"
-	// the number of parallel workers the MQTT broker uses to publish messages
+	// the number of parallel workers the MQTT broker uses to publish messages.
 	CfgMQTTWorkerCount = "mqtt.workerCount"
+	// the number of deleted topics that trigger a garbage collection of the topic manager.
+	CfgMQTTTopicCleanupThreshold = "mqtt.topicCleanupThreshold"
 )
 
 var params = &node.PluginParams{
@@ -22,6 +24,7 @@ var params = &node.PluginParams{
 			fs.String(CfgMQTTBindAddress, "localhost:1883", "bind address on which the MQTT broker listens on")
 			fs.Int(CfgMQTTWSPort, 1888, "port of the WebSocket MQTT broker")
 			fs.Int(CfgMQTTWorkerCount, 100, "number of parallel workers the MQTT broker uses to publish messages")
+			fs.Int(CfgMQTTTopicCleanupThreshold, 10000, "number of deleted topics that trigger a garbage collection of the topic manager")
 			return fs
 		}(),
 	},

--- a/plugins/mqtt/plugin.go
+++ b/plugins/mqtt/plugin.go
@@ -31,6 +31,7 @@ func init() {
 			Name:      "MQTT",
 			DepsFunc:  func(cDeps dependencies) { deps = cDeps },
 			Params:    params,
+			Provide:   provide,
 			Configure: configure,
 			Run:       run,
 		},

--- a/plugins/prometheus/mqtt_broker.go
+++ b/plugins/prometheus/mqtt_broker.go
@@ -1,0 +1,28 @@
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	mqttBrokerTopicsManagerSize prometheus.Gauge
+)
+
+func configureMQTTBroker() {
+
+	mqttBrokerTopicsManagerSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "iota",
+			Subsystem: "mqtt_broker",
+			Name:      "topics_manager_size",
+			Help:      "Number of active topics in the topics manager.",
+		})
+
+	registry.MustRegister(mqttBrokerTopicsManagerSize)
+
+	addCollect(collectMQTTBroker)
+}
+
+func collectMQTTBroker() {
+	mqttBrokerTopicsManagerSize.Set(float64(deps.MQTTBroker.TopicsManagerSize()))
+}

--- a/plugins/prometheus/params.go
+++ b/plugins/prometheus/params.go
@@ -29,6 +29,8 @@ const (
 	CfgPrometheusMigration = "prometheus.migrationMetrics"
 	// include coordinator metrics.
 	CfgPrometheusCoordinator = "prometheus.coordinatorMetrics"
+	// include MQTT broker metrics.
+	CfgPrometheusMQTTBroker = "prometheus.mqttBrokerMetrics"
 	// include debug metrics.
 	CfgPrometheusDebug = "prometheus.debugMetrics"
 	// include go metrics.
@@ -54,6 +56,7 @@ var params = &node.PluginParams{
 			fs.Bool(CfgPrometheusRestAPI, true, "include restAPI metrics")
 			fs.Bool(CfgPrometheusMigration, true, "include migration metrics")
 			fs.Bool(CfgPrometheusCoordinator, true, "include coordinator metrics")
+			fs.Bool(CfgPrometheusMQTTBroker, true, "include MQTT broker metrics")
 			fs.Bool(CfgPrometheusDebug, false, "include debug metrics")
 			fs.Bool(CfgPrometheusGoMetrics, false, "include go metrics")
 			fs.Bool(CfgPrometheusProcessMetrics, false, "include process metrics")

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gohornet/hornet/pkg/model/migrator"
 	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/model/syncmanager"
+	"github.com/gohornet/hornet/pkg/mqtt"
 	"github.com/gohornet/hornet/pkg/node"
 	"github.com/gohornet/hornet/pkg/p2p"
 	"github.com/gohornet/hornet/pkg/protocol/gossip"
@@ -86,6 +87,7 @@ type dependencies struct {
 	TipSelector           *tipselect.TipSelector `optional:"true"`
 	SnapshotManager       *snapshot.SnapshotManager
 	Coordinator           *coordinator.Coordinator `optional:"true"`
+	MQTTBroker            *mqtt.Broker             `optional:"true"`
 }
 
 func configure() {
@@ -117,6 +119,9 @@ func configure() {
 	}
 	if deps.NodeConfig.Bool(CfgPrometheusCoordinator) && deps.Coordinator != nil {
 		configureCoordinator()
+	}
+	if deps.NodeConfig.Bool(CfgPrometheusMQTTBroker) && deps.MQTTBroker != nil {
+		configureMQTTBroker()
 	}
 	if deps.NodeConfig.Bool(CfgPrometheusDebug) {
 		configureDebug()

--- a/private_tangle/config_private_tangle.json
+++ b/private_tangle/config_private_tangle.json
@@ -246,6 +246,7 @@
     "restAPIMetrics": true,
     "migrationMetrics": true,
     "coordinatorMetrics": true,
+    "mqttBrokerMetrics": true,
     "debugMetrics": false,
     "goMetrics": false,
     "processMetrics": false,


### PR DESCRIPTION
This PR fixes a memleak caused by an off-by-one error at topic unsubscription in MQTT, and another one cause by a global map.

It also adds new prometheus metrics to track the size of the MQTT topics manager.