### PR TITLE
Fix broken Websocket for some users

### DIFF
--- a/documentation/docs/post_installation/configuration.md
+++ b/documentation/docs/post_installation/configuration.md
@@ -100,7 +100,7 @@ Example:
 | Name           | Description                                           | Type   |
 | :------------- | :---------------------------------------------------- | :----- |
 | sessionTimeout | How long the auth session should last before expiring | string |
-| username       | The auth username                                     | string |
+| username       | The auth username (max 25 chars)                      | string |
 | passwordHash   | The auth password+salt as a scrypt hash               | string |
 | passwordSalt   | The auth salt used for hashing the password           | string |
 

--- a/plugins/dashboard/params.go
+++ b/plugins/dashboard/params.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"fmt"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -23,6 +24,8 @@ const (
 	CfgDashboardAuthPasswordHash = "dashboard.auth.passwordHash"
 	// the auth salt used for hashing the password
 	CfgDashboardAuthPasswordSalt = "dashboard.auth.passwordSalt"
+
+	maxDashboardAuthUsernameSize = 25
 )
 
 var params = &node.PluginParams{
@@ -33,7 +36,7 @@ var params = &node.PluginParams{
 			fs.String(CfgDashboardBindAddress, "localhost:8081", "the bind address on which the dashboard can be accessed from")
 			fs.Bool(CfgDashboardDevMode, false, "whether to run the dashboard in dev mode")
 			fs.Duration(CfgDashboardAuthSessionTimeout, 72*time.Hour, "how long the auth session should last before expiring")
-			fs.String(CfgDashboardAuthUsername, "admin", "the auth username")
+			fs.String(CfgDashboardAuthUsername, "admin", fmt.Sprintf("the auth username (max %d chars)", maxDashboardAuthUsernameSize))
 			fs.String(CfgDashboardAuthPasswordHash, "0000000000000000000000000000000000000000000000000000000000000000", "the auth password+salt as a scrypt hash")
 			fs.String(CfgDashboardAuthPasswordSalt, "0000000000000000000000000000000000000000000000000000000000000000", "the auth salt used for hashing the password")
 			return fs


### PR DESCRIPTION
- Increase the maxWebsocketMessageSize to account for longer dashboard usernames.
- Introduces a max length of 25 chars for the dashboard username.

This fixes #1250