### PR TITLE
fixed bash complains

### DIFF
--- a/private_tangle/bootstrap.sh
+++ b/private_tangle/bootstrap.sh
@@ -6,7 +6,7 @@ if [[ "$OSTYPE" != "darwin"* && "$EUID" -ne 0 ]]; then
 fi
 
 # Cleanup if necessary
-if [ -d "privatedb" ] || [ -d "snapshots"]; then
+if [ -d "privatedb" ] || [ -d "snapshots" ]; then
   ./cleanup.sh
 fi
 


### PR DESCRIPTION
# Description

fixed a syntax error in the bash script.

```
$ sudo ./bootstrap.sh
./bootstrap.sh: line 9: [: missing `]'
Starting private_tangle_create-snapshots_1 ... done
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

no errors when running bootstrap.sh

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
