### PR TITLE
Adds basic protocol manager

### DIFF
--- a/core/database/core.go
+++ b/core/database/core.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"github.com/iotaledger/hornet/pkg/protocol"
 	"os"
 	"path/filepath"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/iotaledger/hornet/pkg/model/syncmanager"
 	"github.com/iotaledger/hornet/pkg/model/utxo"
 	"github.com/iotaledger/hornet/pkg/profile"
-	iotago "github.com/iotaledger/iota.go/v3"
 )
 
 const (
@@ -222,12 +222,12 @@ func provide(c *dig.Container) error {
 
 	type syncManagerDeps struct {
 		dig.In
-		UTXOManager        *utxo.Manager
-		ProtocolParameters *iotago.ProtocolParameters
+		UTXOManager     *utxo.Manager
+		ProtocolManager *protocol.Manager
 	}
 
 	if err := c.Provide(func(deps syncManagerDeps) *syncmanager.SyncManager {
-		sync, err := syncmanager.New(deps.UTXOManager, milestone.Index(deps.ProtocolParameters.BelowMaxDepth))
+		sync, err := syncmanager.New(deps.UTXOManager, milestone.Index(deps.ProtocolManager.Current().BelowMaxDepth))
 		if err != nil {
 			CoreComponent.LogPanicf("can't initialize sync manager: %s", err)
 		}

--- a/core/pow/core.go
+++ b/core/pow/core.go
@@ -2,13 +2,13 @@ package pow
 
 import (
 	"context"
+	"github.com/iotaledger/hornet/pkg/protocol"
 
 	"go.uber.org/dig"
 
 	"github.com/iotaledger/hive.go/app"
 	"github.com/iotaledger/hornet/pkg/daemon"
 	"github.com/iotaledger/hornet/pkg/pow"
-	iotago "github.com/iotaledger/iota.go/v3"
 )
 
 func init() {
@@ -37,12 +37,12 @@ func provide(c *dig.Container) error {
 
 	type handlerDeps struct {
 		dig.In
-		ProtocolParameters *iotago.ProtocolParameters
+		ProtocolManager *protocol.Manager
 	}
 
 	if err := c.Provide(func(deps handlerDeps) *pow.Handler {
 		// init the pow handler with all possible settings
-		return pow.New(deps.ProtocolParameters.MinPoWScore, ParamsPoW.RefreshTipsInterval)
+		return pow.New(deps.ProtocolManager.Current().MinPoWScore, ParamsPoW.RefreshTipsInterval)
 	}); err != nil {
 		CoreComponent.LogPanic(err)
 	}

--- a/core/protocfg/core.go
+++ b/core/protocfg/core.go
@@ -52,7 +52,7 @@ func initConfigPars(c *dig.Container) error {
 
 	type cfgDeps struct {
 		dig.In
-		Storage *storage.Storage `optional:"true"`
+		Storage *storage.Storage `optional:"true"` // optional because of entry-node mode
 	}
 
 	type cfgResult struct {

--- a/core/protocfg/core.go
+++ b/core/protocfg/core.go
@@ -52,7 +52,7 @@ func initConfigPars(c *dig.Container) error {
 
 	type cfgDeps struct {
 		dig.In
-		Storage *storage.Storage
+		Storage *storage.Storage `optional:"true"`
 	}
 
 	type cfgResult struct {

--- a/core/protocfg/core.go
+++ b/core/protocfg/core.go
@@ -2,6 +2,13 @@ package protocfg
 
 import (
 	"encoding/json"
+	"fmt"
+	"github.com/iotaledger/hive.go/app/core/shutdown"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hornet/pkg/model/storage"
+	"github.com/iotaledger/hornet/pkg/model/syncmanager"
+	"github.com/iotaledger/hornet/pkg/protocol"
+	"github.com/iotaledger/hornet/pkg/tangle"
 
 	flag "github.com/spf13/pflag"
 	"go.uber.org/dig"
@@ -19,47 +26,62 @@ func init() {
 	CoreComponent = &app.CoreComponent{
 		Component: &app.Component{
 			Name:           "ProtoCfg",
+			DepsFunc:       func(cDeps dependencies) { deps = cDeps },
 			Params:         params,
 			InitConfigPars: initConfigPars,
+			Configure:      configure,
 		},
 	}
 }
 
 var (
-	CoreComponent *app.CoreComponent
-
+	CoreComponent       *app.CoreComponent
+	deps                dependencies
 	cooPubKeyRangesFlag = flag.String(CfgProtocolPublicKeyRangesJSON, "", "overwrite public key ranges (JSON)")
 )
 
+type dependencies struct {
+	dig.In
+	Tangle          *tangle.Tangle
+	ProtocolManager *protocol.Manager
+	SyncManager     *syncmanager.SyncManager
+	ShutdownHandler *shutdown.ShutdownHandler
+}
+
 func initConfigPars(c *dig.Container) error {
+
+	type cfgDeps struct {
+		dig.In
+		Storage *storage.Storage
+	}
 
 	type cfgResult struct {
 		dig.Out
-		KeyManager                *keymanager.KeyManager
-		MilestonePublicKeyCount   int `name:"milestonePublicKeyCount"`
-		SupportedProtocolVersions SupportedProtocolVersions
-		ProtocolParameters        *iotago.ProtocolParameters
-		BaseToken                 *BaseToken
+		KeyManager              *keymanager.KeyManager
+		MilestonePublicKeyCount int `name:"milestonePublicKeyCount"`
+		ProtocolManager         *protocol.Manager
+		BaseToken               *BaseToken
 	}
 
-	if err := c.Provide(func() cfgResult {
+	if err := c.Provide(func(deps cfgDeps) cfgResult {
+
+		protoParas := &iotago.ProtocolParameters{
+			Version:       ParamsProtocol.Parameters.Version,
+			NetworkName:   ParamsProtocol.Parameters.NetworkName,
+			Bech32HRP:     iotago.NetworkPrefix(ParamsProtocol.Parameters.Bech32HRP),
+			MinPoWScore:   ParamsProtocol.Parameters.MinPoWScore,
+			BelowMaxDepth: ParamsProtocol.Parameters.BelowMaxDepth,
+			RentStructure: iotago.RentStructure{
+				VByteCost:    ParamsProtocol.Parameters.RentStructureVByteCost,
+				VBFactorData: iotago.VByteCostFactor(ParamsProtocol.Parameters.RentStructureVByteFactorData),
+				VBFactorKey:  iotago.VByteCostFactor(ParamsProtocol.Parameters.RentStructureVByteFactorKey),
+			},
+			TokenSupply: ParamsProtocol.Parameters.TokenSupply,
+		}
 
 		res := cfgResult{
-			MilestonePublicKeyCount:   ParamsProtocol.MilestonePublicKeyCount,
-			SupportedProtocolVersions: ParamsProtocol.SupportedProtocolVersions,
-			ProtocolParameters: &iotago.ProtocolParameters{
-				Version:       ParamsProtocol.Parameters.Version,
-				NetworkName:   ParamsProtocol.Parameters.NetworkName,
-				Bech32HRP:     iotago.NetworkPrefix(ParamsProtocol.Parameters.Bech32HRP),
-				MinPoWScore:   ParamsProtocol.Parameters.MinPoWScore,
-				BelowMaxDepth: ParamsProtocol.Parameters.BelowMaxDepth,
-				RentStructure: iotago.RentStructure{
-					VByteCost:    ParamsProtocol.Parameters.RentStructureVByteCost,
-					VBFactorData: iotago.VByteCostFactor(ParamsProtocol.Parameters.RentStructureVByteFactorData),
-					VBFactorKey:  iotago.VByteCostFactor(ParamsProtocol.Parameters.RentStructureVByteFactorKey),
-				},
-				TokenSupply: ParamsProtocol.Parameters.TokenSupply,
-			},
+			MilestonePublicKeyCount: ParamsProtocol.MilestonePublicKeyCount,
+			ProtocolManager:         protocol.NewManager(deps.Storage, protoParas),
 			BaseToken: &BaseToken{
 				Name:            ParamsProtocol.BaseToken.Name,
 				TickerSymbol:    ParamsProtocol.BaseToken.TickerSymbol,
@@ -104,4 +126,21 @@ func KeyManagerWithConfigPublicKeyRanges(coordinatorPublicKeyRanges ConfigPublic
 	}
 
 	return keyManager, nil
+}
+
+func configure() error {
+	deps.ProtocolManager.LoadPending(deps.SyncManager)
+
+	deps.Tangle.Events.ConfirmedMilestoneChanged.Attach(events.NewClosure(deps.ProtocolManager.HandleConfirmedMilestone))
+
+	unsuppProtoParasClosure := events.NewClosure(func(unsupportedProtocolParas *iotago.ProtocolParamsMilestoneOpt) {
+		unsupportedVersion := unsupportedProtocolParas.ProtocolVersion
+		CoreComponent.LogWarnf("next milestone will run under unsupported protocol version %d!", unsupportedVersion)
+	})
+	deps.ProtocolManager.Events.NextMilestoneUnsupported.Attach(unsuppProtoParasClosure)
+	deps.ProtocolManager.Events.CriticalErrors.Attach(events.NewClosure(func(err error) {
+		deps.ShutdownHandler.SelfShutdown(fmt.Sprintf("protocol manager hit a critical error: %s", err), true)
+	}))
+
+	return nil
 }

--- a/core/protocfg/params.go
+++ b/core/protocfg/params.go
@@ -32,24 +32,8 @@ type BaseToken struct {
 	UseMetricPrefix bool `default:"true" usage:"the base token uses the metric prefix" json:"useMetricPrefix"`
 }
 
-// SupportedProtocolVersions is a slice of supported protocol versions.
-type SupportedProtocolVersions []uint32
-
-// Highest returns the highest version.
-func (versions SupportedProtocolVersions) Highest() byte {
-	return byte(versions[len(versions)-1])
-}
-
-// Lowest returns the lowest version.
-func (versions SupportedProtocolVersions) Lowest() byte {
-	return byte(versions[0])
-}
-
 // ParametersProtocol contains the definition of the parameters used by protocol.
 type ParametersProtocol struct {
-	// The supported protocol versions by this node.
-	SupportedProtocolVersions SupportedProtocolVersions `noflag:"true"`
-
 	Parameters struct {
 		// the protocol version this node supports
 		Version byte `default:"2" usage:"the protocol version this node supports"`
@@ -81,7 +65,6 @@ type ParametersProtocol struct {
 }
 
 var ParamsProtocol = &ParametersProtocol{
-	SupportedProtocolVersions: SupportedProtocolVersions{2}, // make sure to add the versions sorted asc
 	PublicKeyRanges: ConfigPublicKeyRanges{
 		{
 			Key:        "a9b46fe743df783dedd00c954612428b34241f5913cf249d75bed3aafd65e4cd",

--- a/core/snapshot/core.go
+++ b/core/snapshot/core.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"context"
 	"fmt"
+	"github.com/iotaledger/hornet/pkg/protocol"
 	"os"
 
 	"github.com/labstack/gommon/bytes"
@@ -20,7 +21,6 @@ import (
 	"github.com/iotaledger/hornet/pkg/model/utxo"
 	"github.com/iotaledger/hornet/pkg/snapshot"
 	"github.com/iotaledger/hornet/pkg/tangle"
-	iotago "github.com/iotaledger/iota.go/v3"
 )
 
 const (
@@ -103,7 +103,7 @@ func provide(c *dig.Container) error {
 		Storage              *storage.Storage
 		SyncManager          *syncmanager.SyncManager
 		UTXOManager          *utxo.Manager
-		ProtocolParameters   *iotago.ProtocolParameters
+		ProtocolManager      *protocol.Manager
 		PruningPruneReceipts bool   `name:"pruneReceipts"`
 		SnapshotsFullPath    string `name:"snapshotsFullPath"`
 		SnapshotsDeltaPath   string `name:"snapshotsDeltaPath"`
@@ -111,9 +111,9 @@ func provide(c *dig.Container) error {
 
 	return c.Provide(func(deps snapshotDeps) *snapshot.SnapshotManager {
 
-		solidEntryPointCheckThresholdPast := milestone.Index(deps.ProtocolParameters.BelowMaxDepth + SolidEntryPointCheckAdditionalThresholdPast)
-		solidEntryPointCheckThresholdFuture := milestone.Index(deps.ProtocolParameters.BelowMaxDepth + SolidEntryPointCheckAdditionalThresholdFuture)
-		pruningThreshold := milestone.Index(deps.ProtocolParameters.BelowMaxDepth + AdditionalPruningThreshold)
+		solidEntryPointCheckThresholdPast := milestone.Index(deps.ProtocolManager.Current().BelowMaxDepth + SolidEntryPointCheckAdditionalThresholdPast)
+		solidEntryPointCheckThresholdFuture := milestone.Index(deps.ProtocolManager.Current().BelowMaxDepth + SolidEntryPointCheckAdditionalThresholdFuture)
+		pruningThreshold := milestone.Index(deps.ProtocolManager.Current().BelowMaxDepth + AdditionalPruningThreshold)
 
 		snapshotDepth := milestone.Index(ParamsSnapshots.Depth)
 		if snapshotDepth < solidEntryPointCheckThresholdFuture {
@@ -150,7 +150,7 @@ func provide(c *dig.Container) error {
 			deps.Storage,
 			deps.SyncManager,
 			deps.UTXOManager,
-			deps.ProtocolParameters,
+			deps.ProtocolManager,
 			deps.SnapshotsFullPath,
 			deps.SnapshotsDeltaPath,
 			ParamsSnapshots.DeltaSizeThresholdPercentage,

--- a/pkg/common/database_prefixes.go
+++ b/pkg/common/database_prefixes.go
@@ -8,5 +8,6 @@ const (
 	StorePrefixMilestones         byte = 5
 	StorePrefixChildren           byte = 6
 	StorePrefixUnreferencedBlocks byte = 7
+	StorePrefixProtocol           byte = 8
 	StorePrefixHealth             byte = 255
 )

--- a/pkg/model/storage/protocol_storage.go
+++ b/pkg/model/storage/protocol_storage.go
@@ -1,0 +1,42 @@
+package storage
+
+import (
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/serializer/v2"
+	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/pkg/errors"
+)
+
+const (
+	protocolParasStorageKey = "protoParas"
+)
+
+func (s *Storage) StoreProtocolParameters(protoPras *iotago.ProtocolParameters) error {
+	data, err := protoPras.Serialize(serializer.DeSeriModeNoValidation, nil)
+	if err != nil {
+		return errors.Wrap(NewDatabaseError(err), "failed to serialize protocol parameters")
+	}
+
+	if err := s.protocolStore.Set([]byte(protocolParasStorageKey), data); err != nil {
+		return errors.Wrap(NewDatabaseError(err), "failed to protocol parameters")
+	}
+
+	return nil
+}
+
+func (s *Storage) ProtocolParameters() (*iotago.ProtocolParameters, error) {
+	data, err := s.protocolStore.Get([]byte(protocolParasStorageKey))
+	if err != nil {
+		if !errors.Is(err, kvstore.ErrKeyNotFound) {
+			return nil, errors.Wrap(NewDatabaseError(err), "failed to retrieve protocol parameters")
+		}
+		return nil, nil
+	}
+
+	protoParas := &iotago.ProtocolParameters{}
+	if _, err := protoParas.Deserialize(data, serializer.DeSeriModeNoValidation, nil); err != nil {
+		return nil, errors.Wrap(NewDatabaseError(err), "failed to deserialize protocol parameters")
+	}
+
+	return protoParas, nil
+}

--- a/pkg/model/storage/snapshot_db.go
+++ b/pkg/model/storage/snapshot_db.go
@@ -18,6 +18,16 @@ func (s *Storage) configureSnapshotStore(snapshotStore kvstore.KVStore) error {
 	return nil
 }
 
+func (s *Storage) configureProtocolStore(protocolStore kvstore.KVStore) error {
+	protocolStore, err := protocolStore.WithRealm([]byte{common.StorePrefixProtocol})
+	if err != nil {
+		return err
+	}
+
+	s.protocolStore = protocolStore
+	return nil
+}
+
 func (s *Storage) storeSnapshotInfo(snapshot *SnapshotInfo) error {
 
 	data, err := snapshot.Serialize(serializer.DeSeriModeNoValidation, nil)

--- a/pkg/model/storage/storage.go
+++ b/pkg/model/storage/storage.go
@@ -106,6 +106,9 @@ type Storage struct {
 	snapshot      *SnapshotInfo
 	snapshotMutex syncutils.RWMutex
 
+	// protocol
+	protocolStore kvstore.KVStore
+
 	// utxo
 	utxoManager *utxo.Manager
 
@@ -377,6 +380,10 @@ func (s *Storage) configureStorages(tangleStore kvstore.KVStore, cachesProfile .
 	}
 
 	if err := s.configureSnapshotStore(tangleStore); err != nil {
+		return err
+	}
+
+	if err := s.configureProtocolStore(tangleStore); err != nil {
 		return err
 	}
 

--- a/pkg/protocol/gossip/msg_proc_test.go
+++ b/pkg/protocol/gossip/msg_proc_test.go
@@ -3,6 +3,7 @@ package gossip_test
 import (
 	"context"
 	"encoding/json"
+	"github.com/iotaledger/hornet/pkg/protocol"
 	"testing"
 
 	"github.com/libp2p/go-libp2p"
@@ -67,7 +68,7 @@ func TestMessageProcessorEmit(t *testing.T) {
 		TokenSupply:   0,
 	}
 
-	processor, err := gossip.NewMessageProcessor(te.Storage(), te.SyncManager(), gossip.NewRequestQueue(), manager, serverMetrics, protoParas, &gossip.Options{
+	processor, err := gossip.NewMessageProcessor(te.Storage(), te.SyncManager(), gossip.NewRequestQueue(), manager, serverMetrics, protocol.NewManager(te.Storage(), protoParas), &gossip.Options{
 		WorkUnitCacheOpts: testsuite.TestProfileCaches.IncomingBlocksFilter,
 	})
 	require.NoError(t, err)

--- a/pkg/protocol/protocol_manager.go
+++ b/pkg/protocol/protocol_manager.go
@@ -121,10 +121,10 @@ func (m *Manager) LoadPending(syncManager *syncmanager.SyncManager) {
 
 func (m *Manager) readProtocolParasFromMilestone(index milestone.Index) *iotago.ProtocolParamsMilestoneOpt {
 	cachedMs := m.storage.CachedMilestoneByIndexOrNil(index)
-	defer cachedMs.Release(true)
 	if cachedMs == nil {
 		return nil
 	}
+	defer cachedMs.Release(true)
 	return cachedMs.Milestone().Milestone().Opts.MustSet().ProtocolParams()
 }
 

--- a/pkg/protocol/protocol_manager.go
+++ b/pkg/protocol/protocol_manager.go
@@ -1,0 +1,225 @@
+package protocol
+
+import (
+	"fmt"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/serializer/v2"
+	"github.com/iotaledger/hornet/pkg/model/milestone"
+	"github.com/iotaledger/hornet/pkg/model/storage"
+	"github.com/iotaledger/hornet/pkg/model/syncmanager"
+	"github.com/iotaledger/iota.go/v3"
+	"sync"
+)
+
+var (
+	supportedVersions = Versions{2} // make sure to add the versions sorted asc
+)
+
+// Versions is a slice of protocol versions.
+type Versions []uint32
+
+// Highest returns the highest version.
+func (ver Versions) Highest() byte {
+	return byte(ver[len(ver)-1])
+}
+
+// Lowest returns the lowest version.
+func (ver Versions) Lowest() byte {
+	return byte(ver[0])
+}
+
+// Supports tells whether the given version is supported.
+func (ver Versions) Supports(v byte) bool {
+	for _, value := range ver {
+		if value == uint32(v) {
+			return true
+		}
+	}
+	return false
+}
+
+// NewManager creates a new Manager.
+func NewManager(storage *storage.Storage, initProtoParas *iotago.ProtocolParameters) *Manager {
+	return &Manager{
+		Events: &Events{
+			NextMilestoneUnsupported: events.NewEvent(protoParasMsOptCaller),
+			CriticalErrors:           events.NewEvent(events.ErrorCaller),
+		},
+		storage: storage,
+		current: initProtoParas,
+		pending: nil,
+	}
+}
+
+func protoParasMsOptCaller(handler interface{}, params ...interface{}) {
+	handler.(func(protoParas *iotago.ProtocolParamsMilestoneOpt))(params[0].(*iotago.ProtocolParamsMilestoneOpt))
+}
+
+// Events are events happening around the Manager.
+type Events struct {
+	// Emits protocol parameters for the unsupported milestone one milestone before.
+	NextMilestoneUnsupported *events.Event
+	// Emits critical errors.
+	CriticalErrors *events.Event
+}
+
+// Manager handles the knowledge about current, pending and supported protocol versions and parameters.
+type Manager struct {
+	// Events holds the events happening within the Manager.
+	Events      *Events
+	storage     *storage.Storage
+	syncManager *syncmanager.SyncManager
+	currentRWMu sync.RWMutex
+	current     *iotago.ProtocolParameters
+	pendingRWMu sync.RWMutex
+	pending     []*iotago.ProtocolParamsMilestoneOpt
+}
+
+// Init initialises the Manager by loading the last stored or persisting the parameters passed in via constructor.
+func (m *Manager) Init() error {
+	m.currentRWMu.Lock()
+	defer m.currentRWMu.Unlock()
+
+	currentProtoParas, err := m.storage.ProtocolParameters()
+	if err != nil {
+		return err
+	}
+
+	// aka store therefore what the manager was initialised with
+	if currentProtoParas == nil {
+		if err := m.storage.StoreProtocolParameters(m.current); err != nil {
+			return fmt.Errorf("unable to persist init protocol parameters: %w", err)
+		}
+		return nil
+	}
+
+	m.current = currentProtoParas
+
+	return nil
+}
+
+// LoadPending examines the database back to below max depth for pending protocol parameter changes.
+func (m *Manager) LoadPending(syncManager *syncmanager.SyncManager) {
+	m.pendingRWMu.Lock()
+	defer m.pendingRWMu.Unlock()
+
+	// examine below max depth milestone to reconstruct pending protocol changes
+	confMsIndex := syncManager.ConfirmedMilestoneIndex()
+	belowMaxDepthTarget := confMsIndex - milestone.Index(m.current.BelowMaxDepth)
+	for i := belowMaxDepthTarget; i < confMsIndex; i-- {
+		if protoParasMsOpt := m.readProtocolParasFromMilestone(i); protoParasMsOpt != nil {
+			m.pending = append(m.pending, protoParasMsOpt)
+		}
+	}
+}
+
+func (m *Manager) readProtocolParasFromMilestone(index milestone.Index) *iotago.ProtocolParamsMilestoneOpt {
+	cachedMs := m.storage.CachedMilestoneByIndexOrNil(index)
+	defer cachedMs.Release(true)
+	if cachedMs == nil {
+		return nil
+	}
+	return cachedMs.Milestone().Milestone().Opts.MustSet().ProtocolParams()
+}
+
+// SupportedVersions returns a slice of supported protocol versions.
+func (m *Manager) SupportedVersions() Versions {
+	return supportedVersions
+}
+
+// Current returns the current protocol parameters under which the node is operating.
+func (m *Manager) Current() *iotago.ProtocolParameters {
+	m.currentRWMu.RLock()
+	defer m.currentRWMu.RUnlock()
+	return m.current
+}
+
+// Pending returns the currently pending protocol changes.
+func (m *Manager) Pending() []*iotago.ProtocolParamsMilestoneOpt {
+	m.pendingRWMu.RLock()
+	defer m.pendingRWMu.RUnlock()
+	cpy := make([]*iotago.ProtocolParamsMilestoneOpt, len(m.pending))
+	for i, ele := range m.pending {
+		cpy[i] = ele.Clone().(*iotago.ProtocolParamsMilestoneOpt)
+	}
+	return cpy
+}
+
+// NextPendingSupported tells whether the next pending protocol parameters changes are supported.
+func (m *Manager) NextPendingSupported() bool {
+	m.pendingRWMu.RLock()
+	defer m.pendingRWMu.RUnlock()
+	if len(m.pending) == 0 {
+		return true
+	}
+	return m.SupportedVersions().Supports(m.pending[0].ProtocolVersion)
+}
+
+// HandleConfirmedMilestone examines the newly confirmed milestone for protocol parameter changes.
+func (m *Manager) HandleConfirmedMilestone(cachedMilestone *storage.CachedMilestone) {
+	defer cachedMilestone.Release(true) // milestone -1
+	ms := cachedMilestone.Milestone()
+
+	if msProtoParas := ms.Milestone().Opts.MustSet().ProtocolParams(); msProtoParas != nil {
+		m.pendingRWMu.Lock()
+		m.pending = append(m.pending, msProtoParas)
+		m.pendingRWMu.Unlock()
+	}
+
+	if !m.currentShouldChange(ms) {
+		return
+	}
+
+	if err := m.updateCurrent(); err != nil {
+		m.Events.CriticalErrors.Trigger(err)
+		return
+	}
+}
+
+// checks whether the current protocol parameters need to be updated.
+func (m *Manager) currentShouldChange(milestone *storage.Milestone) bool {
+	m.pendingRWMu.RLock()
+	defer m.pendingRWMu.RUnlock()
+	if len(m.pending) == 0 {
+		return false
+	}
+
+	next := m.pending[0]
+
+	switch {
+	case next.TargetMilestoneIndex == milestone.Milestone().Index+1:
+		if !m.SupportedVersions().Supports(next.ProtocolVersion) {
+			m.Events.NextMilestoneUnsupported.Trigger(next)
+		}
+		return false
+	case next.TargetMilestoneIndex > milestone.Milestone().Index:
+		return false
+	default:
+		return true
+	}
+}
+
+func (m *Manager) updateCurrent() error {
+	m.currentRWMu.Lock()
+	defer m.currentRWMu.Unlock()
+	m.pendingRWMu.Lock()
+	defer m.pendingRWMu.Unlock()
+
+	nextMsProtoParamOpt := m.pending[0]
+	nextParams := nextMsProtoParamOpt.Params
+
+	// TODO: needs to be adapted for when protocol parameters struct changes
+	nextProtoParams := &iotago.ProtocolParameters{}
+	if _, err := nextProtoParams.Deserialize(nextParams, serializer.DeSeriModePerformValidation, nil); err != nil {
+		return fmt.Errorf("unable to deserialize next protocol parameters: %w", err)
+	}
+
+	m.current = nextProtoParams
+	m.pending = m.pending[1:]
+
+	if err := m.storage.StoreProtocolParameters(m.current); err != nil {
+		return fmt.Errorf("unable to persist new protocol parameters: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/protocol/protocol_manager.go
+++ b/pkg/protocol/protocol_manager.go
@@ -76,6 +76,7 @@ type Manager struct {
 }
 
 // Init initialises the Manager by loading the last stored or persisting the parameters passed in via constructor.
+// If the Manager got initialised with no storage, then Manager.Init() is a no-op and initProtoParas are used instead.
 func (m *Manager) Init() error {
 	// can only run with provided protocol parameters
 	if m.storage == nil {

--- a/pkg/protocol/protocol_manager.go
+++ b/pkg/protocol/protocol_manager.go
@@ -217,7 +217,7 @@ func (m *Manager) updateCurrent() error {
 	// TODO: needs to be adapted for when protocol parameters struct changes
 	nextProtoParams := &iotago.ProtocolParameters{}
 	if _, err := nextProtoParams.Deserialize(nextParams, serializer.DeSeriModePerformValidation, nil); err != nil {
-		return fmt.Errorf("unable to deserialize next protocol parameters: %w", err)
+		return fmt.Errorf("unable to deserialize new protocol parameters: %w", err)
 	}
 
 	m.current = nextProtoParams

--- a/pkg/protocol/protocol_manager.go
+++ b/pkg/protocol/protocol_manager.go
@@ -77,6 +77,11 @@ type Manager struct {
 
 // Init initialises the Manager by loading the last stored or persisting the parameters passed in via constructor.
 func (m *Manager) Init() error {
+	// can only run with provided protocol parameters
+	if m.storage == nil {
+		return nil
+	}
+
 	m.currentRWMu.Lock()
 	defer m.currentRWMu.Unlock()
 

--- a/pkg/snapshot/snapshot_write.go
+++ b/pkg/snapshot/snapshot_write.go
@@ -459,7 +459,7 @@ func (s *SnapshotManager) createSnapshotWithoutLocking(
 		default:
 			// as the needed milestone diffs are pruned from the database, we need to use
 			// the previous delta snapshot file to extract those in conjunction with what the database has available
-			milestoneDiffProducer, err = newMsDiffsProducerDeltaFileAndDatabase(s.snapshotDeltaPath, s.storage, s.utxoManager, header.LedgerMilestoneIndex, targetIndex, s.protoParas)
+			milestoneDiffProducer, err = newMsDiffsProducerDeltaFileAndDatabase(s.snapshotDeltaPath, s.storage, s.utxoManager, header.LedgerMilestoneIndex, targetIndex, s.protoMng.Current())
 			if err != nil {
 				return err
 			}

--- a/pkg/tangle/attacher.go
+++ b/pkg/tangle/attacher.go
@@ -115,7 +115,7 @@ func (a *BlockAttacher) AttachBlock(ctx context.Context, iotaBlock *iotago.Block
 				return iotago.EmptyBlockID(), errors.WithMessagef(ErrBlockAttacherInvalidBlock, err.Error())
 			}
 
-			if score < float64(a.tangle.protoParas.MinPoWScore) {
+			if score < float64(a.tangle.protoMng.Current().MinPoWScore) {
 				if a.opts.powHandler == nil {
 					return iotago.EmptyBlockID(), ErrBlockAttacherPoWNotAvailable
 				}
@@ -140,7 +140,7 @@ func (a *BlockAttacher) AttachBlock(ctx context.Context, iotaBlock *iotago.Block
 		}
 	}
 
-	block, err := storage.NewBlock(iotaBlock, serializer.DeSeriModePerformValidation, a.tangle.protoParas)
+	block, err := storage.NewBlock(iotaBlock, serializer.DeSeriModePerformValidation, a.tangle.protoMng.Current())
 	if err != nil {
 		return iotago.EmptyBlockID(), errors.WithMessagef(ErrBlockAttacherInvalidBlock, err.Error())
 	}

--- a/pkg/tangle/health.go
+++ b/pkg/tangle/health.go
@@ -26,6 +26,10 @@ func (t *Tangle) IsNodeHealthy() bool {
 		return false
 	}
 
+	if !t.protoMng.NextPendingSupported() {
+		return false
+	}
+
 	// latest milestone timestamp
 	lmi := t.syncManager.LatestMilestoneIndex()
 

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -339,7 +339,7 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 		t.storage.UTXOManager(),
 		memcachedTraverserStorage,
 		blocksMemcache.CachedBlock,
-		t.protoParas,
+		t.protoMng.Current(),
 		milestonePayloadToSolidify,
 		whiteflag.DefaultWhiteFlagTraversalCondition,
 		whiteflag.DefaultCheckBlockReferencedFunc,

--- a/pkg/tangle/tangle.go
+++ b/pkg/tangle/tangle.go
@@ -2,6 +2,7 @@ package tangle
 
 import (
 	"context"
+	"github.com/iotaledger/hornet/pkg/protocol"
 	"runtime"
 	"sync"
 	"time"
@@ -19,7 +20,6 @@ import (
 	"github.com/iotaledger/hornet/pkg/model/storage"
 	"github.com/iotaledger/hornet/pkg/model/syncmanager"
 	"github.com/iotaledger/hornet/pkg/protocol/gossip"
-	iotago "github.com/iotaledger/iota.go/v3"
 )
 
 type Tangle struct {
@@ -48,8 +48,8 @@ type Tangle struct {
 	requester *gossip.Requester
 	// used to persist and validate batches of receipts.
 	receiptService *migrator.ReceiptService
-	// the protocol parameters
-	protoParas *iotago.ProtocolParameters
+	// the protocol manager
+	protoMng *protocol.Manager
 
 	milestoneTimeout             time.Duration
 	whiteFlagParentsSolidTimeout time.Duration
@@ -121,7 +121,7 @@ func New(
 	serverMetrics *metrics.ServerMetrics,
 	requester *gossip.Requester,
 	receiptService *migrator.ReceiptService,
-	protoParas *iotago.ProtocolParameters,
+	protoMng *protocol.Manager,
 	milestoneTimeout time.Duration,
 	whiteFlagParentsSolidTimeout time.Duration,
 	updateSyncedAtStartup bool) *Tangle {
@@ -139,7 +139,7 @@ func New(
 		serverMetrics:                serverMetrics,
 		requester:                    requester,
 		receiptService:               receiptService,
-		protoParas:                   protoParas,
+		protoMng:                     protoMng,
 		milestoneTimeout:             milestoneTimeout,
 		whiteFlagParentsSolidTimeout: whiteFlagParentsSolidTimeout,
 		updateSyncedAtStartup:        updateSyncedAtStartup,

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -2,6 +2,7 @@ package autopeering
 
 import (
 	"context"
+	"github.com/iotaledger/hornet/pkg/protocol"
 	"strings"
 	"time"
 
@@ -33,7 +34,6 @@ import (
 	restapiv2 "github.com/iotaledger/hornet/plugins/restapi/v2"
 	"github.com/iotaledger/hornet/plugins/urts"
 	"github.com/iotaledger/hornet/plugins/warpsync"
-	iotago "github.com/iotaledger/iota.go/v3"
 )
 
 func init() {
@@ -152,7 +152,7 @@ func provide(c *dig.Container) error {
 
 	type autopeeringDeps struct {
 		dig.In
-		ProtocolParameters *iotago.ProtocolParameters
+		ProtocolManager *protocol.Manager
 	}
 
 	if err := c.Provide(func(deps autopeeringDeps) *autopeering.AutopeeringManager {
@@ -161,7 +161,7 @@ func provide(c *dig.Container) error {
 			ParamsAutopeering.BindAddress,
 			ParamsAutopeering.EntryNodes,
 			ParamsAutopeering.EntryNodesPreferIPv6,
-			service.Key(deps.ProtocolParameters.NetworkName),
+			service.Key(deps.ProtocolManager.Current().NetworkName),
 		)
 	}); err != nil {
 		Plugin.LogPanic(err)

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -2,6 +2,7 @@ package autopeering
 
 import (
 	"context"
+	"github.com/iotaledger/hornet/core/protocfg"
 	"github.com/iotaledger/hornet/pkg/protocol"
 	"strings"
 	"time"
@@ -119,6 +120,7 @@ func preProvide(c *dig.Container, _ *app.App, initConfig *app.InitConfig) error 
 		initConfig.ForceDisableComponent(pow.CoreComponent.Identifier())
 		initConfig.ForceDisableComponent(gossip.CoreComponent.Identifier())
 		initConfig.ForceDisableComponent(tangle.CoreComponent.Identifier())
+		initConfig.ForceDisableComponent(protocfg.CoreComponent.Identifier())
 		initConfig.ForceDisableComponent(snapshot.CoreComponent.Identifier())
 		initConfig.ForceDisableComponent(restapiv2.Plugin.Identifier())
 		initConfig.ForceDisableComponent(warpsync.Plugin.Identifier())

--- a/plugins/inx/plugin.go
+++ b/plugins/inx/plugin.go
@@ -2,6 +2,7 @@ package inx
 
 import (
 	"context"
+	"github.com/iotaledger/hornet/pkg/protocol"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -20,7 +21,6 @@ import (
 	"github.com/iotaledger/hornet/pkg/tangle"
 	"github.com/iotaledger/hornet/pkg/tipselect"
 	"github.com/iotaledger/hornet/plugins/restapi"
-	iotago "github.com/iotaledger/iota.go/v3"
 )
 
 func init() {
@@ -47,22 +47,21 @@ var (
 
 type dependencies struct {
 	dig.In
-	SyncManager               *syncmanager.SyncManager
-	UTXOManager               *utxo.Manager
-	Tangle                    *tangle.Tangle
-	TipScoreCalculator        *tangle.TipScoreCalculator
-	Storage                   *storage.Storage
-	KeyManager                *keymanager.KeyManager
-	TipSelector               *tipselect.TipSelector `optional:"true"`
-	MilestonePublicKeyCount   int                    `name:"milestonePublicKeyCount"`
-	SupportedProtocolVersions protocfg.SupportedProtocolVersions
-	ProtocolParameters        *iotago.ProtocolParameters
-	BaseToken                 *protocfg.BaseToken
-	PoWHandler                *pow.Handler
-	INXServer                 *INXServer
-	INXMetrics                *metrics.INXMetrics
-	Echo                      *echo.Echo                 `optional:"true"`
-	RestPluginManager         *restapi.RestPluginManager `optional:"true"`
+	SyncManager             *syncmanager.SyncManager
+	UTXOManager             *utxo.Manager
+	Tangle                  *tangle.Tangle
+	TipScoreCalculator      *tangle.TipScoreCalculator
+	Storage                 *storage.Storage
+	KeyManager              *keymanager.KeyManager
+	TipSelector             *tipselect.TipSelector `optional:"true"`
+	MilestonePublicKeyCount int                    `name:"milestonePublicKeyCount"`
+	ProtocolManager         *protocol.Manager
+	BaseToken               *protocfg.BaseToken
+	PoWHandler              *pow.Handler
+	INXServer               *INXServer
+	INXMetrics              *metrics.INXMetrics
+	Echo                    *echo.Echo                 `optional:"true"`
+	RestPluginManager       *restapi.RestPluginManager `optional:"true"`
 }
 
 func provide(c *dig.Container) error {

--- a/plugins/inx/server.go
+++ b/plugins/inx/server.go
@@ -117,7 +117,7 @@ func (s *INXServer) ReadNodeConfiguration(context.Context, *inx.NoParams) (*inx.
 		})
 	}
 	return &inx.NodeConfiguration{
-		ProtocolParameters:      inx.NewProtocolParameters(deps.ProtocolParameters),
+		ProtocolParameters:      inx.NewProtocolParameters(deps.ProtocolManager.Current()),
 		MilestonePublicKeyCount: uint32(deps.MilestonePublicKeyCount),
 		MilestoneKeyRanges:      keyRanges,
 		BaseToken: &inx.BaseToken{
@@ -128,7 +128,7 @@ func (s *INXServer) ReadNodeConfiguration(context.Context, *inx.NoParams) (*inx.
 			Decimals:        deps.BaseToken.Decimals,
 			UseMetricPrefix: deps.BaseToken.UseMetricPrefix,
 		},
-		SupportedProtocolVersions: deps.SupportedProtocolVersions,
+		SupportedProtocolVersions: deps.ProtocolManager.SupportedVersions(),
 	}, nil
 }
 

--- a/plugins/restapi/v2/blocks.go
+++ b/plugins/restapi/v2/blocks.go
@@ -168,7 +168,7 @@ func sendBlock(c echo.Context) (*blockCreatedResponse, error) {
 		}
 
 		// Do not validate here, the parents might need to be set
-		if _, err := iotaBlock.Deserialize(bytes, serializer.DeSeriModeNoValidation, deps.ProtocolParameters); err != nil {
+		if _, err := iotaBlock.Deserialize(bytes, serializer.DeSeriModeNoValidation, deps.ProtocolManager.Current()); err != nil {
 			return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid block, error: %s", err)
 		}
 
@@ -176,13 +176,13 @@ func sendBlock(c echo.Context) (*blockCreatedResponse, error) {
 		return nil, echo.ErrUnsupportedMediaType
 	}
 
-	if iotaBlock.ProtocolVersion != deps.ProtocolParameters.Version {
+	if iotaBlock.ProtocolVersion != deps.ProtocolManager.Current().Version {
 		return nil, errors.WithMessage(restapi.ErrInvalidParameter, "invalid block, error: protocolVersion invalid")
 	}
 
 	switch payload := iotaBlock.Payload.(type) {
 	case *iotago.Transaction:
-		if payload.Essence.NetworkID != deps.ProtocolParameters.NetworkID() {
+		if payload.Essence.NetworkID != deps.ProtocolManager.Current().NetworkID() {
 			return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid payload, error: wrong networkID: %d", payload.Essence.NetworkID)
 		}
 	default:

--- a/plugins/restapi/v2/node.go
+++ b/plugins/restapi/v2/node.go
@@ -69,8 +69,8 @@ func info() (*infoResponse, error) {
 			},
 			PruningIndex: pruningIndex,
 		},
-		SupportedProtocolVersions: deps.SupportedProtocolVersions,
-		ProtocolParameters:        deps.ProtocolParameters,
+		SupportedProtocolVersions: deps.ProtocolManager.SupportedVersions(),
+		ProtocolParameters:        deps.ProtocolManager.Current(),
 		BaseToken:                 deps.BaseToken,
 		Metrics: nodeMetrics{
 			BlocksPerSecond:           blocksPerSecond,

--- a/plugins/restapi/v2/plugin.go
+++ b/plugins/restapi/v2/plugin.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"github.com/iotaledger/hornet/pkg/protocol"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -20,7 +21,6 @@ import (
 	"github.com/iotaledger/hornet/pkg/tangle"
 	"github.com/iotaledger/hornet/pkg/tipselect"
 	"github.com/iotaledger/hornet/plugins/restapi"
-	iotago "github.com/iotaledger/iota.go/v3"
 )
 
 const (
@@ -141,27 +141,26 @@ var (
 
 type dependencies struct {
 	dig.In
-	Storage                   *storage.Storage
-	SyncManager               *syncmanager.SyncManager
-	Tangle                    *tangle.Tangle
-	TipScoreCalculator        *tangle.TipScoreCalculator
-	PeeringManager            *p2p.Manager
-	GossipService             *gossip.Service
-	UTXOManager               *utxo.Manager
-	PoWHandler                *pow.Handler
-	SnapshotManager           *snapshot.SnapshotManager
-	AppInfo                   *app.AppInfo
-	PeeringConfigManager      *p2p.ConfigManager
-	SupportedProtocolVersions protocfg.SupportedProtocolVersions
-	ProtocolParameters        *iotago.ProtocolParameters
-	BaseToken                 *protocfg.BaseToken
-	RestAPILimitsMaxResults   int                        `name:"restAPILimitsMaxResults"`
-	SnapshotsFullPath         string                     `name:"snapshotsFullPath"`
-	SnapshotsDeltaPath        string                     `name:"snapshotsDeltaPath"`
-	TipSelector               *tipselect.TipSelector     `optional:"true"`
-	Echo                      *echo.Echo                 `optional:"true"`
-	RestPluginManager         *restapi.RestPluginManager `optional:"true"`
-	RestAPIMetrics            *metrics.RestAPIMetrics
+	Storage                 *storage.Storage
+	SyncManager             *syncmanager.SyncManager
+	Tangle                  *tangle.Tangle
+	TipScoreCalculator      *tangle.TipScoreCalculator
+	PeeringManager          *p2p.Manager
+	GossipService           *gossip.Service
+	UTXOManager             *utxo.Manager
+	PoWHandler              *pow.Handler
+	SnapshotManager         *snapshot.SnapshotManager
+	AppInfo                 *app.AppInfo
+	PeeringConfigManager    *p2p.ConfigManager
+	ProtocolManager         *protocol.Manager
+	BaseToken               *protocfg.BaseToken
+	RestAPILimitsMaxResults int                        `name:"restAPILimitsMaxResults"`
+	SnapshotsFullPath       string                     `name:"snapshotsFullPath"`
+	SnapshotsDeltaPath      string                     `name:"snapshotsDeltaPath"`
+	TipSelector             *tipselect.TipSelector     `optional:"true"`
+	Echo                    *echo.Echo                 `optional:"true"`
+	RestPluginManager       *restapi.RestPluginManager `optional:"true"`
+	RestAPIMetrics          *metrics.RestAPIMetrics
 }
 
 func configure() error {

--- a/plugins/restapi/v2/types.go
+++ b/plugins/restapi/v2/types.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"encoding/json"
+	"github.com/iotaledger/hornet/pkg/protocol"
 
 	"github.com/iotaledger/hornet/core/protocfg"
 	"github.com/iotaledger/hornet/pkg/model/milestone"
@@ -50,7 +51,7 @@ type infoResponse struct {
 	// The current status of this node.
 	Status nodeStatus `json:"status"`
 	// The protocol versions this node supports.
-	SupportedProtocolVersions protocfg.SupportedProtocolVersions `json:"supportedProtocolVersions"`
+	SupportedProtocolVersions protocol.Versions `json:"supportedProtocolVersions"`
 	// The protocol parameters used by this node.
 	ProtocolParameters *iotago.ProtocolParameters `json:"protocol"`
 	// The base token of the network.


### PR DESCRIPTION
Makes the `protocfg` plugin init a `protocol.Manager` instance which keeps track of the current protocol parameters and pending ones extracted from milestones. The current protocol parameters are always persisted to disk and up on startup, either the default config protocol parameters are used or the ones available on disk.

Additionally, up on the configure stage, the `protocol.Manager` examines the milestones back `belowMaxDepth` from the current confirmed milestone to reconstruct the pending protocol changes.

`isHealthy` is now dependent on whether there is a pending protocol parameter change with a protocol version which is not supported, in which case healthy is set to false (to inform clients soon enough that the node will not function further).

The `protocol.Manager` shuts down the node if it encounters a critical error.

Since there is a cyclic dependency between the `syncmanager.SyncManager`'s requirement of knowing the below max depth parameter on `New()` and the `protocol.Manager` needing the SyncManager for the above mentioned reconstruction of pending protocol parameters, this function is only executed within `configure` of `protocfg` as to break the cyclic dependency.

All code paths or constructors which took a `iotago.ProtocolParameters` are now taking a `protocol.Manager` and use its `Current()` method to get the current protocol parameters instead.

Fixes https://github.com/iotaledger/hornet/issues/1554