### PR TITLE
Add support for mapdb (in-memory)

### DIFF
--- a/core/database/mapdb.go
+++ b/core/database/mapdb.go
@@ -1,0 +1,26 @@
+package database
+
+import (
+	"github.com/gohornet/hornet/pkg/database"
+	"github.com/gohornet/hornet/pkg/metrics"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/kvstore/mapdb"
+)
+
+func newMapDB(metrics *metrics.DatabaseMetrics) *database.Database {
+
+	events := &database.Events{
+		DatabaseCleanup:    events.NewEvent(database.DatabaseCleanupCaller),
+		DatabaseCompaction: events.NewEvent(events.BoolCaller),
+	}
+
+	return database.New(
+		"",
+		mapdb.NewMapDB(),
+		database.EngineMapDB,
+		metrics,
+		events,
+		false,
+		nil,
+	)
+}

--- a/core/database/params.go
+++ b/core/database/params.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	// the used database engine (pebble/rocksdb).
+	// the used database engine (pebble/rocksdb/mapdb).
 	CfgDatabaseEngine = "db.engine"
 	// the path to the database folder.
 	CfgDatabasePath = "db.path"
@@ -22,7 +22,7 @@ var params = &node.PluginParams{
 	Params: map[string]*flag.FlagSet{
 		"nodeConfig": func() *flag.FlagSet {
 			fs := flag.NewFlagSet("", flag.ContinueOnError)
-			fs.String(CfgDatabaseEngine, database.EngineRocksDB, "the used database engine (pebble/rocksdb)")
+			fs.String(CfgDatabaseEngine, string(database.EngineRocksDB), "the used database engine (pebble/rocksdb/mapdb)")
 			fs.String(CfgDatabasePath, "mainnetdb", "the path to the database folder")
 			fs.Bool(CfgDatabaseAutoRevalidation, false, "whether to automatically start revalidation on startup if the database is corrupted")
 			fs.Bool(CfgDatabaseDebug, false, "ignore the check for corrupted databases (should only be used for debug reasons)")

--- a/core/database/pebble.go
+++ b/core/database/pebble.go
@@ -30,6 +30,8 @@ func newPebble(path string, metrics *metrics.DatabaseMetrics) *database.Database
 	return database.New(
 		path,
 		pebble.New(db),
+		database.EnginePebble,
+		metrics,
 		events,
 		true,
 		func() bool {

--- a/core/database/rocksdb.go
+++ b/core/database/rocksdb.go
@@ -22,6 +22,8 @@ func newRocksDB(path string, metrics *metrics.DatabaseMetrics) *database.Databas
 	database := database.New(
 		path,
 		rocksdb.New(rocksDatabase),
+		database.EngineRocksDB,
+		metrics,
 		events,
 		true,
 		func() bool {

--- a/documentation/docs/post_installation/configuration.md
+++ b/documentation/docs/post_installation/configuration.md
@@ -123,7 +123,7 @@ Example:
 
 | Name             | Description                                                                         | Type   |
 | :--------------- | :---------------------------------------------------------------------------------- | :----- |
-| engine           | The used database engine (pebble/rocksdb)                                           | string |
+| engine           | The used database engine (pebble/rocksdb/mapdb)                                     | string |
 | path             | The path to the database folder                                                     | string |
 | autoRevalidation | Whether to automatically start revalidation on startup if the database is corrupted | bool   |
 

--- a/pkg/snapshot/snapshot_write.go
+++ b/pkg/snapshot/snapshot_write.go
@@ -660,7 +660,7 @@ func createSnapshotFromCurrentStorageState(dbStorage *storage.Storage, filePath 
 // applying the delta diffs onto it and then writing out the merged state.
 func MergeSnapshotsFiles(fullPath string, deltaPath string, targetFileName string) (*MergeInfo, error) {
 
-	targetEngine, err := database.DatabaseEngine(database.EnginePebble)
+	targetEngine, err := database.DatabaseEngine(string(database.EnginePebble))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/toolset/benchmark.go
+++ b/pkg/toolset/benchmark.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -25,7 +24,7 @@ func benchmarkIO(args []string) error {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	objectsCountFlag := fs.Int(FlagToolBenchmarkCount, 500000, "objects count")
 	objectsSizeFlag := fs.Int(FlagToolBenchmarkSize, 1000, "objects size in bytes")
-	databaseEngineFlag := fs.String(FlagToolDatabaseEngine, DefaultValueDatabaseEngine, "database engine (optional, values: pebble, rocksdb)")
+	databaseEngineFlag := fs.String(FlagToolDatabaseEngine, string(DefaultValueDatabaseEngine), "database engine (optional, values: pebble, rocksdb)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", ToolBenchmarkIO)
@@ -46,9 +45,8 @@ func benchmarkIO(args []string) error {
 
 	objectCnt := *objectsCountFlag
 	size := *objectsSizeFlag
-	dbEngine := strings.ToLower(*databaseEngineFlag)
 
-	engine, err := database.DatabaseEngine(dbEngine)
+	dbEngine, err := database.DatabaseEngine(*databaseEngineFlag, database.EnginePebble, database.EngineRocksDB)
 	if err != nil {
 		return err
 	}
@@ -60,7 +58,7 @@ func benchmarkIO(args []string) error {
 
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
-	store, err := database.StoreWithDefaultSettings(tempDir, true, engine)
+	store, err := database.StoreWithDefaultSettings(tempDir, true, dbEngine)
 	if err != nil {
 		return fmt.Errorf("database initialization failed: %w", err)
 	}

--- a/pkg/toolset/snap_hash.go
+++ b/pkg/toolset/snap_hash.go
@@ -44,7 +44,7 @@ func snapshotHash(args []string) error {
 	fullPath := *fullSnapshotPathFlag
 	deltaPath := *deltaSnapshotPathFlag
 
-	targetEngine, err := database.DatabaseEngine(database.EnginePebble)
+	targetEngine, err := database.DatabaseEngine(string(database.EnginePebble))
 	if err != nil {
 		return err
 	}

--- a/plugins/prometheus/database.go
+++ b/plugins/prometheus/database.go
@@ -71,11 +71,11 @@ func (m *storageMetrics) collect() {
 	}
 }
 
-func configureDatabase(name string, db *database.Database, metrics *metrics.DatabaseMetrics) {
+func configureDatabase(name string, db *database.Database) {
 
 	m := &databaseMetrics{
 		database:        db,
-		databaseMetrics: metrics,
+		databaseMetrics: db.Metrics(),
 	}
 
 	m.databaseSizeBytes = prometheus.NewGauge(

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -66,34 +66,32 @@ var (
 
 type dependencies struct {
 	dig.In
-	AppInfo               *app.AppInfo
-	NodeConfig            *configuration.Configuration `name:"nodeConfig"`
-	SyncManager           *syncmanager.SyncManager
-	ServerMetrics         *metrics.ServerMetrics
-	Storage               *storage.Storage
-	StorageMetrics        *metrics.StorageMetrics
-	TangleDatabase        *database.Database       `name:"tangleDatabase"`
-	TangleDatabaseMetrics *metrics.DatabaseMetrics `name:"tangleDatabaseMetrics"`
-	UTXODatabase          *database.Database       `name:"utxoDatabase"`
-	UTXODatabaseMetrics   *metrics.DatabaseMetrics `name:"utxoDatabaseMetrics"`
-	RestAPIMetrics        *metrics.RestAPIMetrics  `optional:"true"`
-	GossipService         *gossip.Service
-	ReceiptService        *migrator.ReceiptService `optional:"true"`
-	Tangle                *tangle.Tangle
-	MigratorService       *migrator.MigratorService `optional:"true"`
-	PeeringManager        *p2p.Manager
-	RequestQueue          gossip.RequestQueue
-	MessageProcessor      *gossip.MessageProcessor
-	TipSelector           *tipselect.TipSelector `optional:"true"`
-	SnapshotManager       *snapshot.SnapshotManager
-	Coordinator           *coordinator.Coordinator `optional:"true"`
-	MQTTBroker            *mqtt.Broker             `optional:"true"`
+	AppInfo          *app.AppInfo
+	NodeConfig       *configuration.Configuration `name:"nodeConfig"`
+	SyncManager      *syncmanager.SyncManager
+	ServerMetrics    *metrics.ServerMetrics
+	Storage          *storage.Storage
+	StorageMetrics   *metrics.StorageMetrics
+	TangleDatabase   *database.Database      `name:"tangleDatabase"`
+	UTXODatabase     *database.Database      `name:"utxoDatabase"`
+	RestAPIMetrics   *metrics.RestAPIMetrics `optional:"true"`
+	GossipService    *gossip.Service
+	ReceiptService   *migrator.ReceiptService `optional:"true"`
+	Tangle           *tangle.Tangle
+	MigratorService  *migrator.MigratorService `optional:"true"`
+	PeeringManager   *p2p.Manager
+	RequestQueue     gossip.RequestQueue
+	MessageProcessor *gossip.MessageProcessor
+	TipSelector      *tipselect.TipSelector `optional:"true"`
+	SnapshotManager  *snapshot.SnapshotManager
+	Coordinator      *coordinator.Coordinator `optional:"true"`
+	MQTTBroker       *mqtt.Broker             `optional:"true"`
 }
 
 func configure() {
 	if deps.NodeConfig.Bool(CfgPrometheusDatabase) {
-		configureDatabase(coreDatabase.TangleDatabaseDirectoryName, deps.TangleDatabase, deps.TangleDatabaseMetrics)
-		configureDatabase(coreDatabase.UTXODatabaseDirectoryName, deps.UTXODatabase, deps.UTXODatabaseMetrics)
+		configureDatabase(coreDatabase.TangleDatabaseDirectoryName, deps.TangleDatabase)
+		configureDatabase(coreDatabase.UTXODatabaseDirectoryName, deps.UTXODatabase)
 		configureStorage(deps.Storage, deps.StorageMetrics)
 	}
 	if deps.NodeConfig.Bool(CfgPrometheusNode) {


### PR DESCRIPTION
Node will run with an in-memory DB only.
Attention: All data is lost after shutdown of the node.

This can be used for integration-/cluster tests.