### PR TITLE
Fixed announce pre-releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -179,6 +179,7 @@ changelog:
   skip: true
 
 announce:
+  skip: "{{ if .Prerelease }}true{{ end }}"
   twitter:
     enabled: true
     message_template: "{{.ProjectName}}-{{.Version}} is out! Find all details at {{ .ReleaseURL }}! #IOTA #HORNET"


### PR DESCRIPTION
This PR will prevent GoReleaser from announcing pre-releases on Twitter.