### PR TITLE
Participation improvements

### DIFF
--- a/pkg/database/rocksdb.go
+++ b/pkg/database/rocksdb.go
@@ -14,6 +14,8 @@ func NewRocksDB(path string) (*rocksdb.RocksDB, error) {
 		rocksdb.Custom([]string{
 			"periodic_compaction_seconds=43200",
 			"level_compaction_dynamic_level_bytes=true",
+			"keep_log_file_num=2",
+			"max_log_file_size=50000000", // 50MB per log file
 		}),
 	}
 

--- a/pkg/model/faucet/test/testenv.go
+++ b/pkg/model/faucet/test/testenv.go
@@ -280,8 +280,6 @@ func NewFaucetTestEnv(t *testing.T,
 
 	// Connect the callbacks from the testsuite to the Faucet
 	te.ConfigureUTXOCallbacks(
-		nil,
-		nil,
 		func(confirmation *whiteflag.Confirmation) {
 			require.NoError(t, f.ApplyConfirmation(confirmation))
 		},

--- a/pkg/model/participation/database_prefixes.go
+++ b/pkg/model/participation/database_prefixes.go
@@ -19,4 +19,5 @@ const (
 	// Staking
 	//ParticipationStoreKeyPrefixStakingAddress            byte = 6
 	ParticipationStoreKeyPrefixStakingTotalParticipation byte = 7
+	ParticipationStoreKeyPrefixStakingCurrentRewards     byte = 9
 )

--- a/pkg/model/participation/database_prefixes.go
+++ b/pkg/model/participation/database_prefixes.go
@@ -8,14 +8,15 @@ const (
 	ParticipationStoreKeyPrefixMessages byte = 1
 
 	// Tracks all active and past participations
-	ParticipationStoreKeyPrefixTrackedOutputs      byte = 2
-	ParticipationStoreKeyPrefixTrackedSpentOutputs byte = 3
+	ParticipationStoreKeyPrefixTrackedOutputs         byte = 2
+	ParticipationStoreKeyPrefixTrackedSpentOutputs    byte = 3
+	ParticipationStoreKeyPrefixTrackedOutputByAddress byte = 8
 
 	// Voting
 	ParticipationStoreKeyPrefixBallotCurrentVoteBalanceForQuestionAndAnswer     byte = 4
 	ParticipationStoreKeyPrefixBallotAccululatedVoteBalanceForQuestionAndAnswer byte = 5
 
 	// Staking
-	ParticipationStoreKeyPrefixStakingAddress            byte = 6
+	//ParticipationStoreKeyPrefixStakingAddress            byte = 6
 	ParticipationStoreKeyPrefixStakingTotalParticipation byte = 7
 )

--- a/pkg/model/participation/database_prefixes.go
+++ b/pkg/model/participation/database_prefixes.go
@@ -17,7 +17,7 @@ const (
 	ParticipationStoreKeyPrefixBallotAccululatedVoteBalanceForQuestionAndAnswer byte = 5
 
 	// Staking
-	//ParticipationStoreKeyPrefixStakingAddress            byte = 6
+	ParticipationStoreKeyPrefixStakingAddress            byte = 6
 	ParticipationStoreKeyPrefixStakingTotalParticipation byte = 7
 	ParticipationStoreKeyPrefixStakingCurrentRewards     byte = 9
 )

--- a/pkg/model/participation/event.go
+++ b/pkg/model/participation/event.go
@@ -378,8 +378,12 @@ func (e *Event) StakingCanOverflow() bool {
 	}
 
 	// Check if total-supply * numerator/denominator * number of milestones can overflow uint64
-	maxRewardPerMilestone := uint64(iotago.TokenSupply) * uint64(staking.Numerator) / uint64(staking.Denominator)
+	maxRewardPerMilestone := staking.rewardsPerMilestone(iotago.TokenSupply)
 	maxNumberOfMilestones := math.MaxUint64 / maxRewardPerMilestone
 
 	return uint64(e.MilestoneIndexEnd-e.MilestoneIndexStart) > maxNumberOfMilestones
+}
+
+func (s *Staking) rewardsPerMilestone(amount uint64) uint64 {
+	return amount * uint64(s.Numerator) / uint64(s.Denominator)
 }

--- a/pkg/model/participation/participation_manager.go
+++ b/pkg/model/participation/participation_manager.go
@@ -650,7 +650,7 @@ func (pm *ParticipationManager) applyNewConfirmedMilestoneIndexForEvents(index m
 
 		// End all participation if event is ending this milestone
 		if event.EndMilestoneIndex() == index {
-			if err := pm.endAllParticipationsAtMilestone(eventID, index, mutations); err != nil {
+			if err := pm.endAllParticipationsAtMilestone(eventID, index+1, mutations); err != nil {
 				mutations.Cancel()
 				return err
 			}

--- a/pkg/model/participation/participation_manager.go
+++ b/pkg/model/participation/participation_manager.go
@@ -342,7 +342,7 @@ func (pm *ParticipationManager) calculatePastParticipationForEvent(event *Event)
 // 	- Output Type 0 (SigLockedSingleOutput) and Type 1 (SigLockedDustAllowanceOutput) are both valid for this.
 // 	- The Indexation must match the configured Indexation.
 //  - The participation data must be parseable.
-func (pm *ParticipationManager) ApplyNewUTXO(index milestone.Index, newOutput *utxo.Output) error {
+func (pm *ParticipationManager) ApplyNewUTXOs(index milestone.Index, newOutputs utxo.Outputs) error {
 
 	acceptingEvents := filterEvents(pm.Events(), index, func(e *Event, index milestone.Index) bool {
 		return e.ShouldAcceptParticipation(index)
@@ -353,7 +353,12 @@ func (pm *ParticipationManager) ApplyNewUTXO(index milestone.Index, newOutput *u
 		return nil
 	}
 
-	return pm.applyNewUTXOForEvents(index, newOutput, acceptingEvents)
+	for _, newOutput := range newOutputs {
+		if err := pm.applyNewUTXOForEvents(index, newOutput, acceptingEvents); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (pm *ParticipationManager) applyNewUTXOForEvents(index milestone.Index, newOutput *utxo.Output, events map[EventID]*Event) error {
@@ -432,7 +437,7 @@ func (pm *ParticipationManager) applyNewUTXOForEvents(index milestone.Index, new
 }
 
 // ApplySpentUTXO checks if the spent UTXO was part of a participation transaction.
-func (pm *ParticipationManager) ApplySpentUTXO(index milestone.Index, spent *utxo.Spent) error {
+func (pm *ParticipationManager) ApplySpentUTXOs(index milestone.Index, spents utxo.Spents) error {
 
 	acceptingEvents := filterEvents(pm.Events(), index, func(e *Event, index milestone.Index) bool {
 		return e.ShouldAcceptParticipation(index)
@@ -443,7 +448,12 @@ func (pm *ParticipationManager) ApplySpentUTXO(index milestone.Index, spent *utx
 		return nil
 	}
 
-	return pm.applySpentUTXOForEvents(index, spent, acceptingEvents)
+	for _, spent := range spents {
+		if err := pm.applySpentUTXOForEvents(index, spent, acceptingEvents); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (pm *ParticipationManager) applySpentUTXOForEvents(index milestone.Index, spent *utxo.Spent, events map[EventID]*Event) error {

--- a/pkg/model/participation/participation_manager.go
+++ b/pkg/model/participation/participation_manager.go
@@ -605,11 +605,9 @@ func (pm *ParticipationManager) applyNewConfirmedMilestoneIndexForEvents(index m
 			}
 
 			if shouldCountParticipation {
-				pm.ForEachActiveParticipation(eventID, func(trackedParticipation *TrackedParticipation) bool {
-					increaseAmount := trackedParticipation.Amount * uint64(staking.Numerator) / uint64(staking.Denominator)
-					total.rewarded += increaseAmount
-					return true
-				})
+				// TODO: this approach will yield just an estimated rewards
+				increaseAmount := total.staked * uint64(staking.Numerator) / uint64(staking.Denominator)
+				total.rewarded += increaseAmount
 			}
 
 			if err := pm.setTotalStakingParticipationForEvent(eventID, index, total, mutations); err != nil {

--- a/pkg/model/participation/participation_manager.go
+++ b/pkg/model/participation/participation_manager.go
@@ -605,8 +605,11 @@ func (pm *ParticipationManager) applyNewConfirmedMilestoneIndexForEvents(index m
 			}
 
 			if shouldCountParticipation {
-				increaseAmount := total.staked * uint64(staking.Numerator) / uint64(staking.Denominator)
-				total.rewarded += increaseAmount
+				pm.ForEachActiveParticipation(eventID, func(trackedParticipation *TrackedParticipation) bool {
+					increaseAmount := trackedParticipation.Amount * uint64(staking.Numerator) / uint64(staking.Denominator)
+					total.rewarded += increaseAmount
+					return true
+				})
 			}
 
 			if err := pm.setTotalStakingParticipationForEvent(eventID, index, total, mutations); err != nil {

--- a/pkg/model/participation/participation_manager.go
+++ b/pkg/model/participation/participation_manager.go
@@ -322,7 +322,9 @@ func (pm *ParticipationManager) calculatePastParticipationForEvent(event *Event)
 			}
 		}
 
-		pm.applyNewConfirmedMilestoneIndexForEvents(currentIndex, events)
+		if err := pm.applyNewConfirmedMilestoneIndexForEvents(currentIndex, events); err != nil {
+			return err
+		}
 
 		if currentIndex >= pm.syncManager.ConfirmedMilestoneIndex() || currentIndex >= event.EndMilestoneIndex() {
 			// We are done

--- a/pkg/model/participation/participation_manager_test.go
+++ b/pkg/model/participation/participation_manager_test.go
@@ -354,7 +354,7 @@ func TestSingleBallotVote(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, castVote.Message().StoredMessageID(), trackedVote.MessageID)
 	require.Equal(t, milestone.Index(6), trackedVote.StartIndex)
-	require.Equal(t, milestone.Index(10), trackedVote.EndIndex)
+	require.Equal(t, milestone.Index(11), trackedVote.EndIndex)
 
 	var messageFromParticipationStore *storage.Message
 	messageFromParticipationStore, err = env.ParticipationManager().MessageForEventAndMessageID(eventID, trackedVote.MessageID)
@@ -521,7 +521,7 @@ func TestBallotVoteCancel(t *testing.T) {
 	// Verify the vote history after the participation ended
 	env.AssertTrackedParticipation(eventID, castVote1, 6, 7, 1_000_000)
 	env.AssertTrackedParticipation(eventID, castVote2, 8, 9, 1_000_000)
-	env.AssertTrackedParticipation(eventID, castVote3, 11, 12, 1_000_000)
+	env.AssertTrackedParticipation(eventID, castVote3, 11, 13, 1_000_000)
 }
 
 func TestBallotAddVoteBalanceBySweeping(t *testing.T) {
@@ -709,9 +709,9 @@ func TestMultipleBallotVotes(t *testing.T) {
 	env.AssertBallotAnswerStatusAtConfirmedMilestoneIndex(eventID, 200_000, 1000_000, 0, 20)
 
 	// Verify all votes
-	env.AssertTrackedParticipation(eventID, wallet1Vote, 8, 12, 5_000_000)
-	env.AssertTrackedParticipation(eventID, wallet2Vote, 8, 12, 150_000_000)
-	env.AssertTrackedParticipation(eventID, wallet3Vote, 8, 12, 200_000_000)
+	env.AssertTrackedParticipation(eventID, wallet1Vote, 8, 13, 5_000_000)
+	env.AssertTrackedParticipation(eventID, wallet2Vote, 8, 13, 150_000_000)
+	env.AssertTrackedParticipation(eventID, wallet3Vote, 8, 13, 200_000_000)
 }
 
 func TestChangeOpinionMidVote(t *testing.T) {
@@ -936,12 +936,12 @@ func TestMultipleConcurrentEventsWithBallot(t *testing.T) {
 	// Verify all votes
 	env.AssertTrackedParticipation(eventID1, wallet1Vote1, 6, 11, 5_000_000) // Voted 1
 	env.AssertInvalidParticipation(eventID2, wallet1Vote1)
-	env.AssertTrackedParticipation(eventID1, wallet1Vote2, 11, 12, 5_000_000)   // Voted 1
-	env.AssertTrackedParticipation(eventID2, wallet1Vote2, 11, 14, 5_000_000)   // Voted 2
-	env.AssertTrackedParticipation(eventID1, wallet2Vote1, 6, 12, 150_000_000)  // Voted 1
-	env.AssertTrackedParticipation(eventID2, wallet3Vote1, 8, 14, 200_000_000)  // Voted 2
-	env.AssertTrackedParticipation(eventID1, wallet4Vote1, 12, 12, 300_000_000) // Voted 0
-	env.AssertTrackedParticipation(eventID2, wallet4Vote2, 13, 14, 300_000_000) // Voted 2
+	env.AssertTrackedParticipation(eventID1, wallet1Vote2, 11, 13, 5_000_000)   // Voted 1
+	env.AssertTrackedParticipation(eventID2, wallet1Vote2, 11, 15, 5_000_000)   // Voted 2
+	env.AssertTrackedParticipation(eventID1, wallet2Vote1, 6, 13, 150_000_000)  // Voted 1
+	env.AssertTrackedParticipation(eventID2, wallet3Vote1, 8, 15, 200_000_000)  // Voted 2
+	env.AssertTrackedParticipation(eventID1, wallet4Vote1, 12, 13, 300_000_000) // Voted 0
+	env.AssertTrackedParticipation(eventID2, wallet4Vote2, 13, 15, 300_000_000) // Voted 2
 
 	// Verify end results
 	env.AssertBallotAnswerStatus(eventID1, event1.EndMilestoneIndex(), 300_000, 300_000, 0, 0)
@@ -1070,12 +1070,12 @@ func TestMultipleConcurrentEventsWithBallotCalculatedAfterEventEnded(t *testing.
 	// Verify all votes
 	env.AssertTrackedParticipation(eventID1, wallet1Vote1, 6, 11, 5_000_000) // Voted 1
 	env.AssertInvalidParticipation(eventID2, wallet1Vote1)
-	env.AssertTrackedParticipation(eventID1, wallet1Vote2, 11, 12, 5_000_000)   // Voted 1
-	env.AssertTrackedParticipation(eventID2, wallet1Vote2, 11, 14, 5_000_000)   // Voted 2
-	env.AssertTrackedParticipation(eventID1, wallet2Vote1, 6, 12, 150_000_000)  // Voted 1
-	env.AssertTrackedParticipation(eventID2, wallet3Vote1, 8, 14, 200_000_000)  // Voted 2
-	env.AssertTrackedParticipation(eventID1, wallet4Vote1, 12, 12, 300_000_000) // Voted 0
-	env.AssertTrackedParticipation(eventID2, wallet4Vote2, 13, 14, 300_000_000) // Voted 2
+	env.AssertTrackedParticipation(eventID1, wallet1Vote2, 11, 13, 5_000_000)   // Voted 1
+	env.AssertTrackedParticipation(eventID2, wallet1Vote2, 11, 15, 5_000_000)   // Voted 2
+	env.AssertTrackedParticipation(eventID1, wallet2Vote1, 6, 13, 150_000_000)  // Voted 1
+	env.AssertTrackedParticipation(eventID2, wallet3Vote1, 8, 15, 200_000_000)  // Voted 2
+	env.AssertTrackedParticipation(eventID1, wallet4Vote1, 12, 13, 300_000_000) // Voted 0
+	env.AssertTrackedParticipation(eventID2, wallet4Vote2, 13, 15, 300_000_000) // Voted 2
 
 	// Verify end results
 	env.AssertBallotAnswerStatus(eventID1, event1.EndMilestoneIndex(), 300_000, 300_000, 0, 0)

--- a/pkg/model/participation/participation_manager_test.go
+++ b/pkg/model/participation/participation_manager_test.go
@@ -1,7 +1,6 @@
 package participation_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1233,7 +1232,7 @@ func TestStakingRewards(t *testing.T) {
 
 	totalRewards := uint64(0)
 	addresses := make(map[string]struct{})
-	env.ParticipationManager().ForEachStakingAddress(eventID, env.ConfirmedMilestoneIndex(), func(address iotago.Address, rewards uint64) bool {
+	env.ParticipationManager().ForEachAddressStakingParticipation(eventID, env.ConfirmedMilestoneIndex(), func(address iotago.Address, _ *participation.TrackedParticipation, rewards uint64) bool {
 		totalRewards += rewards
 		addresses[address.String()] = struct{}{}
 		return true
@@ -1250,7 +1249,7 @@ func TestStakingRewards(t *testing.T) {
 	require.True(t, wallet4Found)
 
 	totalRewardsWithoutFilter := uint64(0)
-	env.ParticipationManager().ForEachStakingAddress(eventID, env.ConfirmedMilestoneIndex(), func(address iotago.Address, rewards uint64) bool {
+	env.ParticipationManager().ForEachAddressStakingParticipation(eventID, env.ConfirmedMilestoneIndex(), func(address iotago.Address, _ *participation.TrackedParticipation, rewards uint64) bool {
 		totalRewardsWithoutFilter += rewards
 		return true
 	}, participation.FilterRequiredMinimumRewards(false))

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -553,15 +553,14 @@ func (pm *ParticipationManager) rewardsForTrackedParticipation(trackedParticipat
 	return rewardsForParticipation, nil
 }
 
-func (pm *ParticipationManager) StakingRewardForAddress(eventID EventID, address iotago.Address) (uint64, error) {
+func (pm *ParticipationManager) StakingRewardForAddress(eventID EventID, address iotago.Address, msIndex milestone.Index) (uint64, error) {
 	var rewards uint64
-	confirmedMilestoneIndex := pm.syncManager.ConfirmedMilestoneIndex()
 	trackedParticipations, err := pm.ParticipationsForAddress(eventID, address)
 	if err != nil {
 		return 0, err
 	}
 	for _, trackedParticipation := range trackedParticipations {
-		amount, err := pm.rewardsForTrackedParticipation(trackedParticipation, confirmedMilestoneIndex)
+		amount, err := pm.rewardsForTrackedParticipation(trackedParticipation, msIndex)
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -536,11 +536,6 @@ func (pm *ParticipationManager) rewardsForTrackedParticipation(trackedParticipat
 	} else {
 		// Participation ended
 		milestonesToCount = uint64(trackedParticipation.EndIndex - trackedParticipation.StartIndex)
-
-		if trackedParticipation.EndIndex == event.EndMilestoneIndex() {
-			// We need to count the last index of the event
-			milestonesToCount++
-		}
 	}
 
 	if trackedParticipation.StartIndex < eventMilestoneCountingStart {

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -705,9 +705,9 @@ func (pm *ParticipationManager) setTotalStakingParticipationForEvent(eventID Eve
 	return mutations.Set(totalParticipationStakingKeyForEvent(eventID, milestone), total.valueBytes())
 }
 
-type StakingRewardsConsumer func(address iotago.Address, rewards uint64) bool
+type StakingRewardsConsumer func(address iotago.Address, participation *TrackedParticipation, rewards uint64) bool
 
-func (pm *ParticipationManager) ForEachStakingAddress(eventID EventID, msIndex milestone.Index, consumer StakingRewardsConsumer, options ...IterateOption) error {
+func (pm *ParticipationManager) ForEachAddressStakingParticipation(eventID EventID, msIndex milestone.Index, consumer StakingRewardsConsumer, options ...IterateOption) error {
 
 	event := pm.Event(eventID)
 	if event == nil {
@@ -765,7 +765,7 @@ func (pm *ParticipationManager) ForEachStakingAddress(eventID EventID, msIndex m
 
 		i++
 
-		return consumerFunc(addr.(iotago.Address), balance)
+		return consumerFunc(addr.(iotago.Address), participation, balance)
 	}); err != nil {
 		return err
 	}

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -498,7 +498,7 @@ func (pm *ParticipationManager) stopCountingBallotAnswers(event *Event, vote *Pa
 
 // Staking
 
-func (pm *ParticipationManager) rewardsForTrackedParticipation(trackedParticipation *TrackedParticipation, atIndex milestone.Index) (uint64, error) {
+func (pm *ParticipationManager) RewardsForTrackedParticipation(trackedParticipation *TrackedParticipation, atIndex milestone.Index) (uint64, error) {
 
 	event := pm.Event(trackedParticipation.EventID)
 	if event == nil {
@@ -555,7 +555,7 @@ func (pm *ParticipationManager) StakingRewardForAddress(eventID EventID, address
 		return 0, err
 	}
 	for _, trackedParticipation := range trackedParticipations {
-		amount, err := pm.rewardsForTrackedParticipation(trackedParticipation, msIndex)
+		amount, err := pm.RewardsForTrackedParticipation(trackedParticipation, msIndex)
 		if err != nil {
 			return 0, err
 		}
@@ -735,7 +735,7 @@ func (pm *ParticipationManager) ForEachAddressStakingParticipation(eventID Event
 			return false
 		}
 
-		balance, err := pm.rewardsForTrackedParticipation(participation, msIndex)
+		balance, err := pm.RewardsForTrackedParticipation(participation, msIndex)
 		if err != nil {
 			innerErr = err
 			return false

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -539,7 +539,7 @@ func (pm *ParticipationManager) RewardsForTrackedParticipation(trackedParticipat
 	}
 
 	if trackedParticipation.StartIndex < eventMilestoneCountingStart {
-		// Substract the commencing milestones, minus the start itself
+		// Subtract the commencing milestones, minus the start itself
 		milestonesToSubtract = uint64(eventMilestoneCountingStart - trackedParticipation.StartIndex)
 	}
 

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -776,5 +776,10 @@ func (pm *ParticipationManager) clearStorageForEventID(eventID EventID) error {
 	if err := pm.participationStore.DeletePrefix(messageKeyForEventPrefix(eventID)); err != nil {
 		return err
 	}
+
+	// Clean up old database keys
+	if err := pm.participationStore.DeletePrefix([]byte{ParticipationStoreKeyPrefixStakingAddress}); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -505,8 +505,8 @@ func (pm *ParticipationManager) RewardsForTrackedParticipation(trackedParticipat
 		return 0, ErrEventNotFound
 	}
 
-	if event.StartMilestoneIndex() >= atIndex {
-		// Event not yet started, so skip
+	if event.StartMilestoneIndex() > atIndex {
+		// Event not yet started counting, so skip
 		return 0, nil
 	}
 

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -155,8 +155,7 @@ func participationKeyForEventPrefix(eventID EventID) []byte {
 
 func participationKeyForEventAndAddressPrefix(eventID EventID, addressBytes []byte) []byte {
 	m := marshalutil.New(66)
-	m.WriteByte(ParticipationStoreKeyPrefixTrackedOutputByAddress) // 1 byte
-	m.WriteBytes(eventID[:])                                       // 32 bytes
+	m.WriteBytes(participationKeyForEventPrefix(eventID)) // 33 bytes
 	m.WriteBytes(addressBytes)                                     // 33 bytes
 	return m.Bytes()
 }

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -156,7 +156,7 @@ func participationKeyForEventPrefix(eventID EventID) []byte {
 func participationKeyForEventAndAddressPrefix(eventID EventID, addressBytes []byte) []byte {
 	m := marshalutil.New(66)
 	m.WriteBytes(participationKeyForEventPrefix(eventID)) // 33 bytes
-	m.WriteBytes(addressBytes)                                     // 33 bytes
+	m.WriteBytes(addressBytes)                            // 33 bytes
 	return m.Bytes()
 }
 

--- a/pkg/model/participation/participation_store.go
+++ b/pkg/model/participation/participation_store.go
@@ -527,24 +527,22 @@ func (pm *ParticipationManager) RewardsForTrackedParticipation(trackedParticipat
 
 	eventMilestoneCountingStart := event.StartMilestoneIndex() + 1
 
-	var milestonesToCount uint64
-	var milestonesToSubtract uint64
-
-	if trackedParticipation.EndIndex == 0 || atIndex < trackedParticipation.EndIndex {
-		// Participation has not ended yet or we are asking for the past of an ended participation, so count including the atIndex milestone
-		milestonesToCount = uint64(atIndex + 1 - trackedParticipation.StartIndex)
-	} else {
-		// Participation ended
-		milestonesToCount = uint64(trackedParticipation.EndIndex - trackedParticipation.StartIndex)
+	if eventMilestoneCountingStart < trackedParticipation.StartIndex {
+		eventMilestoneCountingStart = trackedParticipation.StartIndex
 	}
 
-	if trackedParticipation.StartIndex < eventMilestoneCountingStart {
-		// Subtract the commencing milestones, minus the start itself
-		milestonesToSubtract = uint64(eventMilestoneCountingStart - trackedParticipation.StartIndex)
+	var milestonesToCount uint64
+
+	if trackedParticipation.EndIndex == 0 || atIndex < trackedParticipation.EndIndex {
+		// Participation has not ended yet, or we are asking for the past of an ended participation, so count including the atIndex milestone
+		milestonesToCount = uint64(atIndex + 1 - eventMilestoneCountingStart)
+	} else {
+		// Participation ended
+		milestonesToCount = uint64(trackedParticipation.EndIndex - eventMilestoneCountingStart)
 	}
 
 	rewardsPerMilestone := staking.rewardsPerMilestone(trackedParticipation.Amount)
-	rewardsForParticipation := rewardsPerMilestone * (milestonesToCount - milestonesToSubtract)
+	rewardsForParticipation := rewardsPerMilestone * milestonesToCount
 	return rewardsForParticipation, nil
 }
 

--- a/pkg/model/participation/staking_rewards_test.go
+++ b/pkg/model/participation/staking_rewards_test.go
@@ -1,0 +1,445 @@
+package participation_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gohornet/hornet/pkg/model/hornet"
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	"github.com/gohornet/hornet/pkg/model/participation"
+	"github.com/gohornet/hornet/pkg/model/participation/test"
+)
+
+/*
+A: (5 Milestones) = 6 (staked) 7 8 9 10 (event start) 11 12 13 14 15 (event end)
+B: (3 Milestones) = 6 (staked) 7 8 9 10 (event start) 11 12 13 (spent) 14 15 (event end)
+C: (3+1 Milestones) = 6 (staked) 7 8 9 10 (event start) 11 12 13 (spent) 14 (staked) 15 (event end)
+D: (3+1 Milestones) = 6 (staked) 7 8 9 10 (event start) 11 12 13 (spent) (staked) 14 (spent) 15 (event end)
+E: (5 Milestones) = 6 7 8 9 10 (event start) (staked) 11 12 13 14 15 (event end)
+F: (3 Milestones) = 6 7 8 9 10 (event start) (staked) 11 12 13 (spent) 14 15 (event end)
+G: (3+2 Milestones) = 6 7 8 9 10 (event start) (staked) 11 12 13 (spent) (staked) 14 15 (event end)
+H: (3+1 Milestones) = 6 7 8 9 10 (event start) (staked) 11 12 13 (spent) (staked) 14 (spent) 15 (event end)
+I: (3 Milestones) = 6 7 8 9 10 (event start) 11 12 (staked) 13 14 15 (event end)
+J: (1 Milestones) = 6 7 8 9 10 (event start) 11 12 (staked) 13 (spent) 14 15 (event end)
+K: (1+2 Milestones) = 6 7 8 9 10 (event start) 11 12 (staked) 13 (spent) (staked) 14 15 (event end)
+*/
+
+type stakingTestEnv struct {
+	env     *test.ParticipationTestEnv
+	eventID participation.EventID
+}
+
+func stakingEnv(t *testing.T) *stakingTestEnv {
+	env := test.NewParticipationTestEnv(t, 1_000_000, 1_000_000, 1_000_000, 1_000_000, false)
+
+	confirmedMilestoneIndex := env.ConfirmedMilestoneIndex() // 4
+	require.Equal(t, milestone.Index(4), confirmedMilestoneIndex)
+
+	eventBuilder := participation.NewEventBuilder("AlbinoPugCoin", 6, 10, 15, "The first DogCoin on the Tangle")
+	eventBuilder.Payload(&participation.Staking{
+		Text:           "The rarest DogCoin on earth",
+		Symbol:         "APUG",
+		Numerator:      1,
+		Denominator:    1,
+		AdditionalInfo: "Have you seen an albino Pug?",
+	})
+
+	event, err := eventBuilder.Build()
+	require.NoError(t, err)
+
+	eventID, err := env.ParticipationManager().StoreEvent(event)
+	require.NoError(t, err)
+
+	// Verify the configured indexes
+	require.Equal(t, milestone.Index(6), event.CommenceMilestoneIndex())
+	require.Equal(t, milestone.Index(10), event.StartMilestoneIndex())
+	require.Equal(t, milestone.Index(15), event.EndMilestoneIndex())
+
+	env.IssueMilestone() // 5
+	require.Equal(t, milestone.Index(5), env.ConfirmedMilestoneIndex())
+
+	env.AssertEventsCount(0, 0)
+	env.IssueMilestone() // 6
+	env.AssertEventsCount(1, 0)
+
+	return &stakingTestEnv{
+		env:     env,
+		eventID: eventID,
+	}
+}
+
+func (s *stakingTestEnv) Cleanup() {
+	s.env.Cleanup()
+}
+
+func (s *stakingTestEnv) StakeWalletAndIssueMilestone() {
+	p := s.env.NewParticipationHelper(s.env.Wallet1).
+		WholeWalletBalance().
+		AddParticipation(&participation.Participation{
+			EventID: s.eventID,
+			Answers: []byte{},
+		}).
+		Send()
+	s.IssueMilestone(p.Message().StoredMessageID())
+}
+
+func (s *stakingTestEnv) StakeWalletThenIncreaseBalanceAndIssueMilestone() {
+	p := s.env.NewParticipationHelper(s.env.Wallet1).
+		WholeWalletBalance().
+		AddParticipation(&participation.Participation{
+			EventID: s.eventID,
+			Answers: []byte{},
+		}).
+		Send()
+
+	t := s.env.Transfer(s.env.GenesisWallet, s.env.Wallet1, 1_500_000)
+	s.IssueMilestone(p.Message().StoredMessageID(), t.StoredMessageID())
+	s.AssertWalletBalance(2_500_000)
+}
+
+func (s *stakingTestEnv) CancelStakingAndIssueMilestone() {
+	cancelStake := s.env.CancelParticipations(s.env.Wallet1)
+	s.IssueMilestone(cancelStake.StoredMessageID())
+}
+
+func (s *stakingTestEnv) IncreaseWalletBalanceAndIssueMilestone() {
+	transfer := s.env.Transfer(s.env.GenesisWallet, s.env.Wallet1, 1_500_000)
+	s.IssueMilestone(transfer.StoredMessageID())
+	s.AssertWalletBalance(2_500_000)
+}
+
+func (s *stakingTestEnv) IssueMilestone(parents ...hornet.MessageID) {
+	s.env.IssueMilestone(parents...)
+}
+
+func (s *stakingTestEnv) AssertEventNotCounting() {
+	s.env.AssertEventsCount(1, 0)
+}
+
+func (s *stakingTestEnv) AssertEventCounting() {
+	s.env.AssertEventsCount(1, 1)
+}
+
+func (s *stakingTestEnv) AssertEventEnded() {
+	s.env.AssertEventsCount(0, 0)
+}
+
+func (s *stakingTestEnv) AssertWalletBalance(expected uint64) {
+	s.env.AssertWalletBalance(s.env.Wallet1, expected)
+}
+
+func (s *stakingTestEnv) AssertWalletRewards(expected uint64) {
+	s.env.AssertRewardBalance(s.eventID, s.env.Wallet1.Address(), expected)
+}
+
+func (s *stakingTestEnv) AssertTotalRewards(staked uint64, rewarded uint64) {
+	s.env.AssertStakingRewardsStatusAtConfirmedMilestoneIndex(s.eventID, staked, rewarded)
+}
+
+func TestStakeCaseA(t *testing.T) {
+
+	// A: (5 Milestones) = 6 (staked) 7 8 9 10 (event start) 11 12 13 14 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.StakeWalletAndIssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.AssertWalletRewards(0)
+	env.AssertTotalRewards(1_000_000, 0)
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.IssueMilestone() // 11
+	env.IssueMilestone() // 12
+	env.IssueMilestone() // 13
+	env.IssueMilestone() // 14
+	env.IssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(5_000_000)
+	env.AssertTotalRewards(1_000_000, 5_000_000)
+}
+
+func TestStakeCaseB(t *testing.T) {
+
+	// B: (3 Milestones) = 6 (staked) 7 8 9 10 (event start) 11 12 13 (spent) 14 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.StakeWalletAndIssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.AssertWalletRewards(0)
+	env.AssertTotalRewards(1_000_000, 0)
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.IssueMilestone()                 // 11
+	env.IssueMilestone()                 // 12
+	env.IssueMilestone()                 // 13
+	env.CancelStakingAndIssueMilestone() // 14
+	env.AssertTotalRewards(0, 3_000_000)
+	env.IssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(3_000_000)
+	env.AssertTotalRewards(0, 3_000_000)
+}
+
+func TestStakeCaseC(t *testing.T) {
+
+	// C: (3+1 Milestones) = 6 (staked) 7 8 9 10 (event start) 11 12 13 (spent) 14 (staked) 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.StakeWalletAndIssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.AssertWalletRewards(0)
+	env.AssertTotalRewards(1_000_000, 0)
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.IssueMilestone()                         // 11
+	env.IncreaseWalletBalanceAndIssueMilestone() // 12
+	env.IssueMilestone()                         // 13
+	env.CancelStakingAndIssueMilestone()         // 14
+	env.AssertTotalRewards(0, 3_000_000)
+	env.StakeWalletAndIssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(5_500_000)
+	env.AssertTotalRewards(2_500_000, 5_500_000)
+}
+
+func TestStakeCaseD(t *testing.T) {
+
+	// D: (3+1 Milestones) = 6 (staked) 7 8 9 10 (event start) 11 12 13 (spent) (staked) 14 (spent) 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.StakeWalletAndIssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.AssertWalletRewards(0)
+	env.AssertTotalRewards(1_000_000, 0)
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.IssueMilestone()                         // 11
+	env.IncreaseWalletBalanceAndIssueMilestone() // 12
+	env.IssueMilestone()                         // 13
+	env.StakeWalletAndIssueMilestone()           // 14
+	env.AssertTotalRewards(2_500_000, 5_500_000)
+	env.CancelStakingAndIssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(5_500_000)
+	env.AssertTotalRewards(0, 5_500_000)
+}
+
+func TestStakeCaseE(t *testing.T) {
+
+	// E: (5 Milestones) = 6 7 8 9 10 (event start) (staked) 11 12 13 14 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.IssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.StakeWalletAndIssueMilestone() // 11
+	env.AssertWalletRewards(1_000_000)
+	env.AssertTotalRewards(1_000_000, 1_000_000)
+	env.IssueMilestone() // 12
+	env.IssueMilestone() // 13
+	env.IssueMilestone() // 14
+	env.IssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(5_000_000)
+	env.AssertTotalRewards(1_000_000, 5_000_000)
+}
+
+func TestStakeCaseF(t *testing.T) {
+
+	// F: (3 Milestones) = 6 7 8 9 10 (event start) (staked) 11 12 13 (spent) 14 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.IssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.StakeWalletAndIssueMilestone() // 11
+	env.AssertWalletRewards(1_000_000)
+	env.AssertTotalRewards(1_000_000, 1_000_000)
+	env.IssueMilestone()                 // 12
+	env.IssueMilestone()                 // 13
+	env.CancelStakingAndIssueMilestone() // 14
+	env.AssertTotalRewards(0, 3_000_000)
+	env.IssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(3_000_000)
+	env.AssertTotalRewards(0, 3_000_000)
+}
+
+func TestStakeCaseG(t *testing.T) {
+
+	// G: (3+2 Milestones) = 6 7 8 9 10 (event start) (staked) 11 12 13 (spent) (staked) 14 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.IssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.StakeWalletAndIssueMilestone() // 11
+	env.AssertWalletRewards(1_000_000)
+	env.AssertTotalRewards(1_000_000, 1_000_000)
+	env.IncreaseWalletBalanceAndIssueMilestone() // 12
+	env.IssueMilestone()                         // 13
+	env.StakeWalletAndIssueMilestone()           // 14
+	env.AssertTotalRewards(2_500_000, 5_500_000)
+	env.IssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(8_000_000)
+	env.AssertTotalRewards(2_500_000, 8_000_000)
+}
+
+func TestStakeCaseH(t *testing.T) {
+
+	// H: (3+1 Milestones) = 6 7 8 9 10 (event start) (staked) 11 12 13 (spent) (staked) 14 (spent) 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.IssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.StakeWalletAndIssueMilestone() // 11
+	env.AssertWalletRewards(1_000_000)
+	env.AssertTotalRewards(1_000_000, 1_000_000)
+	env.IncreaseWalletBalanceAndIssueMilestone() // 12
+	env.IssueMilestone()                         // 13
+	env.StakeWalletAndIssueMilestone()           // 14
+	env.AssertTotalRewards(2_500_000, 5_500_000)
+	env.CancelStakingAndIssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(5_500_000)
+	env.AssertTotalRewards(0, 5_500_000)
+}
+
+func TestStakeCaseI(t *testing.T) {
+
+	// I: (3 Milestones) = 6 7 8 9 10 (event start) 11 12 (staked) 13 14 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.IssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.IssueMilestone()               // 11
+	env.IssueMilestone()               // 12
+	env.StakeWalletAndIssueMilestone() // 13
+	env.AssertWalletRewards(1_000_000)
+	env.AssertTotalRewards(1_000_000, 1_000_000)
+	env.IssueMilestone() // 14
+	env.IssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(3_000_000)
+	env.AssertTotalRewards(1_000_000, 3_000_000)
+}
+
+func TestStakeCaseJ(t *testing.T) {
+
+	// J: (1 Milestones) = 6 7 8 9 10 (event start) 11 12 (staked) 13 (spent) 14 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.IssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.IssueMilestone()               // 11
+	env.IssueMilestone()               // 12
+	env.StakeWalletAndIssueMilestone() // 13
+	env.AssertWalletRewards(1_000_000)
+	env.AssertTotalRewards(1_000_000, 1_000_000)
+	env.CancelStakingAndIssueMilestone() // 14
+	env.AssertWalletRewards(1_000_000)
+	env.AssertTotalRewards(0, 1_000_000)
+	env.IssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(1_000_000)
+	env.AssertTotalRewards(0, 1_000_000)
+}
+
+func TestStakeCaseK(t *testing.T) {
+
+	// K: (1+2 Milestones) = 6 7 8 9 10 (event start) 11 12 (staked) 13 (spent) (staked) 14 15 (event end)
+
+	env := stakingEnv(t)
+	defer env.Cleanup()
+
+	env.IssueMilestone() // 7
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 8
+	env.IssueMilestone() // 9
+	env.AssertEventNotCounting()
+	env.IssueMilestone() // 10
+	env.AssertEventCounting()
+	env.IssueMilestone()                                  // 11
+	env.IssueMilestone()                                  // 12
+	env.StakeWalletThenIncreaseBalanceAndIssueMilestone() // 13
+	env.AssertWalletRewards(1_000_000)
+	env.AssertTotalRewards(1_000_000, 1_000_000)
+	env.StakeWalletAndIssueMilestone() // 14
+	env.AssertWalletRewards(3_500_000)
+	env.AssertTotalRewards(2_500_000, 3_500_000)
+	env.IssueMilestone() // 15
+	env.AssertEventEnded()
+
+	env.AssertWalletRewards(6_000_000)
+	env.AssertTotalRewards(2_500_000, 6_000_000)
+}

--- a/pkg/model/participation/staking_rewards_test.go
+++ b/pkg/model/participation/staking_rewards_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/model/participation"
 	"github.com/gohornet/hornet/pkg/model/participation/test"
+	iotago "github.com/iotaledger/iota.go/v2"
 )
 
 /*
@@ -133,6 +134,10 @@ func (s *stakingTestEnv) AssertWalletRewards(expected uint64) {
 	s.env.AssertRewardBalance(s.eventID, s.env.Wallet1.Address(), expected)
 }
 
+func (s *stakingTestEnv) AssertWalletRewardsAtIndex(expected uint64, milestoneIndex milestone.Index) {
+	s.env.AssertRewardBalance(s.eventID, s.env.Wallet1.Address(), expected, milestoneIndex)
+}
+
 func (s *stakingTestEnv) AssertTotalRewards(staked uint64, rewarded uint64) {
 	s.env.AssertStakingRewardsStatusAtConfirmedMilestoneIndex(s.eventID, staked, rewarded)
 }
@@ -159,9 +164,16 @@ func TestStakeCaseA(t *testing.T) {
 	env.IssueMilestone() // 14
 	env.IssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
 
 	env.AssertWalletRewards(5_000_000)
 	env.AssertTotalRewards(1_000_000, 5_000_000)
+
+	env.AssertWalletRewardsAtIndex(1_000_000, 11)
+	env.AssertWalletRewardsAtIndex(2_000_000, 12)
+	env.AssertWalletRewardsAtIndex(3_000_000, 13)
+	env.AssertWalletRewardsAtIndex(4_000_000, 14)
+	env.AssertWalletRewardsAtIndex(5_000_000, 15)
 }
 
 func TestStakeCaseB(t *testing.T) {
@@ -187,6 +199,13 @@ func TestStakeCaseB(t *testing.T) {
 	env.AssertTotalRewards(0, 3_000_000)
 	env.IssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
+
+	env.AssertWalletRewardsAtIndex(1_000_000, 11)
+	env.AssertWalletRewardsAtIndex(2_000_000, 12)
+	env.AssertWalletRewardsAtIndex(3_000_000, 13)
+	env.AssertWalletRewardsAtIndex(3_000_000, 14)
+	env.AssertWalletRewardsAtIndex(3_000_000, 15)
 
 	env.AssertWalletRewards(3_000_000)
 	env.AssertTotalRewards(0, 3_000_000)
@@ -215,6 +234,13 @@ func TestStakeCaseC(t *testing.T) {
 	env.AssertTotalRewards(0, 3_000_000)
 	env.StakeWalletAndIssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
+
+	env.AssertWalletRewardsAtIndex(1_000_000, 11)
+	env.AssertWalletRewardsAtIndex(2_000_000, 12)
+	env.AssertWalletRewardsAtIndex(3_000_000, 13)
+	env.AssertWalletRewardsAtIndex(3_000_000, 14)
+	env.AssertWalletRewardsAtIndex(5_500_000, 15)
 
 	env.AssertWalletRewards(5_500_000)
 	env.AssertTotalRewards(2_500_000, 5_500_000)
@@ -243,6 +269,13 @@ func TestStakeCaseD(t *testing.T) {
 	env.AssertTotalRewards(2_500_000, 5_500_000)
 	env.CancelStakingAndIssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
+
+	env.AssertWalletRewardsAtIndex(1_000_000, 11)
+	env.AssertWalletRewardsAtIndex(2_000_000, 12)
+	env.AssertWalletRewardsAtIndex(3_000_000, 13)
+	env.AssertWalletRewardsAtIndex(5_500_000, 14)
+	env.AssertWalletRewardsAtIndex(5_500_000, 15)
 
 	env.AssertWalletRewards(5_500_000)
 	env.AssertTotalRewards(0, 5_500_000)
@@ -270,6 +303,13 @@ func TestStakeCaseE(t *testing.T) {
 	env.IssueMilestone() // 14
 	env.IssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
+
+	env.AssertWalletRewardsAtIndex(1_000_000, 11)
+	env.AssertWalletRewardsAtIndex(2_000_000, 12)
+	env.AssertWalletRewardsAtIndex(3_000_000, 13)
+	env.AssertWalletRewardsAtIndex(4_000_000, 14)
+	env.AssertWalletRewardsAtIndex(5_000_000, 15)
 
 	env.AssertWalletRewards(5_000_000)
 	env.AssertTotalRewards(1_000_000, 5_000_000)
@@ -298,6 +338,13 @@ func TestStakeCaseF(t *testing.T) {
 	env.AssertTotalRewards(0, 3_000_000)
 	env.IssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
+
+	env.AssertWalletRewardsAtIndex(1_000_000, 11)
+	env.AssertWalletRewardsAtIndex(2_000_000, 12)
+	env.AssertWalletRewardsAtIndex(3_000_000, 13)
+	env.AssertWalletRewardsAtIndex(3_000_000, 14)
+	env.AssertWalletRewardsAtIndex(3_000_000, 15)
 
 	env.AssertWalletRewards(3_000_000)
 	env.AssertTotalRewards(0, 3_000_000)
@@ -326,6 +373,13 @@ func TestStakeCaseG(t *testing.T) {
 	env.AssertTotalRewards(2_500_000, 5_500_000)
 	env.IssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
+
+	env.AssertWalletRewardsAtIndex(1_000_000, 11)
+	env.AssertWalletRewardsAtIndex(2_000_000, 12)
+	env.AssertWalletRewardsAtIndex(3_000_000, 13)
+	env.AssertWalletRewardsAtIndex(5_500_000, 14)
+	env.AssertWalletRewardsAtIndex(8_000_000, 15)
 
 	env.AssertWalletRewards(8_000_000)
 	env.AssertTotalRewards(2_500_000, 8_000_000)
@@ -354,6 +408,13 @@ func TestStakeCaseH(t *testing.T) {
 	env.AssertTotalRewards(2_500_000, 5_500_000)
 	env.CancelStakingAndIssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
+
+	env.AssertWalletRewardsAtIndex(1_000_000, 11)
+	env.AssertWalletRewardsAtIndex(2_000_000, 12)
+	env.AssertWalletRewardsAtIndex(3_000_000, 13)
+	env.AssertWalletRewardsAtIndex(5_500_000, 14)
+	env.AssertWalletRewardsAtIndex(5_500_000, 15)
 
 	env.AssertWalletRewards(5_500_000)
 	env.AssertTotalRewards(0, 5_500_000)
@@ -381,6 +442,12 @@ func TestStakeCaseI(t *testing.T) {
 	env.IssueMilestone() // 14
 	env.IssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
+
+	env.AssertWalletRewardsAtIndex(0, 12)
+	env.AssertWalletRewardsAtIndex(1_000_000, 13)
+	env.AssertWalletRewardsAtIndex(2_000_000, 14)
+	env.AssertWalletRewardsAtIndex(3_000_000, 15)
 
 	env.AssertWalletRewards(3_000_000)
 	env.AssertTotalRewards(1_000_000, 3_000_000)
@@ -410,6 +477,12 @@ func TestStakeCaseJ(t *testing.T) {
 	env.AssertTotalRewards(0, 1_000_000)
 	env.IssueMilestone() // 15
 	env.AssertEventEnded()
+	env.IssueMilestone() // 16
+
+	env.AssertWalletRewardsAtIndex(0, 12)
+	env.AssertWalletRewardsAtIndex(1_000_000, 13)
+	env.AssertWalletRewardsAtIndex(1_000_000, 14)
+	env.AssertWalletRewardsAtIndex(1_000_000, 15)
 
 	env.AssertWalletRewards(1_000_000)
 	env.AssertTotalRewards(0, 1_000_000)
@@ -440,6 +513,72 @@ func TestStakeCaseK(t *testing.T) {
 	env.IssueMilestone() // 15
 	env.AssertEventEnded()
 
+	env.AssertWalletRewardsAtIndex(0, 12)
+	env.AssertWalletRewardsAtIndex(1_000_000, 13)
+	env.AssertWalletRewardsAtIndex(3_500_000, 14)
+	env.AssertWalletRewardsAtIndex(6_000_000, 15)
+
 	env.AssertWalletRewards(6_000_000)
 	env.AssertTotalRewards(2_500_000, 6_000_000)
+}
+
+func TestTotalRewards(t *testing.T) {
+
+	participations := []struct {
+		amount     uint64
+		startIndex milestone.Index
+		endIndex   milestone.Index
+	}{
+		{138706054, 2426818, 2430387},
+		{88706054, 2430415, 2664079},
+		{199602671, 2664096, 2679429},
+		{200000000, 2679439, 2689571},
+		{50000000, 2689596, 2712115},
+		{5000000, 2712137, 2732909},
+		{2500000, 2732925, 2733841},
+		{1500000, 2733850, 0},
+	}
+
+	assertTotalRewardsFromParticipations(t, participations, 2815845, 110455992)
+}
+
+func assertTotalRewardsFromParticipations(t *testing.T, participations []struct {
+	amount     uint64
+	startIndex milestone.Index
+	endIndex   milestone.Index
+}, milestoneIndexToCalculate milestone.Index, expectedRewards uint64) {
+
+	env := test.NewParticipationTestEnv(t, 1_000_000, 1_000_000, 1_000_000, 1_000_000, false)
+	defer env.Cleanup()
+
+	eventBuilder := participation.NewEventBuilder("AlbinoPugCoin", 2041634, 2102114, 2879714, "The first DogCoin on the Tangle")
+	eventBuilder.Payload(&participation.Staking{
+		Text:           "The rarest DogCoin on earth",
+		Symbol:         "APUG",
+		Numerator:      4,
+		Denominator:    1000000,
+		AdditionalInfo: "Have you seen an albino Pug?",
+	})
+
+	event, err := eventBuilder.Build()
+	require.NoError(t, err)
+
+	eventID, err := env.ParticipationManager().StoreEvent(event)
+	require.NoError(t, err)
+
+	var sum uint64
+	for _, p := range participations {
+		rewards, err := env.ParticipationManager().RewardsForTrackedParticipation(&participation.TrackedParticipation{
+			EventID:    eventID,
+			OutputID:   &iotago.UTXOInputID{},
+			MessageID:  hornet.NullMessageID(),
+			Amount:     p.amount,
+			StartIndex: p.startIndex,
+			EndIndex:   p.endIndex,
+		}, milestoneIndexToCalculate)
+		require.NoError(t, err)
+		sum += rewards
+	}
+
+	require.Equal(t, int(expectedRewards), int(sum)) // converting to int to have a readable test output
 }

--- a/pkg/model/participation/test/testenv.go
+++ b/pkg/model/participation/test/testenv.go
@@ -365,3 +365,7 @@ func (env *ParticipationTestEnv) AssertRewardBalance(eventID participation.Event
 	require.NoError(env.t, err)
 	require.Exactly(env.t, balance, rewards)
 }
+
+func (env *ParticipationTestEnv) AssertWalletBalance(wallet *utils.HDWallet, expectedBalance uint64) {
+	env.te.AssertWalletBalance(wallet, expectedBalance)
+}

--- a/pkg/model/participation/test/testenv.go
+++ b/pkg/model/participation/test/testenv.go
@@ -361,7 +361,7 @@ func (env *ParticipationTestEnv) AssertInvalidParticipation(eventID participatio
 }
 
 func (env *ParticipationTestEnv) AssertRewardBalance(eventID participation.EventID, address iotago.Address, balance uint64) {
-	rewards, err := env.ParticipationManager().StakingRewardForAddress(eventID, address)
+	rewards, err := env.ParticipationManager().StakingRewardForAddress(eventID, address, env.ConfirmedMilestoneIndex())
 	require.NoError(env.t, err)
 	require.Exactly(env.t, balance, rewards)
 }

--- a/pkg/model/participation/test/testenv.go
+++ b/pkg/model/participation/test/testenv.go
@@ -137,14 +137,13 @@ func NewParticipationTestEnv(t *testing.T, wallet1Balance uint64, wallet2Balance
 
 	// Connect the callbacks from the testsuite to the ParticipationManager
 	te.ConfigureUTXOCallbacks(
-		func(index milestone.Index, output *utxo.Output) {
-			require.NoError(t, pm.ApplyNewUTXO(index, output))
-		},
-		func(index milestone.Index, spent *utxo.Spent) {
-			require.NoError(t, pm.ApplySpentUTXO(index, spent))
-		},
 		nil,
-		func(index milestone.Index) {
+		nil,
+		nil,
+		nil,
+		func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
+			require.NoError(t, pm.ApplyNewUTXOs(index, newOutputs))
+			require.NoError(t, pm.ApplySpentUTXOs(index, newSpents))
 			require.NoError(t, pm.ApplyNewConfirmedMilestoneIndex(index))
 		},
 	)

--- a/pkg/model/participation/test/testenv.go
+++ b/pkg/model/participation/test/testenv.go
@@ -142,9 +142,7 @@ func NewParticipationTestEnv(t *testing.T, wallet1Balance uint64, wallet2Balance
 		nil,
 		nil,
 		func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
-			require.NoError(t, pm.ApplyNewUTXOs(index, newOutputs))
-			require.NoError(t, pm.ApplySpentUTXOs(index, newSpents))
-			require.NoError(t, pm.ApplyNewConfirmedMilestoneIndex(index))
+			require.NoError(t, pm.ApplyNewLedgerUpdate(index, newOutputs, newSpents))
 		},
 	)
 

--- a/pkg/model/participation/test/testenv.go
+++ b/pkg/model/participation/test/testenv.go
@@ -138,9 +138,6 @@ func NewParticipationTestEnv(t *testing.T, wallet1Balance uint64, wallet2Balance
 	// Connect the callbacks from the testsuite to the ParticipationManager
 	te.ConfigureUTXOCallbacks(
 		nil,
-		nil,
-		nil,
-		nil,
 		func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
 			require.NoError(t, pm.ApplyNewLedgerUpdate(index, newOutputs, newSpents))
 		},

--- a/pkg/tangle/events.go
+++ b/pkg/tangle/events.go
@@ -31,6 +31,10 @@ func MPSMetricsCaller(handler interface{}, params ...interface{}) {
 	handler.(func(*MPSMetrics))(params[0].(*MPSMetrics))
 }
 
+func LedgerUpdatedCaller(handler interface{}, params ...interface{}) {
+	handler.(func(milestone.Index, utxo.Outputs, utxo.Spents))(params[0].(milestone.Index), params[1].(utxo.Outputs), params[2].(utxo.Spents))
+}
+
 func UTXOOutputCaller(handler interface{}, params ...interface{}) {
 	handler.(func(milestone.Index, *utxo.Output))(params[0].(milestone.Index), params[1].(*utxo.Output))
 }
@@ -60,6 +64,7 @@ type Events struct {
 	ConfirmationMetricsUpdated     *events.Event
 	MilestoneSolidificationFailed  *events.Event
 	MilestoneTimeout               *events.Event
+	LedgerUpdated                  *events.Event
 	NewUTXOOutput                  *events.Event
 	NewUTXOSpent                   *events.Event
 	NewReceipt                     *events.Event

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -328,6 +328,9 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 			t.Events.MilestoneConfirmed.Trigger(confirmation)
 			timeMilestoneConfirmed = time.Now()
 		},
+		func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
+			t.Events.LedgerUpdated.Trigger(index, newOutputs, newSpents)
+		},
 		func(index milestone.Index, output *utxo.Output) {
 			t.Events.NewUTXOOutput.Trigger(index, output)
 		},

--- a/pkg/tangle/tangle.go
+++ b/pkg/tangle/tangle.go
@@ -172,6 +172,7 @@ func New(
 			ConfirmationMetricsUpdated:     events.NewEvent(ConfirmationMetricsCaller),
 			MilestoneSolidificationFailed:  events.NewEvent(milestone.IndexCaller),
 			MilestoneTimeout:               events.NewEvent(events.VoidCaller),
+			LedgerUpdated:                  events.NewEvent(LedgerUpdatedCaller),
 			NewUTXOOutput:                  events.NewEvent(UTXOOutputCaller),
 			NewUTXOSpent:                   events.NewEvent(UTXOSpentCaller),
 			NewReceipt:                     events.NewEvent(ReceiptCaller),

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -100,6 +100,7 @@ func (te *TestEnvironment) configureCoordinator(cooPrivateKeys []ed25519.Private
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	require.NoError(te.TestInterface, err)
 	require.Equal(te.TestInterface, 1, confirmedMilestoneStats.MessagesReferenced)
@@ -158,6 +159,11 @@ func (te *TestEnvironment) IssueAndConfirmMilestoneOnTips(tips hornet.MessageIDs
 			}
 			if te.OnConfirmedMilestoneIndexChanged != nil {
 				te.OnConfirmedMilestoneIndexChanged(confirmation.MilestoneIndex)
+			}
+		},
+		func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
+			if te.OnLedgerUpdatedFunc != nil {
+				te.OnLedgerUpdatedFunc(index, newOutputs, newSpents)
 			}
 		},
 		func(index milestone.Index, output *utxo.Output) {

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -157,25 +157,14 @@ func (te *TestEnvironment) IssueAndConfirmMilestoneOnTips(tips hornet.MessageIDs
 			if te.OnMilestoneConfirmed != nil {
 				te.OnMilestoneConfirmed(confirmation)
 			}
-			if te.OnConfirmedMilestoneIndexChanged != nil {
-				te.OnConfirmedMilestoneIndexChanged(confirmation.MilestoneIndex)
-			}
 		},
 		func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
 			if te.OnLedgerUpdatedFunc != nil {
 				te.OnLedgerUpdatedFunc(index, newOutputs, newSpents)
 			}
 		},
-		func(index milestone.Index, output *utxo.Output) {
-			if te.OnNewOutput != nil {
-				te.OnNewOutput(index, output)
-			}
-		},
-		func(index milestone.Index, spent *utxo.Spent) {
-			if te.OnNewSpent != nil {
-				te.OnNewSpent(index, spent)
-			}
-		},
+		nil,
+		nil,
 		nil,
 	)
 	require.NoError(te.TestInterface, err)

--- a/pkg/testsuite/test_environment.go
+++ b/pkg/testsuite/test_environment.go
@@ -84,26 +84,14 @@ type TestEnvironment struct {
 	// GenesisOutput marks the initial output created when bootstrapping the tangle.
 	GenesisOutput *utxo.Output
 
-	// OnNewOutput callback that will be called for each created UTXO. This is equivalent to the tangle.NewUTXOOutput event.
-	OnNewOutput OnNewOutputFunc
-
-	// OnNewSpent callback that will be called for each spent UTXO. This is equivalent to the tangle.NewUTXOSpent event.
-	OnNewSpent OnNewSpentFunc
-
 	// OnMilestoneConfirmed callback that will be called at confirming a milestone. This is equivalent to the tangle.MilestoneConfirmed event.
 	OnMilestoneConfirmed OnMilestoneConfirmedFunc
-
-	// OnConfirmedMilestoneIndexChanged callback that will be called after confirming a milestone. This is equivalent to the tangle.ConfirmedMilestoneIndexChanged event.
-	OnConfirmedMilestoneIndexChanged OnConfirmedMilestoneIndexChangedFunc
 
 	// OnLedgerUpdatedFunc callback that will be called after the ledger gets updating during confirmation. This is equivalent to the tangle.LedgerUpdated event.
 	OnLedgerUpdatedFunc OnLedgerUpdatedFunc
 }
 
-type OnNewOutputFunc func(index milestone.Index, output *utxo.Output)
-type OnNewSpentFunc func(index milestone.Index, spent *utxo.Spent)
 type OnMilestoneConfirmedFunc func(confirmation *whiteflag.Confirmation)
-type OnConfirmedMilestoneIndexChangedFunc func(index milestone.Index)
 type OnLedgerUpdatedFunc func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents)
 
 // SetupTestEnvironment initializes a clean database with initial snapshot,
@@ -189,11 +177,8 @@ func SetupTestEnvironment(testInterface testing.TB, genesisAddress *iotago.Ed255
 	return te
 }
 
-func (te *TestEnvironment) ConfigureUTXOCallbacks(onNewOutputFunc OnNewOutputFunc, onNewSpentFunc OnNewSpentFunc, onMilestoneConfirmedFunc OnMilestoneConfirmedFunc, onConfirmedMilestoneIndexChanged OnConfirmedMilestoneIndexChangedFunc, onLedgerUpdatedFunc OnLedgerUpdatedFunc) {
-	te.OnNewOutput = onNewOutputFunc
-	te.OnNewSpent = onNewSpentFunc
+func (te *TestEnvironment) ConfigureUTXOCallbacks(onMilestoneConfirmedFunc OnMilestoneConfirmedFunc, onLedgerUpdatedFunc OnLedgerUpdatedFunc) {
 	te.OnMilestoneConfirmed = onMilestoneConfirmedFunc
-	te.OnConfirmedMilestoneIndexChanged = onConfirmedMilestoneIndexChanged
 	te.OnLedgerUpdatedFunc = onLedgerUpdatedFunc
 }
 

--- a/pkg/testsuite/test_environment.go
+++ b/pkg/testsuite/test_environment.go
@@ -95,12 +95,16 @@ type TestEnvironment struct {
 
 	// OnConfirmedMilestoneIndexChanged callback that will be called after confirming a milestone. This is equivalent to the tangle.ConfirmedMilestoneIndexChanged event.
 	OnConfirmedMilestoneIndexChanged OnConfirmedMilestoneIndexChangedFunc
+
+	// OnLedgerUpdatedFunc callback that will be called after the ledger gets updating during confirmation. This is equivalent to the tangle.LedgerUpdated event.
+	OnLedgerUpdatedFunc OnLedgerUpdatedFunc
 }
 
 type OnNewOutputFunc func(index milestone.Index, output *utxo.Output)
 type OnNewSpentFunc func(index milestone.Index, spent *utxo.Spent)
 type OnMilestoneConfirmedFunc func(confirmation *whiteflag.Confirmation)
 type OnConfirmedMilestoneIndexChangedFunc func(index milestone.Index)
+type OnLedgerUpdatedFunc func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents)
 
 // SetupTestEnvironment initializes a clean database with initial snapshot,
 // configures a coordinator with a clean state, bootstraps the network and issues the first "numberOfMilestones" milestones.
@@ -185,11 +189,12 @@ func SetupTestEnvironment(testInterface testing.TB, genesisAddress *iotago.Ed255
 	return te
 }
 
-func (te *TestEnvironment) ConfigureUTXOCallbacks(onNewOutputFunc OnNewOutputFunc, onNewSpentFunc OnNewSpentFunc, onMilestoneConfirmedFunc OnMilestoneConfirmedFunc, onConfirmedMilestoneIndexChanged OnConfirmedMilestoneIndexChangedFunc) {
+func (te *TestEnvironment) ConfigureUTXOCallbacks(onNewOutputFunc OnNewOutputFunc, onNewSpentFunc OnNewSpentFunc, onMilestoneConfirmedFunc OnMilestoneConfirmedFunc, onConfirmedMilestoneIndexChanged OnConfirmedMilestoneIndexChangedFunc, onLedgerUpdatedFunc OnLedgerUpdatedFunc) {
 	te.OnNewOutput = onNewOutputFunc
 	te.OnNewSpent = onNewSpentFunc
 	te.OnMilestoneConfirmed = onMilestoneConfirmedFunc
 	te.OnConfirmedMilestoneIndexChanged = onConfirmedMilestoneIndexChanged
+	te.OnLedgerUpdatedFunc = onLedgerUpdatedFunc
 }
 
 func (te *TestEnvironment) NetworkID() iotago.NetworkID {

--- a/pkg/testsuite/test_environment.go
+++ b/pkg/testsuite/test_environment.go
@@ -87,7 +87,7 @@ type TestEnvironment struct {
 	// OnMilestoneConfirmed callback that will be called at confirming a milestone. This is equivalent to the tangle.MilestoneConfirmed event.
 	OnMilestoneConfirmed OnMilestoneConfirmedFunc
 
-	// OnLedgerUpdatedFunc callback that will be called after the ledger gets updating during confirmation. This is equivalent to the tangle.LedgerUpdated event.
+	// OnLedgerUpdatedFunc callback that will be called after the ledger gets updated during confirmation. This is equivalent to the tangle.LedgerUpdated event.
 	OnLedgerUpdatedFunc OnLedgerUpdatedFunc
 }
 

--- a/pkg/toolset/database_merge.go
+++ b/pkg/toolset/database_merge.go
@@ -314,6 +314,7 @@ func copyAndVerifyMilestoneCone(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/toolset/database_verify.go
+++ b/pkg/toolset/database_verify.go
@@ -259,6 +259,7 @@ func verifyDatabase(
 			nil,
 			nil,
 			nil,
+			nil,
 		)
 		if err != nil {
 			return err

--- a/plugins/participation/participation.go
+++ b/plugins/participation/participation.go
@@ -359,7 +359,7 @@ func getRewards(c echo.Context) (*RewardsResponse, error) {
 	return response, nil
 }
 
-func getOutputsByBech32Address(c echo.Context) (*ParticipationsResponse, error) {
+func getOutputsByBech32Address(c echo.Context) (*AddressOutputsResponse, error) {
 	bech32Address, err := restapi.ParseBech32AddressParam(c, deps.Bech32HRP)
 	if err != nil {
 		return nil, err
@@ -373,7 +373,7 @@ func getOutputsByBech32Address(c echo.Context) (*ParticipationsResponse, error) 
 	}
 }
 
-func getOutputsByEd25519Address(c echo.Context) (*ParticipationsResponse, error) {
+func getOutputsByEd25519Address(c echo.Context) (*AddressOutputsResponse, error) {
 	address, err := restapi.ParseEd25519AddressParam(c)
 	if err != nil {
 		return nil, err
@@ -381,11 +381,11 @@ func getOutputsByEd25519Address(c echo.Context) (*ParticipationsResponse, error)
 	return ed25519Outputs(address)
 }
 
-func ed25519Outputs(address *iotago.Ed25519Address) (*ParticipationsResponse, error) {
+func ed25519Outputs(address *iotago.Ed25519Address) (*AddressOutputsResponse, error) {
 	eventIDs := deps.ParticipationManager.EventIDs(participation.StakingPayloadTypeID)
 
-	response := &ParticipationsResponse{
-		Participations: make(map[string]*TrackedParticipation),
+	response := &AddressOutputsResponse{
+		Outputs: make(map[string]*OutputStatusResponse),
 	}
 
 	for _, eventID := range eventIDs {
@@ -399,14 +399,22 @@ func ed25519Outputs(address *iotago.Ed25519Address) (*ParticipationsResponse, er
 		if err != nil {
 			return nil, errors.WithMessagef(echo.ErrInternalServerError, "error fetching outputs: %s", err)
 		}
-		for _, participation := range participations {
+		for _, trackedParticipation := range participations {
+
 			t := &TrackedParticipation{
-				MessageID:           participation.MessageID.ToHex(),
-				Amount:              participation.Amount,
-				StartMilestoneIndex: participation.StartIndex,
-				EndMilestoneIndex:   participation.EndIndex,
+				MessageID:           trackedParticipation.MessageID.ToHex(),
+				Amount:              trackedParticipation.Amount,
+				StartMilestoneIndex: trackedParticipation.StartIndex,
+				EndMilestoneIndex:   trackedParticipation.EndIndex,
 			}
-			response.Participations[participation.OutputID.ToHex()] = t
+			outputResponse := response.Outputs[hex.EncodeToString(trackedParticipation.OutputID[:])]
+			if outputResponse == nil {
+				outputResponse = &OutputStatusResponse{
+					Participations: make(map[string]*TrackedParticipation),
+				}
+				response.Outputs[hex.EncodeToString(trackedParticipation.OutputID[:])] = outputResponse
+			}
+			outputResponse.Participations[hex.EncodeToString(trackedParticipation.EventID[:])] = t
 		}
 	}
 

--- a/plugins/participation/participation.go
+++ b/plugins/participation/participation.go
@@ -324,10 +324,10 @@ func getRewards(c echo.Context) (*RewardsResponse, error) {
 
 	var addresses []string
 	rewardsByAddress := make(map[string]uint64)
-	if err := deps.ParticipationManager.ForEachStakingAddress(eventID, milestoneIndex, func(address iotago.Address, rewards uint64) bool {
+	if err := deps.ParticipationManager.ForEachAddressStakingParticipation(eventID, milestoneIndex, func(address iotago.Address, _ *participation.TrackedParticipation, rewards uint64) bool {
 		addr := address.String()
 		addresses = append(addresses, addr)
-		rewardsByAddress[addr] = rewards
+		rewardsByAddress[addr] += rewards
 		return true
 	}, participation.FilterRequiredMinimumRewards(true)); err != nil {
 		return nil, errors.WithMessagef(echo.ErrInternalServerError, "error fetching rewards: %s", err)

--- a/plugins/participation/participation.go
+++ b/plugins/participation/participation.go
@@ -413,6 +413,10 @@ func ed25519Outputs(address *iotago.Ed25519Address) (*AddressOutputsResponse, er
 		Outputs: make(map[string]*OutputStatusResponse),
 	}
 
+	// We need to lock the ledger here so that we don't get partial results while the next milestone is being confirmed
+	deps.UTXOManager.ReadLockLedger()
+	defer deps.UTXOManager.ReadUnlockLedger()
+
 	for _, eventID := range eventIDs {
 
 		event := deps.ParticipationManager.Event(eventID)

--- a/plugins/participation/plugin.go
+++ b/plugins/participation/plugin.go
@@ -290,14 +290,8 @@ func run() {
 func configureEvents() {
 
 	onLedgerUpdated = events.NewClosure(func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
-		if err := deps.ParticipationManager.ApplyNewUTXOs(index, newOutputs); err != nil {
-			deps.ShutdownHandler.SelfShutdown(fmt.Sprintf("participation plugin hit a critical error while applying new UTXO: %s", err.Error()))
-		}
-		if err := deps.ParticipationManager.ApplySpentUTXOs(index, newSpents); err != nil {
-			deps.ShutdownHandler.SelfShutdown(fmt.Sprintf("participation plugin hit a critical error while applying spent TXO: %s", err.Error()))
-		}
-		if err := deps.ParticipationManager.ApplyNewConfirmedMilestoneIndex(index); err != nil {
-			deps.ShutdownHandler.SelfShutdown(fmt.Sprintf("participation plugin hit a critical error while applying new confirmed milestone index: %s", err.Error()))
+		if err := deps.ParticipationManager.ApplyNewLedgerUpdate(index, newOutputs, newSpents); err != nil {
+			deps.ShutdownHandler.SelfShutdown(fmt.Sprintf("participation plugin hit a critical error while applying new ledger update: %s", err.Error()))
 		}
 	})
 }

--- a/plugins/participation/plugin.go
+++ b/plugins/participation/plugin.go
@@ -51,13 +51,13 @@ const (
 	// RouteAddressBech32Status is the route to get the staking rewards for the given bech32 address.
 	RouteAddressBech32Status = "/addresses/:" + restapi.ParameterAddress
 
-	// RouteAddressBech32Outputs is the route to get the outputs for a given address.
+	// RouteAddressBech32Outputs is the route to get the outputs for the given bech32 address.
 	RouteAddressBech32Outputs = "/addresses/:" + restapi.ParameterAddress + "/outputs"
 
 	// RouteAddressEd25519Status is the route to get the staking rewards for the given ed25519 address.
 	RouteAddressEd25519Status = "/addresses/ed25519/:" + restapi.ParameterAddress
 
-	// RouteAddressEd25519Outputs is the route to get the outputs for a given address.
+	// RouteAddressEd25519Outputs is the route to get the outputs for the given ed25519 address.
 	RouteAddressEd25519Outputs = "/addresses/ed25519/:" + restapi.ParameterAddress + "/outputs"
 
 	// RouteAdminCreateEvent is the route the node operator can use to add events.

--- a/plugins/participation/plugin.go
+++ b/plugins/participation/plugin.go
@@ -51,8 +51,14 @@ const (
 	// RouteAddressBech32Status is the route to get the staking rewards for the given bech32 address.
 	RouteAddressBech32Status = "/addresses/:" + restapi.ParameterAddress
 
+	// RouteAddressBech32Outputs is the route to get the outputs for a given address.
+	RouteAddressBech32Outputs = "/addresses/:" + restapi.ParameterAddress + "/outputs"
+
 	// RouteAddressEd25519Status is the route to get the staking rewards for the given ed25519 address.
 	RouteAddressEd25519Status = "/addresses/ed25519/:" + restapi.ParameterAddress
+
+	// RouteAddressEd25519Outputs is the route to get the outputs for a given address.
+	RouteAddressEd25519Outputs = "/addresses/ed25519/:" + restapi.ParameterAddress + "/outputs"
 
 	// RouteAdminCreateEvent is the route the node operator can use to add events.
 	// POST creates a new event to track
@@ -207,8 +213,24 @@ func configure() {
 		return restapi.JSONResponse(c, http.StatusOK, resp)
 	})
 
+	routeGroup.GET(RouteAddressBech32Outputs, func(c echo.Context) error {
+		resp, err := getOutputsByBech32Address(c)
+		if err != nil {
+			return err
+		}
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
 	routeGroup.GET(RouteAddressEd25519Status, func(c echo.Context) error {
 		resp, err := getRewardsByEd25519Address(c)
+		if err != nil {
+			return err
+		}
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteAddressEd25519Outputs, func(c echo.Context) error {
+		resp, err := getOutputsByEd25519Address(c)
 		if err != nil {
 			return err
 		}

--- a/plugins/participation/types.go
+++ b/plugins/participation/types.go
@@ -46,6 +46,8 @@ type AddressReward struct {
 type AddressRewardsResponse struct {
 	// Rewards is a map of rewards per event.
 	Rewards map[string]*AddressReward `json:"rewards"`
+	// MilestoneIndex is the milestone index the rewards were calculated for.
+	MilestoneIndex milestone.Index `json:"milestoneIndex"`
 }
 
 // AddressOutputsResponse defines the response of a GET RouteAddressBech32Outputs or RouteAddressEd25519Outputs REST API call.

--- a/plugins/participation/types.go
+++ b/plugins/participation/types.go
@@ -48,6 +48,12 @@ type AddressRewardsResponse struct {
 	Rewards map[string]*AddressReward `json:"rewards"`
 }
 
+// AddressOutputsResponse defines the response of a GET RouteAddressBech32Outputs or RouteAddressEd25519Outputs REST API call.
+type AddressOutputsResponse struct {
+	// Outputs is a map of output status per outputID.
+	Outputs map[string]*OutputStatusResponse `json:"outputs"`
+}
+
 // RewardsResponse defines the response of a GET RouteAdminRewards REST API call and contains the rewards for each address.
 type RewardsResponse struct {
 	// Symbol is the symbol of the rewarded tokens.


### PR DESCRIPTION
- This implementation of the Participation plugin does not calculate each address rewards on every milestone confirmation. Instead it keeps a track of each participation per address so that the rewards can be calculated on-demand for each address.
- Additionally it keeps track of the rewards generated per milestone (same approach as with voting).
- New API endpoint allow fetching all participations outputs per address

_**Note: this change is not compatible with the current events in the database. Participation should be recalculated by removing the old db.**_