### PR TITLE
Fix/Check for updates

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	goversion "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 	"go.uber.org/dig"
@@ -122,6 +123,15 @@ Command line flags:
 		panic(err)
 	}
 
+	versionString := Version
+	if _, err := goversion.NewSemver(Version); err == nil {
+		// version is a valid SemVer => release version
+		versionString = "       v" + versionString
+	} else {
+		// version is not a valid SemVer => maybe self-compiled
+		versionString = "commit: " + versionString
+	}
+
 	fmt.Printf(`
               ██╗  ██╗ ██████╗ ██████╗ ███╗   ██╗███████╗████████╗
               ██║  ██║██╔═══██╗██╔══██╗████╗  ██║██╔════╝╚══██╔══╝
@@ -129,8 +139,8 @@ Command line flags:
               ██╔══██║██║   ██║██╔══██╗██║╚██╗██║██╔══╝     ██║
               ██║  ██║╚██████╔╝██║  ██║██║ ╚████║███████╗   ██║
               ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝╚══════╝   ╚═╝
-                                   v%s
-`+"\n", Version)
+                            %s
+`+"\n", versionString)
 
 	printConfig(maskedKeys)
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,89 @@
+package version
+
+import (
+	"strings"
+
+	goversion "github.com/hashicorp/go-version"
+	"github.com/tcnksm/go-latest"
+)
+
+// fixVersion fixes broken version strings.
+func fixVersion(version string) string {
+	ver := strings.Replace(version, "v", "", 1)
+	if !strings.Contains(ver, "-rc.") {
+		ver = strings.Replace(ver, "-rc", "-rc.", 1)
+	}
+	return ver
+}
+
+// versionIsPreRelease checks if a version is a pre-release.
+func versionIsPreRelease(version *goversion.Version) bool {
+	// version is a pre-release if the string is not empty
+	return version.Prerelease() != ""
+}
+
+// versionFilterFunc filters possible versions for updates based on the current AppVersion.
+// If the AppVersion is self-compiled, we don't search for updates.
+// We only check for any versions in the same MAJOR version. (e.g. 1.1.3 => 1.2.0)
+// If the AppVersion is a pre-release, we also check for any pre-releases in the same MAJOR version. (e.g. 1.1.4-rc1 => 1.2.0-alpha1 / 1.1.5)
+func versionFilterFunc(fixedAppVersion string) latest.TagFilterFunc {
+
+	appVersion, err := goversion.NewSemver(fixedAppVersion)
+	if err != nil {
+		// if the AppVersion can't be parsed, it may be a self compiled version.
+		// => no need to check for updates.
+
+		// filter everything
+		return func(version string) bool {
+			return false
+		}
+	}
+
+	appIsPreRelease := versionIsPreRelease(appVersion)
+	appVersionMajor := appVersion.Segments()[0]
+
+	// filter versions based on current AppVersion
+	return func(version string) bool {
+		ver, err := goversion.NewSemver(fixVersion(version))
+		if err != nil {
+			// every version that can't be parsed is ignored.
+			return false
+		}
+
+		if !appIsPreRelease && versionIsPreRelease(ver) {
+			// the current AppVersion is not a pre-release.
+			// => ignore all pre-releases.
+			return false
+		}
+
+		// we only check for any versions in the same MAJOR version.
+		return appVersionMajor == ver.Segments()[0]
+	}
+}
+
+// VersionChecker can be used to check for updates on GitHub.
+type VersionChecker struct {
+	fixedAppVersion string
+	versionSource   latest.Source
+}
+
+// NewVersionChecker creates a new VersionChecker that can be used to check for updates on GitHub.
+func NewVersionChecker(owner string, repository string, version string) *VersionChecker {
+
+	fixedAppVersion := fixVersion(version)
+
+	return &VersionChecker{
+		fixedAppVersion: fixedAppVersion,
+		versionSource: &latest.GithubTag{
+			Owner:             owner,
+			Repository:        repository,
+			FixVersionStrFunc: fixVersion,
+			TagFilterFunc:     versionFilterFunc(fixedAppVersion),
+		},
+	}
+}
+
+// CheckForUpdates checks for latest updates on GitHub.
+func (v *VersionChecker) CheckForUpdates() (*latest.CheckResponse, error) {
+	return latest.Check(v.versionSource, v.fixedAppVersion)
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,8 +10,13 @@ import (
 // fixVersion fixes broken version strings.
 func fixVersion(version string) string {
 	ver := strings.Replace(version, "v", "", 1)
-	if !strings.Contains(ver, "-rc.") {
-		ver = strings.Replace(ver, "-rc", "-rc.", 1)
+
+	for _, prerelease := range []string{"rc", "alpha", "beta"} {
+		prerelease = "-" + prerelease
+		prerelease_dot := prerelease + "."
+		if !strings.Contains(ver, prerelease_dot) {
+			ver = strings.Replace(ver, prerelease, prerelease_dot, 1)
+		}
 	}
 	return ver
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,29 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersion(t *testing.T) {
+
+	filter_self_compiled := versionFilterFunc(fixVersion("6875ccee"))
+	require.False(t, filter_self_compiled("6875ccee"))      // self-compiled
+	require.False(t, filter_self_compiled("v2.0.0"))        // major
+	require.False(t, filter_self_compiled("v2.0.0-alpha1")) // major - pre-release
+
+	filter_stable_version := versionFilterFunc(fixVersion("v1.1.3"))
+	require.False(t, filter_stable_version("6875ccee"))      // self-compiled
+	require.True(t, filter_stable_version("v1.2.0"))         // same major
+	require.False(t, filter_stable_version("v1.2.0-rc1"))    // same major - pre-release
+	require.False(t, filter_stable_version("v2.0.0"))        // other major
+	require.False(t, filter_stable_version("v2.0.0-alpha1")) // other major - pre-release
+
+	filter_pre_release := versionFilterFunc(fixVersion("v1.1.3-rc1"))
+	require.False(t, filter_pre_release("6875ccee"))      // self-compiled
+	require.True(t, filter_pre_release("v1.2.0"))         // same major
+	require.True(t, filter_pre_release("v1.2.0-rc1"))     // same major - pre-release
+	require.False(t, filter_pre_release("v2.0.0"))        // other major
+	require.False(t, filter_pre_release("v2.0.0-alpha1")) // other major - pre-release
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -3,10 +3,64 @@ package version
 import (
 	"testing"
 
+	"github.com/hashicorp/go-version"
+	goversion "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
+	"github.com/tcnksm/go-latest"
 )
 
-func TestVersion(t *testing.T) {
+type versionCheckerMock struct {
+	tags              []string
+	fixVersionStrFunc latest.FixVersionStrFunc
+	tagFilterFunc     latest.TagFilterFunc
+}
+
+func (ver *versionCheckerMock) Validate() error {
+	return nil
+}
+
+func (ver *versionCheckerMock) Fetch() (*latest.FetchResponse, error) {
+
+	var versions []*goversion.Version
+	var malformeds []string
+	fr := &latest.FetchResponse{
+		Versions:   versions,
+		Malformeds: malformeds,
+		Meta:       &latest.Meta{},
+	}
+
+	for _, name := range ver.tags {
+		if !ver.tagFilterFunc(name) {
+			fr.Malformeds = append(fr.Malformeds, name)
+			continue
+		}
+		v, err := version.NewVersion(ver.fixVersionStrFunc(name))
+		if err != nil {
+			fr.Malformeds = append(fr.Malformeds, ver.fixVersionStrFunc(name))
+			continue
+		}
+		fr.Versions = append(fr.Versions, v)
+	}
+
+	return fr, nil
+}
+
+// newVersionCheckerMock creates a new VersionChecker that can be used for tests.
+func newVersionCheckerMock(version string, tags []string) *VersionChecker {
+
+	fixedAppVersion := fixVersion(version)
+
+	return &VersionChecker{
+		fixedAppVersion: fixedAppVersion,
+		versionSource: &versionCheckerMock{
+			tags:              tags,
+			fixVersionStrFunc: fixVersion,
+			tagFilterFunc:     versionFilterFunc(fixedAppVersion),
+		},
+	}
+}
+
+func TestVersionFilterFunc(t *testing.T) {
 
 	filter_self_compiled := versionFilterFunc(fixVersion("6875ccee"))
 	require.False(t, filter_self_compiled("6875ccee"))      // self-compiled
@@ -20,10 +74,98 @@ func TestVersion(t *testing.T) {
 	require.False(t, filter_stable_version("v2.0.0"))        // other major
 	require.False(t, filter_stable_version("v2.0.0-alpha1")) // other major - pre-release
 
-	filter_pre_release := versionFilterFunc(fixVersion("v1.1.3-rc1"))
-	require.False(t, filter_pre_release("6875ccee"))      // self-compiled
-	require.True(t, filter_pre_release("v1.2.0"))         // same major
-	require.True(t, filter_pre_release("v1.2.0-rc1"))     // same major - pre-release
-	require.False(t, filter_pre_release("v2.0.0"))        // other major
-	require.False(t, filter_pre_release("v2.0.0-alpha1")) // other major - pre-release
+	filter_pre_release_rc := versionFilterFunc(fixVersion("v1.1.3-rc1"))
+	require.False(t, filter_pre_release_rc("6875ccee"))      // self-compiled
+	require.True(t, filter_pre_release_rc("v1.2.0"))         // same major
+	require.True(t, filter_pre_release_rc("v1.2.0-rc1"))     // same major - pre-release
+	require.False(t, filter_pre_release_rc("v2.0.0"))        // other major
+	require.False(t, filter_pre_release_rc("v2.0.0-alpha1")) // other major - pre-release
+
+	filter_pre_release_alpha := versionFilterFunc(fixVersion("v1.1.3-alpha1"))
+	require.False(t, filter_pre_release_alpha("6875ccee"))      // self-compiled
+	require.True(t, filter_pre_release_alpha("v1.2.0"))         // same major
+	require.True(t, filter_pre_release_alpha("v1.2.0-rc1"))     // same major - pre-release
+	require.False(t, filter_pre_release_alpha("v2.0.0"))        // other major
+	require.False(t, filter_pre_release_alpha("v2.0.0-alpha1")) // other major - pre-release
+}
+
+func TestVersion(t *testing.T) {
+
+	var checkResponse *latest.CheckResponse
+	var err error
+
+	version_self_compiled := newVersionCheckerMock("6875ccee", []string{"6875ccee", "v1.2.0", "v1.2.0-rc1", "v2.0.0", "v2.0.0-alpha1"})
+	checkResponse, err = version_self_compiled.CheckForUpdates()
+	require.Error(t, err) // no updates available
+	require.Nil(t, checkResponse)
+
+	version_stable_version := newVersionCheckerMock("v1.1.3", []string{"6875ccee", "v1.2.0", "v1.2.0-rc1", "v2.0.0", "v2.0.0-alpha1"})
+	checkResponse, err = version_stable_version.CheckForUpdates()
+	require.NoError(t, err)
+	require.NotNil(t, checkResponse)
+	require.Equal(t, "1.2.0", checkResponse.Current)
+	require.EqualValues(t, []string{"6875ccee", "v1.2.0-rc1", "v2.0.0", "v2.0.0-alpha1"}, checkResponse.Malformeds)
+	require.False(t, checkResponse.Latest)
+	require.True(t, checkResponse.Outdated)
+	require.False(t, checkResponse.New)
+
+	version_pre_release_rc := newVersionCheckerMock("v1.1.3-rc1", []string{"6875ccee", "v1.2.0", "v1.2.0-rc1", "v2.0.0", "v2.0.0-alpha1"})
+	checkResponse, err = version_pre_release_rc.CheckForUpdates()
+	require.NoError(t, err)
+	require.NotNil(t, checkResponse)
+	require.Equal(t, "1.2.0", checkResponse.Current)
+	require.EqualValues(t, []string{"6875ccee", "v2.0.0", "v2.0.0-alpha1"}, checkResponse.Malformeds)
+	require.False(t, checkResponse.Latest)
+	require.True(t, checkResponse.Outdated)
+	require.False(t, checkResponse.New)
+
+	version_pre_release_rc1 := newVersionCheckerMock("v1.1.3-rc1", []string{"6875ccee", "v1.1.3-rc10", "v1.1.3-rc11", "v2.0.0", "v2.0.0-alpha1"})
+	checkResponse, err = version_pre_release_rc1.CheckForUpdates()
+	require.NoError(t, err)
+	require.NotNil(t, checkResponse)
+	require.Equal(t, "1.1.3-rc.11", checkResponse.Current)
+	require.EqualValues(t, []string{"6875ccee", "v2.0.0", "v2.0.0-alpha1"}, checkResponse.Malformeds)
+	require.False(t, checkResponse.Latest)
+	require.True(t, checkResponse.Outdated)
+	require.False(t, checkResponse.New)
+
+	version_pre_release_rc9 := newVersionCheckerMock("v1.1.3-rc9", []string{"6875ccee", "v1.1.3-rc10", "v1.1.3-rc11", "v2.0.0", "v2.0.0-alpha1"})
+	checkResponse, err = version_pre_release_rc9.CheckForUpdates()
+	require.NoError(t, err)
+	require.NotNil(t, checkResponse)
+	require.Equal(t, "1.1.3-rc.11", checkResponse.Current)
+	require.EqualValues(t, []string{"6875ccee", "v2.0.0", "v2.0.0-alpha1"}, checkResponse.Malformeds)
+	require.False(t, checkResponse.Latest)
+	require.True(t, checkResponse.Outdated)
+	require.False(t, checkResponse.New)
+
+	version_pre_release_rc10 := newVersionCheckerMock("v1.1.3-rc10", []string{"6875ccee", "v1.1.3-rc10", "v1.1.3-rc11", "v2.0.0", "v2.0.0-alpha1"})
+	checkResponse, err = version_pre_release_rc10.CheckForUpdates()
+	require.NoError(t, err)
+	require.NotNil(t, checkResponse)
+	require.Equal(t, "1.1.3-rc.11", checkResponse.Current)
+	require.EqualValues(t, []string{"6875ccee", "v2.0.0", "v2.0.0-alpha1"}, checkResponse.Malformeds)
+	require.False(t, checkResponse.Latest)
+	require.True(t, checkResponse.Outdated)
+	require.False(t, checkResponse.New)
+
+	version_pre_release_alpha := newVersionCheckerMock("v1.1.3-alpha1", []string{"6875ccee", "v1.2.0", "v1.2.0-rc1", "v2.0.0", "v2.0.0-alpha1"})
+	checkResponse, err = version_pre_release_alpha.CheckForUpdates()
+	require.NoError(t, err)
+	require.NotNil(t, checkResponse)
+	require.Equal(t, "1.2.0", checkResponse.Current)
+	require.EqualValues(t, []string{"6875ccee", "v2.0.0", "v2.0.0-alpha1"}, checkResponse.Malformeds)
+	require.False(t, checkResponse.Latest)
+	require.True(t, checkResponse.Outdated)
+	require.False(t, checkResponse.New)
+
+	version_pre_release_alpha9 := newVersionCheckerMock("v1.1.3-alpha9", []string{"6875ccee", "v1.1.3-alpha10", "v1.1.3-alpha11", "v2.0.0", "v2.0.0-alpha1"})
+	checkResponse, err = version_pre_release_alpha9.CheckForUpdates()
+	require.NoError(t, err)
+	require.NotNil(t, checkResponse)
+	require.Equal(t, "1.1.3-alpha.11", checkResponse.Current)
+	require.EqualValues(t, []string{"6875ccee", "v2.0.0", "v2.0.0-alpha1"}, checkResponse.Malformeds)
+	require.False(t, checkResponse.Latest)
+	require.True(t, checkResponse.Outdated)
+	require.False(t, checkResponse.New)
 }

--- a/plugins/versioncheck/plugin.go
+++ b/plugins/versioncheck/plugin.go
@@ -2,15 +2,14 @@ package versioncheck
 
 import (
 	"context"
-	"strings"
 	"time"
 
-	"github.com/tcnksm/go-latest"
 	"go.uber.org/dig"
 
 	"github.com/gohornet/hornet/pkg/app"
 	"github.com/gohornet/hornet/pkg/node"
 	"github.com/gohornet/hornet/pkg/shutdown"
+	"github.com/gohornet/hornet/pkg/version"
 	"github.com/iotaledger/hive.go/timeutil"
 )
 
@@ -20,6 +19,7 @@ func init() {
 		Pluggable: node.Pluggable{
 			Name:      "VersionCheck",
 			DepsFunc:  func(cDeps dependencies) { deps = cDeps },
+			Provide:   provide,
 			Configure: configure,
 			Run:       run,
 		},
@@ -29,23 +29,23 @@ func init() {
 var (
 	Plugin *node.Plugin
 	deps   dependencies
-
-	githubTag *latest.GithubTag
 )
 
 type dependencies struct {
 	dig.In
-	AppInfo *app.AppInfo
+	AppInfo        *app.AppInfo
+	VersionChecker *version.VersionChecker
+}
+
+func provide(c *dig.Container) {
+	if err := c.Provide(func(appInfo *app.AppInfo) *version.VersionChecker {
+		return version.NewVersionChecker("gohornet", "hornet", appInfo.Version)
+	}); err != nil {
+		Plugin.LogPanic(err)
+	}
 }
 
 func configure() {
-	githubTag = &latest.GithubTag{
-		Owner:             "gohornet",
-		Repository:        "hornet",
-		FixVersionStrFunc: fixVersion,
-		TagFilterFunc:     includeVersionInCheck,
-	}
-
 	checkLatestVersion()
 }
 
@@ -59,30 +59,8 @@ func run() {
 	}
 }
 
-func fixVersion(version string) string {
-	ver := strings.Replace(version, "v", "", 1)
-	if !strings.Contains(ver, "-rc.") {
-		ver = strings.Replace(ver, "-rc", "-rc.", 1)
-	}
-	return ver
-}
-
-func includeVersionInCheck(version string) bool {
-	isPrerelease := func(ver string) bool {
-		return strings.Contains(ver, "-rc")
-	}
-
-	if isPrerelease(deps.AppInfo.Version) {
-		// When using pre-release versions, check for any updates
-		return true
-	}
-
-	return !isPrerelease(version)
-}
-
 func checkLatestVersion() {
-
-	res, err := latest.Check(githubTag, fixVersion(deps.AppInfo.Version))
+	res, err := deps.VersionChecker.CheckForUpdates()
 	if err != nil {
 		Plugin.LogWarnf("Update check failed: %s", err)
 		return


### PR DESCRIPTION
This PR changes the logic of the update check.

We only check for versions with the same major version as the application now.
If it is self-compiled, we don't check for updates.

If it is a pre-release, we also check for pre-releases in the same major version.