### PR TITLE
Added new outputs API endpoint

### DIFF
--- a/pkg/indexer/types.go
+++ b/pkg/indexer/types.go
@@ -54,7 +54,7 @@ func (q queryResults) IDs() iotago.OutputIDs {
 }
 
 func addressBytesForAddress(addr iotago.Address) (addressBytes, error) {
-	return addr.Serialize(serializer.DeSeriModeNoValidation, nil)
+	return addr.Serialize(serializer.DeSeriModeNoValidation, iotago.ZeroRentParas)
 }
 
 type IndexerResult struct {

--- a/pkg/model/storage/message.go
+++ b/pkg/model/storage/message.go
@@ -78,7 +78,7 @@ func (msg *Message) Message() *iotago.Message {
 	msg.messageOnce.Do(func() {
 		iotaMsg := &iotago.Message{}
 		// No need to verify the message again here
-		if _, err := iotaMsg.Deserialize(msg.data, serializer.DeSeriModeNoValidation, nil); err != nil {
+		if _, err := iotaMsg.Deserialize(msg.data, serializer.DeSeriModeNoValidation, iotago.ZeroRentParas); err != nil {
 			panic(fmt.Sprintf("failed to deserialize message: %v, error: %s", msg.messageID.ToHex(), err))
 		}
 

--- a/pkg/model/utxo/output.go
+++ b/pkg/model/utxo/output.go
@@ -203,6 +203,8 @@ func (u *Manager) ReadRawOutputBytesByOutputIDWithoutLocking(outputID *iotago.Ou
 	if err != nil {
 		return nil, err
 	}
+
+	// messageID + milestoneIndex + milestoneTimestamp
 	offset := iotago.MessageIDLength + serializer.UInt32ByteSize + serializer.UInt32ByteSize
 	if len(value) <= offset {
 		return nil, errors.New("invalid UTXO output length")

--- a/pkg/model/utxo/output.go
+++ b/pkg/model/utxo/output.go
@@ -163,7 +163,7 @@ func (o *Output) kvStorableLoad(_ *Manager, key []byte, value []byte) error {
 	if err != nil {
 		return err
 	}
-	_, err = o.output.Deserialize(valueUtil.ReadRemainingBytes(), serializer.DeSeriModeNoValidation, nil)
+	_, err = o.output.Deserialize(valueUtil.ReadRemainingBytes(), serializer.DeSeriModeNoValidation, iotago.ZeroRentParas)
 	if err != nil {
 		return err
 	}
@@ -195,6 +195,19 @@ func (u *Manager) ReadOutputByOutputIDWithoutLocking(outputID *iotago.OutputID) 
 		return nil, err
 	}
 	return output, nil
+}
+
+func (u *Manager) ReadRawOutputBytesByOutputIDWithoutLocking(outputID *iotago.OutputID) ([]byte, error) {
+	key := outputStorageKeyForOutputID(outputID)
+	value, err := u.utxoStorage.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	offset := iotago.MessageIDLength + serializer.UInt32ByteSize + serializer.UInt32ByteSize
+	if len(value) <= offset {
+		return nil, errors.New("invalid UTXO output length")
+	}
+	return value[offset:], nil
 }
 
 func (u *Manager) ReadOutputByOutputID(outputID *iotago.OutputID) (*Output, error) {

--- a/pkg/model/utxo/output.go
+++ b/pkg/model/utxo/output.go
@@ -111,7 +111,7 @@ func (o *Output) kvStorableValue() (value []byte) {
 	ms.WriteUint32(uint32(o.milestoneIndex)) // 4 bytes
 	ms.WriteUint32(o.milestoneTimestamp)     // 4 bytes
 
-	bytes, err := o.output.Serialize(serializer.DeSeriModeNoValidation, nil)
+	bytes, err := o.output.Serialize(serializer.DeSeriModeNoValidation, iotago.ZeroRentParas)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/model/utxo/output_test.go
+++ b/pkg/model/utxo/output_test.go
@@ -94,7 +94,7 @@ func AssertOutputUnspentAndSpentTransitions(t *testing.T, output *Output, spent 
 
 func CreateOutputAndAssertSerialization(t *testing.T, messageID hornet.MessageID, msIndex milestone.Index, msTimestamp uint64, outputID *iotago.OutputID, iotaOutput iotago.Output) *Output {
 	output := CreateOutput(outputID, messageID, msIndex, msTimestamp, iotaOutput)
-	outputBytes, err := output.Output().Serialize(serializer.DeSeriModeNoValidation, nil)
+	outputBytes, err := output.Output().Serialize(serializer.DeSeriModeNoValidation, iotago.ZeroRentParas)
 	require.NoError(t, err)
 
 	require.Equal(t, byteutils.ConcatBytes([]byte{UTXOStoreKeyPrefixOutput}, outputID[:]), output.kvStorableKey())

--- a/pkg/model/utxo/receipt.go
+++ b/pkg/model/utxo/receipt.go
@@ -29,7 +29,7 @@ func (rt *ReceiptTuple) kvStorableKey() (key []byte) {
 }
 
 func (rt *ReceiptTuple) kvStorableValue() (value []byte) {
-	receiptBytes, err := rt.Receipt.Serialize(serializer.DeSeriModeNoValidation, nil)
+	receiptBytes, err := rt.Receipt.Serialize(serializer.DeSeriModeNoValidation, iotago.ZeroRentParas)
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ func (rt *ReceiptTuple) kvStorableLoad(_ *Manager, key []byte, value []byte) err
 	}
 
 	r := &iotago.Receipt{}
-	if _, err := r.Deserialize(value, serializer.DeSeriModeNoValidation, nil); err != nil {
+	if _, err := r.Deserialize(value, serializer.DeSeriModeNoValidation, iotago.ZeroRentParas); err != nil {
 		return err
 	}
 

--- a/pkg/model/utxo/snapshot.go
+++ b/pkg/model/utxo/snapshot.go
@@ -21,7 +21,7 @@ func (o *Output) SnapshotBytes() []byte {
 	m.WriteUint32(uint32(o.milestoneIndex))
 	m.WriteUint32(o.milestoneTimestamp)
 
-	bytes, err := o.output.Serialize(serializer.DeSeriModeNoValidation, nil)
+	bytes, err := o.output.Serialize(serializer.DeSeriModeNoValidation, iotago.ZeroRentParas)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/pow/pow.go
+++ b/pkg/pow/pow.go
@@ -64,7 +64,7 @@ func (h *Handler) DoPoW(ctx context.Context, msg *iotago.Message, parallelism in
 	}
 
 	getPoWData := func(msg *iotago.Message) (powData []byte, err error) {
-		msgData, err := msg.Serialize(serializer.DeSeriModeNoValidation, nil)
+		msgData, err := msg.Serialize(serializer.DeSeriModeNoValidation, iotago.ZeroRentParas)
 		if err != nil {
 			return nil, fmt.Errorf("unable to perform PoW as msg can't be serialized: %w", err)
 		}

--- a/pkg/protocol/gossip/msg_proc.go
+++ b/pkg/protocol/gossip/msg_proc.go
@@ -307,7 +307,7 @@ func (proc *MessageProcessor) processMilestoneRequest(p *Protocol, data []byte) 
 	}
 	defer cachedMessage.Release(true) // message -1
 
-	cachedRequestedData, err := cachedMessage.Message().Message().Serialize(serializer.DeSeriModeNoValidation, nil)
+	cachedRequestedData, err := cachedMessage.Message().Message().Serialize(serializer.DeSeriModeNoValidation, iotago.ZeroRentParas)
 	if err != nil {
 		// can't reply if serialization fails
 		return
@@ -335,7 +335,7 @@ func (proc *MessageProcessor) processMessageRequest(p *Protocol, data []byte) {
 	}
 	defer cachedMessage.Release(true) // message -1
 
-	cachedRequestedData, err := cachedMessage.Message().Message().Serialize(serializer.DeSeriModeNoValidation, nil)
+	cachedRequestedData, err := cachedMessage.Message().Message().Serialize(serializer.DeSeriModeNoValidation, iotago.ZeroRentParas)
 	if err != nil {
 		// can't reply if serialization fails
 		return

--- a/plugins/debug/debug.go
+++ b/plugins/debug/debug.go
@@ -237,7 +237,7 @@ func milestoneDiff(c echo.Context) (*milestoneDiffResponse, error) {
 	spents := make([]*restapiv2.OutputResponse, len(diff.Spents))
 
 	for i, output := range diff.Outputs {
-		o, err := restapiv2.NewOutputResponse(output, diff.Index)
+		o, err := restapiv2.NewOutputResponse(output, diff.Index, false)
 		if err != nil {
 			return nil, err
 		}
@@ -245,7 +245,7 @@ func milestoneDiff(c echo.Context) (*milestoneDiffResponse, error) {
 	}
 
 	for i, spent := range diff.Spents {
-		o, err := restapiv2.NewSpentResponse(spent, diff.Index)
+		o, err := restapiv2.NewSpentResponse(spent, diff.Index, false)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/restapi/v2/plugin.go
+++ b/plugins/restapi/v2/plugin.go
@@ -66,7 +66,7 @@ const (
 	// GET returns the output IDs of all UTXO changes.
 	RouteMilestoneUTXOChanges = "/milestones/:" + restapipkg.ParameterMilestoneIndex + "/utxo-changes"
 
-	// RouteOutput is the route for getting output by its outputID (transactionHash + outputIndex).
+	// RouteOutput is the route for getting an output by its outputID (transactionHash + outputIndex).
 	// GET returns the output.
 	RouteOutput = "/outputs/:" + restapipkg.ParameterOutputID
 

--- a/plugins/restapi/v2/plugin.go
+++ b/plugins/restapi/v2/plugin.go
@@ -42,7 +42,7 @@ const (
 	// GET returns message metadata (including info about "promotion/reattachment needed").
 	RouteMessageMetadata = "/messages/:" + restapipkg.ParameterMessageID + "/metadata"
 
-	// RouteMessageBytes is the route for getting message raw data by it's messageID.
+	// RouteMessageBytes is the route for getting message raw data by its messageID.
 	// GET returns raw message data (bytes).
 	RouteMessageBytes = "/messages/:" + restapipkg.ParameterMessageID + "/raw"
 
@@ -58,7 +58,7 @@ const (
 	// GET returns message data (json).
 	RouteTransactionsIncludedMessage = "/transactions/:" + restapipkg.ParameterTransactionID + "/included-message"
 
-	// RouteMilestone is the route for getting a milestone by it's milestoneIndex.
+	// RouteMilestone is the route for getting a milestone by its milestoneIndex.
 	// GET returns the milestone.
 	RouteMilestone = "/milestones/:" + restapipkg.ParameterMilestoneIndex
 
@@ -66,9 +66,17 @@ const (
 	// GET returns the output IDs of all UTXO changes.
 	RouteMilestoneUTXOChanges = "/milestones/:" + restapipkg.ParameterMilestoneIndex + "/utxo-changes"
 
-	// RouteOutput is the route for getting outputs by their outputID (transactionHash + outputIndex).
+	// RouteOutput is the route for getting output by its outputID (transactionHash + outputIndex).
 	// GET returns the output.
 	RouteOutput = "/outputs/:" + restapipkg.ParameterOutputID
+
+	// RouteOutputMetadata is the route for getting output metadata by its outputID (transactionHash + outputIndex) without getting the data again.
+	// GET returns the output metadata.
+	RouteOutputMetadata = "/outputs/:" + restapipkg.ParameterOutputID + "/metadata"
+
+	// RouteOutputBytes is the route for getting output raw data by its outputID (transactionHash + outputIndex).
+	// GET returns the raw output data (bytes).
+	RouteOutputBytes = "/outputs/:" + restapipkg.ParameterOutputID + "/raw"
 
 	// RouteTreasury is the route for getting the current treasury output.
 	RouteTreasury = "/treasury"
@@ -234,7 +242,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
@@ -243,7 +250,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
@@ -252,17 +258,31 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
 	routeGroup.GET(RouteOutput, func(c echo.Context) error {
-		resp, err := outputByID(c)
+		resp, err := outputByID(c, false)
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteOutputMetadata, func(c echo.Context) error {
+		resp, err := outputByID(c, true)
+		if err != nil {
+			return err
+		}
+		return restapipkg.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteOutputBytes, func(c echo.Context) error {
+		resp, err := rawOutputByID(c)
+		if err != nil {
+			return err
+		}
+		return c.Blob(http.StatusOK, echo.MIMEOctetStream, resp)
 	})
 
 	routeGroup.GET(RouteTreasury, func(c echo.Context) error {
@@ -270,7 +290,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
@@ -279,7 +298,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
@@ -288,7 +306,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
@@ -297,7 +314,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
@@ -305,7 +321,6 @@ func configure() {
 		if err := removePeer(c); err != nil {
 			return err
 		}
-
 		return c.NoContent(http.StatusNoContent)
 	})
 
@@ -314,7 +329,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
@@ -323,7 +337,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
@@ -332,7 +345,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
@@ -341,7 +353,6 @@ func configure() {
 		if err != nil {
 			return err
 		}
-
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 }

--- a/plugins/restapi/v2/types.go
+++ b/plugins/restapi/v2/types.go
@@ -157,7 +157,7 @@ type OutputResponse struct {
 	// The ledger index at which this output was available at.
 	LedgerIndex milestone.Index `json:"ledgerIndex"`
 	// The output in its serialized form.
-	RawOutput *json.RawMessage `json:"output"`
+	RawOutput *json.RawMessage `json:"output,omitempty"`
 }
 
 // addressBalanceResponse defines the response of a GET addresses REST API call.

--- a/plugins/restapi/v2/utxo.go
+++ b/plugins/restapi/v2/utxo.go
@@ -103,6 +103,7 @@ func rawOutputByID(c echo.Context) ([]byte, error) {
 		if errors.Is(err, kvstore.ErrKeyNotFound) {
 			return nil, errors.WithMessagef(echo.ErrNotFound, "output not found: %s", outputID.ToHex())
 		}
+		return nil, errors.WithMessagef(echo.ErrInternalServerError, "reading raw output failed: %s, error: %s", outputID.ToHex(), err)
 	}
 
 	return bytes, nil

--- a/plugins/restapi/v2/utxo.go
+++ b/plugins/restapi/v2/utxo.go
@@ -13,30 +13,34 @@ import (
 	"github.com/iotaledger/hive.go/kvstore"
 )
 
-func NewOutputResponse(output *utxo.Output, ledgerIndex milestone.Index) (*OutputResponse, error) {
+func NewOutputResponse(output *utxo.Output, ledgerIndex milestone.Index, metadataOnly bool) (*OutputResponse, error) {
 	rawOutputJSON, err := output.Output().MarshalJSON()
 	if err != nil {
 		return nil, errors.WithMessagef(echo.ErrInternalServerError, "marshaling output failed: %s, error: %s", output.OutputID().ToHex(), err)
 	}
 
-	rawRawOutputJSON := json.RawMessage(rawOutputJSON)
-
 	transactionID := output.OutputID().TransactionID()
 
-	return &OutputResponse{
+	r := &OutputResponse{
 		MessageID:                output.MessageID().ToHex(),
 		TransactionID:            hex.EncodeToString(transactionID[:]),
 		Spent:                    false,
 		OutputIndex:              output.OutputID().Index(),
-		RawOutput:                &rawRawOutputJSON,
 		MilestoneIndexBooked:     output.MilestoneIndex(),
 		MilestoneTimestampBooked: output.MilestoneTimestamp(),
 		LedgerIndex:              ledgerIndex,
-	}, nil
+	}
+
+	if !metadataOnly {
+		rawRawOutputJSON := json.RawMessage(rawOutputJSON)
+		r.RawOutput = &rawRawOutputJSON
+	}
+
+	return r, nil
 }
 
-func NewSpentResponse(spent *utxo.Spent, ledgerIndex milestone.Index) (*OutputResponse, error) {
-	response, err := NewOutputResponse(spent.Output(), ledgerIndex)
+func NewSpentResponse(spent *utxo.Spent, ledgerIndex milestone.Index, metadataOnly bool) (*OutputResponse, error) {
+	response, err := NewOutputResponse(spent.Output(), ledgerIndex, metadataOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +51,7 @@ func NewSpentResponse(spent *utxo.Spent, ledgerIndex milestone.Index) (*OutputRe
 	return response, nil
 }
 
-func outputByID(c echo.Context) (*OutputResponse, error) {
+func outputByID(c echo.Context, metadataOnly bool) (*OutputResponse, error) {
 	outputID, err := restapi.ParseOutputIDParam(c)
 	if err != nil {
 		return nil, err
@@ -75,7 +79,7 @@ func outputByID(c echo.Context) (*OutputResponse, error) {
 			}
 			return nil, errors.WithMessagef(echo.ErrInternalServerError, "reading output failed: %s, error: %s", outputID.ToHex(), err)
 		}
-		return NewOutputResponse(output, ledgerIndex)
+		return NewOutputResponse(output, ledgerIndex, metadataOnly)
 	}
 
 	spent, err := deps.UTXOManager.ReadSpentForOutputIDWithoutLocking(outputID)
@@ -85,7 +89,23 @@ func outputByID(c echo.Context) (*OutputResponse, error) {
 		}
 		return nil, errors.WithMessagef(echo.ErrInternalServerError, "reading output failed: %s, error: %s", outputID.ToHex(), err)
 	}
-	return NewSpentResponse(spent, ledgerIndex)
+	return NewSpentResponse(spent, ledgerIndex, metadataOnly)
+}
+
+func rawOutputByID(c echo.Context) ([]byte, error) {
+	outputID, err := restapi.ParseOutputIDParam(c)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := deps.UTXOManager.ReadRawOutputBytesByOutputIDWithoutLocking(outputID)
+	if err != nil {
+		if errors.Is(err, kvstore.ErrKeyNotFound) {
+			return nil, errors.WithMessagef(echo.ErrNotFound, "output not found: %s", outputID.ToHex())
+		}
+	}
+
+	return bytes, nil
 }
 
 func treasury(_ echo.Context) (*treasuryResponse, error) {


### PR DESCRIPTION
Added:
- `api/v2/outputs/{outputId}/metadata` that returns just the metadata and not the output serialized as JSON
- `api/v2/outputs/{outputId}/raw` that returns the raw bytes of the given output