### PR TITLE
Updated API Reference Page  Links

### DIFF
--- a/documentation/docs/api_reference.md
+++ b/documentation/docs/api_reference.md
@@ -10,9 +10,16 @@ keywords:
 - Reference
 ---
 
-# API Reference
+# API References
 
-You can find specifications for the REST API for the IOTA node software in the [IOTA REST API reference](https://editor.swagger.io/?url=https://raw.githubusercontent.com/rufsam/protocol-rfcs/master/text/0026-rest-api/0026-rest-api.yaml).
+You can find specifications for the REST and EVENT APIs for the IOTA node software within Chrysalis in the links below:
+
+- [Rest](https://github.com/iotaledger/tips/blob/main/tips/TIP-0013/tip-0013.md).
+- [EVENT API](https://github.com/iotaledger/tips/blob/main/tips/TIP-0016/tip-0016.md)
+
+You can find specifications for the REST and EVENT APIs for the IOTA node software within Stardust in the links below:
+
+- [Rest](https://github.com/iotaledger/tips/pull/57)
+- [EVENT API](https://github.com/iotaledger/tips/pull/66)
 
 
-The node event API is in charge of publishing information about events within the node software. You can find more information in the [Node event API reference](https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/luca-moser/protocol-rfcs/rfc/node-event-api/text/0033-node-event-api/0033-node-event-api.yml). 


### PR DESCRIPTION
# Description

Links listed within the "API Reference" page now link to their respective TIP pages in the repo.

Fixes #(issue)

## Type of change


- [x] Documentation Fix


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
