### PR TITLE
Add database snapshot tool

### DIFF
--- a/core/database/core.go
+++ b/core/database/core.go
@@ -87,7 +87,7 @@ func initConfigPars(c *dig.Container) {
 	}
 
 	if err := c.Provide(func(deps cfgDeps) cfgResult {
-		dbEngine, err := database.DatabaseEngine(deps.NodeConfig.String(CfgDatabaseEngine))
+		dbEngine, err := database.DatabaseEngineFromStringAllowed(deps.NodeConfig.String(CfgDatabaseEngine))
 		if err != nil {
 			CorePlugin.LogPanic(err)
 		}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -16,6 +16,7 @@ type Engine string
 
 const (
 	EngineUnknown Engine = "unknown"
+	EngineAuto    Engine = "auto"
 	EngineRocksDB Engine = "rocksdb"
 	EnginePebble  Engine = "pebble"
 	EngineMapDB   Engine = "mapdb"

--- a/pkg/snapshot/pruning.go
+++ b/pkg/snapshot/pruning.go
@@ -195,9 +195,11 @@ func (s *SnapshotManager) pruneDatabase(ctx context.Context, targetIndex milesto
 
 	// calculate solid entry points for the new end of the tangle history
 	var solidEntryPoints []*storage.SolidEntryPoint
-	err := s.forEachSolidEntryPoint(
+	err := forEachSolidEntryPoint(
 		ctx,
+		s.storage,
 		targetIndex,
+		s.solidEntryPointCheckThresholdPast,
 		func(sep *storage.SolidEntryPoint) bool {
 			solidEntryPoints = append(solidEntryPoints, sep)
 			return true

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -182,13 +182,18 @@ func (s *SnapshotManager) shouldTakeSnapshot(confirmedMilestoneIndex milestone.I
 	return confirmedMilestoneIndex-(s.snapshotDepth+s.snapshotInterval) >= snapshotInfo.SnapshotIndex
 }
 
-func (s *SnapshotManager) forEachSolidEntryPoint(ctx context.Context, targetIndex milestone.Index, solidEntryPointConsumer func(sep *storage.SolidEntryPoint) bool) error {
+func forEachSolidEntryPoint(
+	ctx context.Context,
+	dbStorage *storage.Storage,
+	targetIndex milestone.Index,
+	solidEntryPointCheckThresholdPast milestone.Index,
+	solidEntryPointConsumer func(sep *storage.SolidEntryPoint) bool) error {
 
 	solidEntryPoints := make(map[string]milestone.Index)
 
-	metadataMemcache := storage.NewMetadataMemcache(s.storage.CachedMessageMetadata)
-	memcachedParentsTraverserStorage := dag.NewMemcachedParentsTraverserStorage(s.storage, metadataMemcache)
-	memcachedChildrenTraverserStorage := dag.NewMemcachedChildrenTraverserStorage(s.storage, metadataMemcache)
+	metadataMemcache := storage.NewMetadataMemcache(dbStorage.CachedMessageMetadata)
+	memcachedParentsTraverserStorage := dag.NewMemcachedParentsTraverserStorage(dbStorage, metadataMemcache)
+	memcachedChildrenTraverserStorage := dag.NewMemcachedChildrenTraverserStorage(dbStorage, metadataMemcache)
 
 	defer func() {
 		// all releases are forced since the cone is referenced and not needed anymore
@@ -217,7 +222,6 @@ func (s *SnapshotManager) forEachSolidEntryPoint(ctx context.Context, targetInde
 
 			if cachedMsgMeta == nil {
 				// Ignore this message since it doesn't exist anymore
-				s.LogWarnf("%s, msg ID: %v, child msg ID: %v", ErrChildMsgNotFound, messageID.ToHex(), childMessageID.ToHex())
 				continue
 			}
 
@@ -232,14 +236,14 @@ func (s *SnapshotManager) forEachSolidEntryPoint(ctx context.Context, targetInde
 	}
 
 	// Iterate from a reasonable old milestone to the target index to check for solid entry points
-	for milestoneIndex := targetIndex - s.solidEntryPointCheckThresholdPast; milestoneIndex <= targetIndex; milestoneIndex++ {
+	for milestoneIndex := targetIndex - solidEntryPointCheckThresholdPast; milestoneIndex <= targetIndex; milestoneIndex++ {
 
 		if err := utils.ReturnErrIfCtxDone(ctx, ErrSnapshotCreationWasAborted); err != nil {
 			// stop snapshot creation if node was shutdown
 			return err
 		}
 
-		cachedMilestone := s.storage.CachedMilestoneOrNil(milestoneIndex) // milestone +1
+		cachedMilestone := dbStorage.CachedMilestoneOrNil(milestoneIndex) // milestone +1
 		if cachedMilestone == nil {
 			return errors.Wrapf(ErrCritical, "milestone (%d) not found!", milestoneIndex)
 		}
@@ -313,25 +317,28 @@ func (s *SnapshotManager) forEachSolidEntryPoint(ctx context.Context, targetInde
 	return nil
 }
 
-func (s *SnapshotManager) checkSnapshotLimits(targetIndex milestone.Index, snapshotInfo *storage.SnapshotInfo, writeToDatabase bool) error {
+func checkSnapshotLimits(
+	snapshotInfo *storage.SnapshotInfo,
+	confirmedMilestoneIndex milestone.Index,
+	targetIndex milestone.Index,
+	solidEntryPointCheckThresholdPast milestone.Index,
+	solidEntryPointCheckThresholdFuture milestone.Index,
+	checkIncreasingSnapshotIndex bool) error {
 
-	confirmedMilestoneIndex := s.syncManager.ConfirmedMilestoneIndex()
-
-	if confirmedMilestoneIndex < s.solidEntryPointCheckThresholdFuture {
-		return errors.Wrapf(ErrNotEnoughHistory, "minimum confirmed index: %d, actual confirmed index: %d", s.solidEntryPointCheckThresholdFuture+1, confirmedMilestoneIndex)
+	if confirmedMilestoneIndex < solidEntryPointCheckThresholdFuture {
+		return errors.Wrapf(ErrNotEnoughHistory, "minimum confirmed index: %d, actual confirmed index: %d", solidEntryPointCheckThresholdFuture+1, confirmedMilestoneIndex)
 	}
 
-	minimumIndex := s.solidEntryPointCheckThresholdPast + 1
-	maximumIndex := confirmedMilestoneIndex - s.solidEntryPointCheckThresholdFuture
+	minimumIndex := solidEntryPointCheckThresholdPast + 1
+	maximumIndex := confirmedMilestoneIndex - solidEntryPointCheckThresholdFuture
 
-	if writeToDatabase && minimumIndex < snapshotInfo.SnapshotIndex+1 {
-		// if we write the snapshot state to the database, the newly generated snapshot index must be greater than the last snapshot index
+	if checkIncreasingSnapshotIndex && minimumIndex < snapshotInfo.SnapshotIndex+1 {
 		minimumIndex = snapshotInfo.SnapshotIndex + 1
 	}
 
-	if minimumIndex < snapshotInfo.PruningIndex+1+s.solidEntryPointCheckThresholdPast {
+	if minimumIndex < snapshotInfo.PruningIndex+1+solidEntryPointCheckThresholdPast {
 		// since we always generate new solid entry points, we need enough history
-		minimumIndex = snapshotInfo.PruningIndex + 1 + s.solidEntryPointCheckThresholdPast
+		minimumIndex = snapshotInfo.PruningIndex + 1 + solidEntryPointCheckThresholdPast
 	}
 
 	switch {

--- a/pkg/snapshot/snapshot_write.go
+++ b/pkg/snapshot/snapshot_write.go
@@ -713,7 +713,11 @@ func CreateSnapshotFromStorage(
 
 	// roll back the confirmation in the temporary UTXO manager
 	utxoManagerTemp := utxo.New(utxoStoreTemp)
-	for msIndex := ledgerIndex; msIndex >= targetIndex; msIndex-- {
+
+	// we only need to rollback until the resulting ledgerIndex == targetIndex,
+	// but everytime we run RollbackConfirmationWithoutLocking we decrease the ledgerIndex by 1.
+	// => msIndex > targetIndex is correct in this case.
+	for msIndex := ledgerIndex; msIndex > targetIndex; msIndex-- {
 
 		msDiff, err := utxoManagerTemp.MilestoneDiffWithoutLocking(msIndex)
 		if err != nil {

--- a/pkg/snapshot/snapshot_write.go
+++ b/pkg/snapshot/snapshot_write.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/model/utxo"
 	"github.com/gohornet/hornet/pkg/utils"
+	"github.com/iotaledger/hive.go/kvstore"
 	iotago "github.com/iotaledger/iota.go/v2"
 )
 
@@ -63,15 +64,22 @@ func producerFromChannels(prodChan <-chan interface{}, errChan <-chan error) fun
 }
 
 // returns a producer which produces solid entry points.
-func newSEPsProducer(ctx context.Context, s *SnapshotManager, targetIndex milestone.Index) SEPProducerFunc {
+func newSEPsProducer(
+	ctx context.Context,
+	dbStorage *storage.Storage,
+	targetIndex milestone.Index,
+	solidEntryPointCheckThresholdPast milestone.Index) SEPProducerFunc {
+
 	prodChan := make(chan interface{})
 	errChan := make(chan error)
 
 	go func() {
 		// calculate solid entry points for the target index
-		if err := s.forEachSolidEntryPoint(
+		if err := forEachSolidEntryPoint(
 			ctx,
+			dbStorage,
 			targetIndex,
+			solidEntryPointCheckThresholdPast,
 			func(sep *storage.SolidEntryPoint) bool {
 				prodChan <- sep.MessageID
 				return true
@@ -371,8 +379,8 @@ func (s *SnapshotManager) readSnapshotIndexFromFullSnapshotFile(snapshotFullPath
 }
 
 // returns the timestamp of the target milestone.
-func (s *SnapshotManager) readTargetMilestoneTimestamp(targetIndex milestone.Index) (time.Time, error) {
-	cachedMilestoneTarget := s.storage.CachedMilestoneOrNil(targetIndex) // milestone +1
+func readTargetMilestoneTimestamp(dbStorage *storage.Storage, targetIndex milestone.Index) (time.Time, error) {
+	cachedMilestoneTarget := dbStorage.CachedMilestoneOrNil(targetIndex) // milestone +1
 	if cachedMilestoneTarget == nil {
 		return time.Time{}, errors.Wrapf(ErrCritical, "target milestone (%d) not found", targetIndex)
 	}
@@ -414,7 +422,14 @@ func (s *SnapshotManager) createSnapshotWithoutLocking(
 		return errors.Wrap(ErrCritical, "no snapshot info found")
 	}
 
-	if err := s.checkSnapshotLimits(targetIndex, snapshotInfo, writeToDatabase); err != nil {
+	if err := checkSnapshotLimits(
+		snapshotInfo,
+		s.syncManager.ConfirmedMilestoneIndex(),
+		targetIndex,
+		s.solidEntryPointCheckThresholdPast,
+		s.solidEntryPointCheckThresholdFuture,
+		// if we write the snapshot state to the database, the newly generated snapshot index must be greater than the last snapshot index
+		writeToDatabase); err != nil {
 		return err
 	}
 
@@ -425,7 +440,7 @@ func (s *SnapshotManager) createSnapshotWithoutLocking(
 		SEPMilestoneIndex: targetIndex,
 	}
 
-	targetMsTimestamp, err := s.readTargetMilestoneTimestamp(targetIndex)
+	targetMsTimestamp, err := readTargetMilestoneTimestamp(s.storage, targetIndex)
 	if err != nil {
 		return err
 	}
@@ -494,7 +509,7 @@ func (s *SnapshotManager) createSnapshotWithoutLocking(
 	}
 
 	// stream data into snapshot file
-	snapshotMetrics, err := StreamSnapshotDataTo(snapshotFile, uint64(targetMsTimestamp.Unix()), header, newSEPsProducer(ctx, s, targetIndex), utxoProducer, milestoneDiffProducer)
+	snapshotMetrics, err := StreamSnapshotDataTo(snapshotFile, uint64(targetMsTimestamp.Unix()), header, newSEPsProducer(ctx, s.storage, targetIndex, s.solidEntryPointCheckThresholdPast), utxoProducer, milestoneDiffProducer)
 	if err != nil {
 		_ = snapshotFile.Close()
 		return fmt.Errorf("couldn't generate %s snapshot file: %w", snapshotNames[snapshotType], err)
@@ -520,7 +535,7 @@ func (s *SnapshotManager) createSnapshotWithoutLocking(
 	timeSnapshotMilestoneIndexChanged := timeStreamSnapshotData
 	if writeToDatabase {
 		// since we write to the database, the targetIndex should exist
-		targetMsTimestamp, err := s.readTargetMilestoneTimestamp(targetIndex)
+		targetMsTimestamp, err := readTargetMilestoneTimestamp(s.storage, targetIndex)
 		if err != nil {
 			return err
 		}
@@ -646,6 +661,155 @@ func createSnapshotFromCurrentStorageState(dbStorage *storage.Storage, filePath 
 	return &ReadFileHeader{
 		FileHeader:         *snapshotFileHeader,
 		Timestamp:          uint64(snapshotInfo.Timestamp.Unix()),
+		SEPCount:           uint64(sepsCount),
+		OutputCount:        uint64(unspentOutputsCount),
+		MilestoneDiffCount: 0,
+	}, nil
+}
+
+// CreateSnapshotFromStorage creates a snapshot file by streaming data from the database into a snapshot file.
+func CreateSnapshotFromStorage(
+	ctx context.Context,
+	dbStorage *storage.Storage,
+	utxoManager *utxo.Manager,
+	filePath string,
+	targetIndex milestone.Index,
+	solidEntryPointCheckThresholdPast milestone.Index,
+	solidEntryPointCheckThresholdFuture milestone.Index,
+) (*ReadFileHeader, error) {
+
+	snapshotInfo := dbStorage.SnapshotInfo()
+	if snapshotInfo == nil {
+		return nil, errors.New("no snapshot info found")
+	}
+
+	// ledger index corresponds to the CMI
+	ledgerIndex, err := utxoManager.ReadLedgerIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	// check if the targetIndex is possible
+	if err := checkSnapshotLimits(
+		snapshotInfo,
+		ledgerIndex,
+		targetIndex,
+		solidEntryPointCheckThresholdPast,
+		solidEntryPointCheckThresholdFuture,
+		false); err != nil {
+		return nil, err
+	}
+
+	// create a temp storage in memory
+	utxoStoreTemp, err := database.StoreWithDefaultSettings("", false, database.EngineMapDB)
+	if err != nil {
+		return nil, fmt.Errorf("create temp storage failed: %w", err)
+	}
+
+	// copy current ledger state to the temp storage
+	if err := kvstore.Copy(dbStorage.UTXOStore(), utxoStoreTemp); err != nil {
+		return nil, fmt.Errorf("copy kvstore failed: %w", err)
+	}
+
+	// roll back the confirmation in the temporary UTXO manager
+	utxoManagerTemp := utxo.New(utxoStoreTemp)
+	for msIndex := ledgerIndex; msIndex >= targetIndex; msIndex-- {
+
+		msDiff, err := utxoManagerTemp.MilestoneDiffWithoutLocking(msIndex)
+		if err != nil {
+			return nil, fmt.Errorf("load milestone diff failed: %w", err)
+		}
+
+		var treasuryMutationTuple *utxo.TreasuryMutationTuple
+		if msDiff.TreasuryOutput != nil {
+			treasuryMutationTuple = &utxo.TreasuryMutationTuple{
+				NewOutput:   msDiff.TreasuryOutput,
+				SpentOutput: msDiff.SpentTreasuryOutput,
+			}
+		}
+
+		if err := utxoManagerTemp.RollbackConfirmationWithoutLocking(
+			msIndex,
+			msDiff.Outputs,
+			msDiff.Spents,
+			treasuryMutationTuple,
+			nil); err != nil {
+			return nil, fmt.Errorf("rollback milestone confirmation (%d) failed: %w", msIndex, err)
+		}
+	}
+
+	// read out treasury tx
+	unspentTreasuryOutput, err := utxoManagerTemp.UnspentTreasuryOutputWithoutLocking()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get unspent treasury output: %w", err)
+	}
+
+	snapshotFileHeader := &FileHeader{
+		Version:              SupportedFormatVersion,
+		Type:                 Full,
+		NetworkID:            snapshotInfo.NetworkID,
+		SEPMilestoneIndex:    targetIndex,
+		LedgerMilestoneIndex: targetIndex,
+		TreasuryOutput:       unspentTreasuryOutput,
+	}
+
+	targetMsTimestamp, err := readTargetMilestoneTimestamp(dbStorage, targetIndex)
+	if err != nil {
+		return nil, fmt.Errorf("read target milestone timestamp failed: %w", err)
+	}
+
+	// create a prepped solid entry point producer which counts how many went through
+	sepsCount := 0
+	sepProducer := newSEPsProducer(ctx, dbStorage, targetIndex, solidEntryPointCheckThresholdPast)
+	countingSepProducer := func() (hornet.MessageID, error) {
+		sep, err := sepProducer()
+		if sep != nil {
+			sepsCount++
+		}
+		return sep, err
+	}
+
+	// create a prepped output producer which counts how many went through
+	unspentOutputsCount := 0
+	cmiUTXOProducer := newCMIUTXOProducer(utxoManagerTemp)
+	countingOutputProducer := func() (*Output, error) {
+		output, err := cmiUTXOProducer()
+		if output != nil {
+			unspentOutputsCount++
+		}
+		return output, err
+	}
+
+	milestoneDiffProducer := func() (*MilestoneDiff, error) {
+		// we won't have any ms diffs within this merged full snapshot file
+		return nil, nil
+	}
+
+	snapshotFile, tempFilePath, err := utils.CreateTempFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// stream data into snapshot file
+	if _, err := StreamSnapshotDataTo(
+		snapshotFile,
+		uint64(targetMsTimestamp.Unix()),
+		snapshotFileHeader,
+		countingSepProducer,
+		countingOutputProducer,
+		milestoneDiffProducer); err != nil {
+		_ = snapshotFile.Close()
+		return nil, fmt.Errorf("couldn't generate %s snapshot file: %w", snapshotNames[Full], err)
+	}
+
+	// finalize file
+	if err := utils.CloseFileAndRename(snapshotFile, tempFilePath, filePath); err != nil {
+		return nil, err
+	}
+
+	return &ReadFileHeader{
+		FileHeader:         *snapshotFileHeader,
+		Timestamp:          uint64(targetMsTimestamp.Unix()),
 		SEPCount:           uint64(sepsCount),
 		OutputCount:        uint64(unspentOutputsCount),
 		MilestoneDiffCount: 0,

--- a/pkg/snapshot/snapshot_write.go
+++ b/pkg/snapshot/snapshot_write.go
@@ -828,7 +828,7 @@ func CreateSnapshotFromStorage(
 // applying the delta diffs onto it and then writing out the merged state.
 func MergeSnapshotsFiles(fullPath string, deltaPath string, targetFileName string) (*MergeInfo, error) {
 
-	targetEngine, err := database.DatabaseEngine(string(database.EnginePebble))
+	targetEngine, err := database.DatabaseEngineAllowed(database.EnginePebble)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/toolset/benchmark.go
+++ b/pkg/toolset/benchmark.go
@@ -46,7 +46,7 @@ func benchmarkIO(args []string) error {
 	objectCnt := *objectsCountFlag
 	size := *objectsSizeFlag
 
-	dbEngine, err := database.DatabaseEngine(*databaseEngineFlag, database.EnginePebble, database.EngineRocksDB)
+	dbEngine, err := database.DatabaseEngineFromStringAllowed(*databaseEngineFlag, database.EnginePebble, database.EngineRocksDB)
 	if err != nil {
 		return err
 	}

--- a/pkg/toolset/database.go
+++ b/pkg/toolset/database.go
@@ -188,7 +188,7 @@ func getTangleStorage(path string,
 	markTainted bool,
 	checkSnapInfo bool) (*storage.Storage, error) {
 
-	dbEngine, err := database.DatabaseEngine(dbEngineStr, database.EnginePebble, database.EngineRocksDB)
+	dbEngine, err := database.DatabaseEngineFromStringAllowed(dbEngineStr, database.EnginePebble, database.EngineRocksDB, database.EngineAuto)
 	if err != nil {
 		return nil, err
 	}
@@ -242,14 +242,14 @@ func checkSnapshotInfo(dbStorage *storage.Storage) error {
 	return nil
 }
 
-func createTangleStorage(name string, tangleDatabasePath string, utxoDatabasePath string, dbEngine database.Engine) (*storage.Storage, error) {
+func createTangleStorage(name string, tangleDatabasePath string, utxoDatabasePath string, dbEngine ...database.Engine) (*storage.Storage, error) {
 
-	storeTangle, err := database.StoreWithDefaultSettings(tangleDatabasePath, true, dbEngine)
+	storeTangle, err := database.StoreWithDefaultSettings(tangleDatabasePath, true, dbEngine...)
 	if err != nil {
 		return nil, fmt.Errorf("%s tangle database initialization failed: %w", name, err)
 	}
 
-	storeUTXO, err := database.StoreWithDefaultSettings(utxoDatabasePath, true, dbEngine)
+	storeUTXO, err := database.StoreWithDefaultSettings(utxoDatabasePath, true, dbEngine...)
 	if err != nil {
 		return nil, fmt.Errorf("%s utxo database initialization failed: %w", name, err)
 	}

--- a/pkg/toolset/database_merge.go
+++ b/pkg/toolset/database_merge.go
@@ -37,7 +37,7 @@ func databaseMerge(args []string) error {
 	genesisSnapshotFilePathFlag := fs.String(FlagToolSnapshotPath, "", "the path to the genesis snapshot file (optional)")
 	databasePathSourceFlag := fs.String(FlagToolDatabasePathSource, "", "the path to the source database")
 	databasePathTargetFlag := fs.String(FlagToolDatabasePathTarget, "", "the path to the target database")
-	databaseEngineSourceFlag := fs.String(FlagToolDatabaseEngineSource, string(DefaultValueDatabaseEngine), "the engine of the source database (values: pebble, rocksdb)")
+	databaseEngineSourceFlag := fs.String(FlagToolDatabaseEngineSource, string(database.EngineAuto), "the engine of the source database (optional, values: pebble, rocksdb, auto)")
 	databaseEngineTargetFlag := fs.String(FlagToolDatabaseEngineTarget, string(DefaultValueDatabaseEngine), "the engine of the target database (values: pebble, rocksdb)")
 	targetIndexFlag := fs.Uint32(FlagToolDatabaseTargetIndex, 0, "the target index (optional)")
 	nodeURLFlag := fs.String(FlagToolDatabaseMergeNodeURL, "", "URL of the node (optional)")

--- a/pkg/toolset/database_migration.go
+++ b/pkg/toolset/database_migration.go
@@ -58,7 +58,7 @@ func databaseMigration(args []string) error {
 		return fmt.Errorf("'%s' (%s) already exist", FlagToolDatabasePathTarget, targetPath)
 	}
 
-	targetEngine, err := database.DatabaseEngine(*databaseEngineTargetFlag, database.EnginePebble, database.EngineRocksDB)
+	targetEngine, err := database.DatabaseEngineFromStringAllowed(*databaseEngineTargetFlag, database.EnginePebble, database.EngineRocksDB)
 	if err != nil {
 		return err
 	}

--- a/pkg/toolset/database_snapshot.go
+++ b/pkg/toolset/database_snapshot.go
@@ -53,7 +53,7 @@ func databaseSnapshot(args []string) error {
 	solidEntryPointCheckThresholdPast := milestone.Index(belowMaxDepth + snapCore.SolidEntryPointCheckAdditionalThresholdPast)
 	solidEntryPointCheckThresholdFuture := milestone.Index(belowMaxDepth + snapCore.SolidEntryPointCheckAdditionalThresholdFuture)
 
-	tangleStoreSource, err := getTangleStorage(*databasePathSourceFlag, "source", string(database.EngineRocksDB), true, true, true, true, true)
+	tangleStoreSource, err := getTangleStorage(*databasePathSourceFlag, "source", string(database.EngineAuto), true, true, true, true, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/toolset/database_snapshot.go
+++ b/pkg/toolset/database_snapshot.go
@@ -1,0 +1,93 @@
+package toolset
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	flag "github.com/spf13/pflag"
+
+	snapCore "github.com/gohornet/hornet/core/snapshot"
+	"github.com/gohornet/hornet/pkg/database"
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	"github.com/gohornet/hornet/pkg/snapshot"
+)
+
+const (
+	belowMaxDepth milestone.Index = 15
+)
+
+func databaseSnapshot(args []string) error {
+
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	snapshotPathTargetFlag := fs.String(FlagToolSnapshotPathTarget, "", "the path to the target snapshot file")
+	databasePathSourceFlag := fs.String(FlagToolDatabasePathSource, "", "the path to the source database")
+	targetIndexFlag := fs.Uint32(FlagToolDatabaseTargetIndex, 0, "the target index")
+	outputJSONFlag := fs.Bool(FlagToolOutputJSON, false, FlagToolDescriptionOutputJSON)
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", ToolDatabaseSnapshot)
+		fs.PrintDefaults()
+		println(fmt.Sprintf("\nexample: %s --%s %s --%s %s --%s %s",
+			ToolDatabaseSnapshot,
+			FlagToolSnapshotPathTarget,
+			"full_snapshot.bin",
+			FlagToolDatabasePathSource,
+			DefaultValueMainnetDatabasePath,
+			FlagToolDatabaseTargetIndex,
+			"100",
+		))
+	}
+
+	if err := parseFlagSet(fs, args); err != nil {
+		return err
+	}
+
+	if len(*snapshotPathTargetFlag) == 0 {
+		return fmt.Errorf("'%s' not specified", FlagToolSnapshotPathTarget)
+	}
+	if len(*databasePathSourceFlag) == 0 {
+		return fmt.Errorf("'%s' not specified", FlagToolDatabasePathSource)
+	}
+
+	solidEntryPointCheckThresholdPast := milestone.Index(belowMaxDepth + snapCore.SolidEntryPointCheckAdditionalThresholdPast)
+	solidEntryPointCheckThresholdFuture := milestone.Index(belowMaxDepth + snapCore.SolidEntryPointCheckAdditionalThresholdFuture)
+
+	tangleStoreSource, err := getTangleStorage(*databasePathSourceFlag, "source", string(database.EngineRocksDB), true, true, true, true, true)
+	if err != nil {
+		return err
+	}
+
+	if !*outputJSONFlag {
+		fmt.Println("creating full snapshot file...")
+	}
+
+	ts := time.Now()
+
+	readFileHeader, err := snapshot.CreateSnapshotFromStorage(
+		getGracefulStopContext(),
+		tangleStoreSource,
+		tangleStoreSource.UTXOManager(),
+		*snapshotPathTargetFlag,
+		milestone.Index(*targetIndexFlag),
+		solidEntryPointCheckThresholdPast,
+		solidEntryPointCheckThresholdFuture,
+	)
+	if err != nil {
+		return err
+	}
+
+	if !*outputJSONFlag {
+		fmt.Printf("metadata:\n")
+	}
+
+	if err := printSnapshotHeaderInfo("", *snapshotPathTargetFlag, readFileHeader, *outputJSONFlag); err != nil {
+		return err
+	}
+
+	if !*outputJSONFlag {
+		fmt.Printf("successfully created full snapshot '%s', took %v\n", *snapshotPathTargetFlag, time.Since(ts).Truncate(time.Millisecond))
+	}
+
+	return nil
+}

--- a/pkg/toolset/database_verify.go
+++ b/pkg/toolset/database_verify.go
@@ -27,7 +27,6 @@ func databaseVerify(args []string) error {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	configFilePathFlag := fs.String(FlagToolConfigFilePath, "", "the path to the config file")
 	databasePathSourceFlag := fs.String(FlagToolDatabasePathSource, "", "the path to the source database")
-	databaseEngineSourceFlag := fs.String(FlagToolDatabaseEngineSource, string(DefaultValueDatabaseEngine), "the engine of the source database (values: pebble, rocksdb)")
 	genesisSnapshotFilePathFlag := fs.String(FlagToolSnapshotPath, "", "the path to the genesis snapshot file")
 
 	fs.Usage = func() {
@@ -54,16 +53,13 @@ func databaseVerify(args []string) error {
 	if len(*databasePathSourceFlag) == 0 {
 		return fmt.Errorf("'%s' not specified", FlagToolDatabasePathSource)
 	}
-	if len(*databaseEngineSourceFlag) == 0 {
-		return fmt.Errorf("'%s' not specified", FlagToolDatabaseEngineSource)
-	}
 	if len(*genesisSnapshotFilePathFlag) == 0 {
 		return fmt.Errorf("'%s' not specified", FlagToolSnapshotPath)
 	}
 
 	// we don't need to check the health of the source db.
 	// it is fine as long as all messages in the cone are found.
-	tangleStoreSource, err := getTangleStorage(*databasePathSourceFlag, "source", *databaseEngineSourceFlag, true, true, false, false, true)
+	tangleStoreSource, err := getTangleStorage(*databasePathSourceFlag, "source", string(database.EngineAuto), true, true, false, false, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/toolset/snap_hash.go
+++ b/pkg/toolset/snap_hash.go
@@ -44,7 +44,7 @@ func snapshotHash(args []string) error {
 	fullPath := *fullSnapshotPathFlag
 	deltaPath := *deltaSnapshotPathFlag
 
-	targetEngine, err := database.DatabaseEngine(string(database.EnginePebble))
+	targetEngine, err := database.DatabaseEngineAllowed(database.EnginePebble)
 	if err != nil {
 		return err
 	}

--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -80,6 +80,7 @@ const (
 	ToolDatabaseHealth          = "db-health"
 	ToolDatabaseMerge           = "db-merge"
 	ToolDatabaseMigration       = "db-migration"
+	ToolDatabaseSnapshot        = "db-snapshot"
 	ToolDatabaseSplit           = "db-split"
 	ToolDatabaseVerify          = "db-verify"
 	ToolCoordinatorFixStateFile = "coo-fix-state"
@@ -138,6 +139,7 @@ func HandleTools() {
 		ToolDatabaseHealth:          databaseHealth,
 		ToolDatabaseMerge:           databaseMerge,
 		ToolDatabaseMigration:       databaseMigration,
+		ToolDatabaseSnapshot:        databaseSnapshot,
 		ToolDatabaseSplit:           databaseSplit,
 		ToolDatabaseVerify:          databaseVerify,
 		ToolCoordinatorFixStateFile: coordinatorFixStateFile,
@@ -180,6 +182,7 @@ func listTools() {
 	fmt.Printf("%-20s checks the health status of the database\n", fmt.Sprintf("%s:", ToolDatabaseHealth))
 	fmt.Printf("%-20s merges missing tangle data from a database to another one\n", fmt.Sprintf("%s:", ToolDatabaseMerge))
 	fmt.Printf("%-20s migrates the database to another engine\n", fmt.Sprintf("%s:", ToolDatabaseMigration))
+	fmt.Printf("%-20s creates a full snapshot from a database\n", fmt.Sprintf("%s:", ToolDatabaseSnapshot))
 	fmt.Printf("%-20s split a legacy database into `tangle` and `utxo`\n", fmt.Sprintf("%s:", ToolDatabaseSplit))
 	fmt.Printf("%-20s verifies a valid ledger state and the existence of all messages`\n", fmt.Sprintf("%s:", ToolDatabaseVerify))
 	fmt.Printf("%-20s applies the latest milestone in the database to the coordinator state file\n", fmt.Sprintf("%s:", ToolCoordinatorFixStateFile))


### PR DESCRIPTION
This PR adds a tool to create a full snapshot from an existing database.
The current ledger state is copied into an in-memory database, and the ledger state is rolled back until the target index.
This way the resulting snapshot doesn't contain any milestone diffs.