### PR TITLE
Fix INX deadlock

### DIFF
--- a/pkg/tangle/events.go
+++ b/pkg/tangle/events.go
@@ -43,6 +43,10 @@ func ReceiptCaller(handler interface{}, params ...interface{}) {
 	handler.(func(*iotago.ReceiptMilestoneOpt))(params[0].(*iotago.ReceiptMilestoneOpt))
 }
 
+func ReferencedBlocksCountUpdatedCaller(handler interface{}, params ...interface{}) {
+	handler.(func(msIndex milestone.Index, referencedBlocksCount int))(params[0].(milestone.Index), params[1].(int))
+}
+
 type Events struct {
 	BPSMetricsUpdated              *events.Event
 	ReceivedNewBlock               *events.Event
@@ -63,4 +67,5 @@ type Events struct {
 	LedgerUpdated                  *events.Event
 	TreasuryMutated                *events.Event
 	NewReceipt                     *events.Event
+	ReferencedBlocksCountUpdated   *events.Event
 }

--- a/pkg/tangle/events.go
+++ b/pkg/tangle/events.go
@@ -48,24 +48,40 @@ func ReferencedBlocksCountUpdatedCaller(handler interface{}, params ...interface
 }
 
 type Events struct {
-	BPSMetricsUpdated              *events.Event
-	ReceivedNewBlock               *events.Event
-	ReceivedKnownBlock             *events.Event
-	ProcessedBlock                 *events.Event
-	BlockSolid                     *events.Event
-	BlockReferenced                *events.Event
-	ReceivedNewMilestoneBlock      *events.Event
-	LatestMilestoneChanged         *events.Event
-	LatestMilestoneIndexChanged    *events.Event
-	MilestoneConfirmed             *events.Event
-	ConfirmedMilestoneChanged      *events.Event
+	// block events
+	ReceivedNewBlock          *events.Event
+	BlockSolid                *events.Event
+	ReceivedNewMilestoneBlock *events.Event // remove with dashboard removal PR
+
+	// milestone events
+	LatestMilestoneChanged        *events.Event
+	LatestMilestoneIndexChanged   *events.Event
+	MilestoneSolidificationFailed *events.Event
+	MilestoneTimeout              *events.Event
+
+	// metrics
+	BPSMetricsUpdated *events.Event
+
+	// Events related to milestone confirmation
+
+	// Hint: Ledger is write locked
 	ConfirmedMilestoneIndexChanged *events.Event
-	NewConfirmedMilestoneMetric    *events.Event
-	ConfirmationMetricsUpdated     *events.Event
-	MilestoneSolidificationFailed  *events.Event
-	MilestoneTimeout               *events.Event
-	LedgerUpdated                  *events.Event
-	TreasuryMutated                *events.Event
-	NewReceipt                     *events.Event
-	ReferencedBlocksCountUpdated   *events.Event
+	// Hint: Ledger is not locked
+	NewConfirmedMilestoneMetric *events.Event // used for dashboard metrics
+	// Hint: Ledger is not locked
+	MilestoneConfirmed *events.Event // used for dashboard metrics
+	// Hint: Ledger is not locked
+	ConfirmationMetricsUpdated *events.Event // used for prometheus metrics
+	// Hint: Ledger is not locked
+	ConfirmedMilestoneChanged *events.Event
+	// Hint: Ledger is not locked
+	BlockReferenced *events.Event
+	// Hint: Ledger is not locked
+	ReferencedBlocksCountUpdated *events.Event
+	// Hint: Ledger is not locked
+	LedgerUpdated *events.Event
+	// Hint: Ledger is not locked
+	TreasuryMutated *events.Event
+	// Hint: Ledger is not locked
+	NewReceipt *events.Event
 }

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -319,9 +319,22 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 		return
 	}
 
-	var timeStartConfirmation, timeSetConfirmedMilestoneIndex, timeUpdateConeRootIndexes, timeConfirmedMilestoneChanged, timeConfirmedMilestoneIndexChanged, timeMilestoneConfirmedSyncEvent, timeMilestoneConfirmed time.Time
+	var (
+		timeStart                             time.Time
+		timeSetConfirmedMilestoneIndexStart   time.Time
+		timeSetConfirmedMilestoneIndexEnd     time.Time
+		timeUpdateConeRootIndexesEnd          time.Time
+		timeConfirmedMilestoneIndexChangedEnd time.Time
+		timeMilestoneConfirmedStart           time.Time
+		timeMilestoneConfirmedEnd             time.Time
+		timeConfirmedMilestoneChangedStart    time.Time
+		timeConfirmedMilestoneChangedEnd      time.Time
+	)
 
-	timeStart := time.Now()
+	var newReceipt *iotago.ReceiptMilestoneOpt
+	var newConfirmation *whiteflag.Confirmation
+
+	timeStart = time.Now()
 	confirmedMilestoneStats, confirmationMetrics, err := whiteflag.ConfirmMilestone(
 		t.storage.UTXOManager(),
 		memcachedTraverserStorage,
@@ -332,37 +345,10 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 		whiteflag.DefaultCheckBlockReferencedFunc,
 		whiteflag.DefaultSetBlockReferencedFunc,
 		t.serverMetrics,
-		func(blockMeta *storage.CachedMetadata, index milestone.Index, confTime uint32) {
-			t.Events.BlockReferenced.Trigger(blockMeta, index, confTime)
-		},
-		func(confirmation *whiteflag.Confirmation) {
-			timeStartConfirmation = time.Now()
-			if err := t.syncManager.SetConfirmedMilestoneIndex(milestoneIndexToSolidify); err != nil {
-				t.LogPanicf("SetConfirmedMilestoneIndex failed: %s", err)
-			}
-			timeSetConfirmedMilestoneIndex = time.Now()
-			if t.syncManager.IsNodeAlmostSynced() {
-				// propagate new cone root indexes to the future cone (needed for URTS, heaviest branch tipselection, block broadcasting, etc...)
-				// we can safely ignore errors of the future cone solidifier.
-				_ = dag.UpdateConeRootIndexes(milestoneSolidificationCtx, memcachedTraverserStorage, confirmation.Mutations.BlocksReferenced, confirmation.MilestoneIndex)
-			}
-			timeUpdateConeRootIndexes = time.Now()
-			t.Events.ConfirmedMilestoneChanged.Trigger(cachedMilestoneToSolidify) // milestone pass +1
-			timeConfirmedMilestoneChanged = time.Now()
-			t.Events.ConfirmedMilestoneIndexChanged.Trigger(milestoneIndexToSolidify)
-			timeConfirmedMilestoneIndexChanged = time.Now()
-			t.milestoneConfirmedSyncEvent.Trigger(milestoneIndexToSolidify)
-			timeMilestoneConfirmedSyncEvent = time.Now()
-			t.Events.MilestoneConfirmed.Trigger(confirmation)
-			timeMilestoneConfirmed = time.Now()
-		},
-		func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
-			t.Events.LedgerUpdated.Trigger(index, newOutputs, newSpents)
-		},
-		func(index milestone.Index, tuple *utxo.TreasuryMutationTuple) {
-			t.Events.TreasuryMutated.Trigger(index, tuple)
-		},
+		// Hint: Ledger is write locked
 		func(rt *utxo.ReceiptTuple) error {
+			newReceipt = rt.Receipt
+
 			if t.receiptService != nil {
 				if t.receiptService.ValidationEnabled {
 					if err := t.receiptService.ValidateWithoutLocking(rt.Receipt); err != nil {
@@ -379,12 +365,58 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 					}
 				}
 			}
-			t.Events.NewReceipt.Trigger(rt.Receipt)
 			return nil
+		},
+		// Hint: Ledger is write locked
+		func(confirmation *whiteflag.Confirmation) {
+			newConfirmation = confirmation
+
+			timeSetConfirmedMilestoneIndexStart = time.Now()
+			if err := t.syncManager.SetConfirmedMilestoneIndex(milestoneIndexToSolidify); err != nil {
+				t.LogPanicf("SetConfirmedMilestoneIndex failed: %s", err)
+			}
+			timeSetConfirmedMilestoneIndexEnd = time.Now()
+
+			if t.syncManager.IsNodeAlmostSynced() {
+				// propagate new cone root indexes to the future cone (needed for URTS, heaviest branch tipselection, block broadcasting, etc...)
+				// we can safely ignore errors of the future cone solidifier.
+				_ = dag.UpdateConeRootIndexes(milestoneSolidificationCtx, memcachedTraverserStorage, confirmation.Mutations.BlocksReferenced, confirmation.MilestoneIndex)
+			}
+			timeUpdateConeRootIndexesEnd = time.Now()
+
+			t.Events.ConfirmedMilestoneIndexChanged.Trigger(milestoneIndexToSolidify)
+			timeConfirmedMilestoneIndexChangedEnd = time.Now()
+		},
+		// Hint: Ledger is not locked
+		func(blockMeta *storage.CachedMetadata, index milestone.Index, confTime uint32) {
+			t.Events.BlockReferenced.Trigger(blockMeta, index, confTime)
+		},
+		// Hint: Ledger is not locked
+		func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
+			t.Events.LedgerUpdated.Trigger(index, newOutputs, newSpents)
+		},
+		// Hint: Ledger is not locked
+		func(index milestone.Index, tuple *utxo.TreasuryMutationTuple) {
+			t.Events.TreasuryMutated.Trigger(index, tuple)
 		})
 
 	if err != nil {
 		t.LogPanic(err)
+	}
+
+	if newReceipt != nil {
+		t.Events.NewReceipt.Trigger(newReceipt)
+	}
+
+	timeConfirmedMilestoneChangedStart = time.Now()
+	t.Events.ConfirmedMilestoneChanged.Trigger(cachedMilestoneToSolidify) // milestone pass +1
+	timeConfirmedMilestoneChangedEnd = time.Now()
+
+	if newConfirmation != nil {
+		t.Events.ReferencedBlocksCountUpdated.Trigger(milestoneIndexToSolidify, len(newConfirmation.Mutations.BlocksReferenced))
+		timeMilestoneConfirmedStart = time.Now()
+		t.Events.MilestoneConfirmed.Trigger(newConfirmation)
+		timeMilestoneConfirmedEnd = time.Now()
 	}
 
 	t.LogInfof("Milestone confirmed (%d): txsReferenced: %v, txsValue: %v, txsZeroValue: %v, txsConflicting: %v, collect: %v, total: %v",
@@ -397,11 +429,11 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 		time.Since(timeStart).Truncate(time.Millisecond),
 	)
 
-	confirmationMetrics.DurationSetConfirmedMilestoneIndex = timeSetConfirmedMilestoneIndex.Sub(timeStartConfirmation)
-	confirmationMetrics.DurationUpdateConeRootIndexes = timeUpdateConeRootIndexes.Sub(timeSetConfirmedMilestoneIndex)
-	confirmationMetrics.DurationConfirmedMilestoneChanged = timeConfirmedMilestoneChanged.Sub(timeUpdateConeRootIndexes)
-	confirmationMetrics.DurationConfirmedMilestoneIndexChanged = timeConfirmedMilestoneIndexChanged.Sub(timeConfirmedMilestoneChanged)
-	confirmationMetrics.DurationMilestoneConfirmed = timeMilestoneConfirmed.Sub(timeConfirmedMilestoneIndexChanged)
+	confirmationMetrics.DurationSetConfirmedMilestoneIndex = timeSetConfirmedMilestoneIndexEnd.Sub(timeSetConfirmedMilestoneIndexStart)
+	confirmationMetrics.DurationUpdateConeRootIndexes = timeUpdateConeRootIndexesEnd.Sub(timeSetConfirmedMilestoneIndexEnd)
+	confirmationMetrics.DurationConfirmedMilestoneIndexChanged = timeConfirmedMilestoneIndexChangedEnd.Sub(timeUpdateConeRootIndexesEnd)
+	confirmationMetrics.DurationConfirmedMilestoneChanged = timeConfirmedMilestoneChangedEnd.Sub(timeConfirmedMilestoneChangedStart)
+	confirmationMetrics.DurationMilestoneConfirmed = timeMilestoneConfirmedEnd.Sub(timeMilestoneConfirmedStart)
 	confirmationMetrics.DurationTotal = time.Since(timeStart)
 
 	t.Events.ConfirmationMetricsUpdated.Trigger(confirmationMetrics)

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -401,8 +401,7 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 	confirmationMetrics.DurationUpdateConeRootIndexes = timeUpdateConeRootIndexes.Sub(timeSetConfirmedMilestoneIndex)
 	confirmationMetrics.DurationConfirmedMilestoneChanged = timeConfirmedMilestoneChanged.Sub(timeUpdateConeRootIndexes)
 	confirmationMetrics.DurationConfirmedMilestoneIndexChanged = timeConfirmedMilestoneIndexChanged.Sub(timeConfirmedMilestoneChanged)
-	confirmationMetrics.DurationMilestoneConfirmedSyncEvent = timeMilestoneConfirmedSyncEvent.Sub(timeConfirmedMilestoneIndexChanged)
-	confirmationMetrics.DurationMilestoneConfirmed = timeMilestoneConfirmed.Sub(timeMilestoneConfirmedSyncEvent)
+	confirmationMetrics.DurationMilestoneConfirmed = timeMilestoneConfirmed.Sub(timeConfirmedMilestoneIndexChanged)
 	confirmationMetrics.DurationTotal = time.Since(timeStart)
 
 	t.Events.ConfirmationMetricsUpdated.Trigger(confirmationMetrics)

--- a/pkg/tangle/tangle.go
+++ b/pkg/tangle/tangle.go
@@ -173,6 +173,7 @@ func New(
 			ConfirmedMilestoneIndexChanged: events.NewEvent(milestone.IndexCaller),
 			NewConfirmedMilestoneMetric:    events.NewEvent(NewConfirmedMilestoneMetricCaller),
 			ConfirmationMetricsUpdated:     events.NewEvent(ConfirmationMetricsCaller),
+			ReferencedBlocksCountUpdated:   events.NewEvent(ReferencedBlocksCountUpdatedCaller),
 			MilestoneSolidificationFailed:  events.NewEvent(milestone.IndexCaller),
 			MilestoneTimeout:               events.NewEvent(events.VoidCaller),
 			LedgerUpdated:                  events.NewEvent(LedgerUpdatedCaller),

--- a/pkg/tangle/tangle.go
+++ b/pkg/tangle/tangle.go
@@ -85,9 +85,8 @@ type Tangle struct {
 
 	startWaitGroup sync.WaitGroup
 
-	blockProcessedSyncEvent     *events.SyncEvent
-	blockSolidSyncEvent         *events.SyncEvent
-	milestoneConfirmedSyncEvent *events.SyncEvent
+	blockProcessedSyncEvent *events.SyncEvent
+	blockSolidSyncEvent     *events.SyncEvent
 
 	milestoneSolidificationCtxLock    syncutils.Mutex
 	milestoneSolidificationCancelFunc context.CancelFunc
@@ -157,12 +156,9 @@ func New(
 		milestoneSolidifierQueueSize:     2,
 		blockProcessedSyncEvent:          events.NewSyncEvent(),
 		blockSolidSyncEvent:              events.NewSyncEvent(),
-		milestoneConfirmedSyncEvent:      events.NewSyncEvent(),
 		Events: &Events{
 			BPSMetricsUpdated:              events.NewEvent(BPSMetricsCaller),
 			ReceivedNewBlock:               events.NewEvent(storage.NewBlockCaller),
-			ReceivedKnownBlock:             events.NewEvent(storage.BlockCaller),
-			ProcessedBlock:                 events.NewEvent(storage.BlockIDCaller),
 			BlockSolid:                     events.NewEvent(storage.BlockMetadataCaller),
 			BlockReferenced:                events.NewEvent(storage.BlockReferencedCaller),
 			ReceivedNewMilestoneBlock:      events.NewEvent(storage.BlockIDCaller),

--- a/pkg/tangle/tangle_processor.go
+++ b/pkg/tangle/tangle_processor.go
@@ -233,14 +233,8 @@ func (t *Tangle) processIncomingTx(incomingBlock *storage.Block, requests gossip
 		if proto != nil {
 			proto.Metrics.KnownBlocks.Inc()
 		}
-		t.Events.ReceivedKnownBlock.Trigger(cachedBlock)
 	}
 
-	// "ProcessedBlock" event has to be fired after "ReceivedNewBlock" event,
-	// otherwise there is a race condition in the coordinator plugin that tries to "ComputeMerkleTreeRootHash"
-	// with the block it issued itself because the block may be not solid yet and therefore their database entries
-	// are not created yet.
-	t.Events.ProcessedBlock.Trigger(incomingBlock.BlockID())
 	t.blockProcessedSyncEvent.Trigger(incomingBlock.BlockID())
 
 	for _, request := range requests {
@@ -276,16 +270,6 @@ func (t *Tangle) RegisterBlockSolidEvent(blockID iotago.BlockID) chan struct{} {
 // DeregisterBlockSolidEvent removes a registered event to free the memory if not used.
 func (t *Tangle) DeregisterBlockSolidEvent(blockID iotago.BlockID) {
 	t.blockSolidSyncEvent.DeregisterEvent(blockID)
-}
-
-// RegisterMilestoneConfirmedEvent returns a channel that gets closed when the milestone is confirmed.
-func (t *Tangle) RegisterMilestoneConfirmedEvent(msIndex milestone.Index) chan struct{} {
-	return t.milestoneConfirmedSyncEvent.RegisterEvent(msIndex)
-}
-
-// DeregisterMilestoneConfirmedEvent removes a registered event to free the memory if not used.
-func (t *Tangle) DeregisterMilestoneConfirmedEvent(msIndex milestone.Index) {
-	t.milestoneConfirmedSyncEvent.DeregisterEvent(msIndex)
 }
 
 func (t *Tangle) PrintStatus() {

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -163,12 +163,12 @@ func (te *TestEnvironment) PerformWhiteFlagConfirmation(milestonePayload *iotago
 			err := te.syncManager.SetConfirmedMilestoneIndex(confirmation.MilestoneIndex, true)
 			require.NoError(te.TestInterface, err)
 		},
+		nil,
 		func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
 			if te.OnLedgerUpdatedFunc != nil {
 				te.OnLedgerUpdatedFunc(index, newOutputs, newSpents)
 			}
 		},
-		nil,
 		nil,
 	)
 	return wfConf, confirmedMilestoneStats, err

--- a/pkg/whiteflag/confirmation.go
+++ b/pkg/whiteflag/confirmation.go
@@ -38,7 +38,6 @@ type ConfirmationMetrics struct {
 	DurationUpdateConeRootIndexes                    time.Duration
 	DurationConfirmedMilestoneChanged                time.Duration
 	DurationConfirmedMilestoneIndexChanged           time.Duration
-	DurationMilestoneConfirmedSyncEvent              time.Duration
 	DurationMilestoneConfirmed                       time.Duration
 	DurationTotal                                    time.Duration
 }

--- a/pkg/whiteflag/confirmation.go
+++ b/pkg/whiteflag/confirmation.go
@@ -68,14 +68,12 @@ func ConfirmMilestone(
 	checkBlockReferencedFunc CheckBlockReferencedFunc,
 	setBlockReferencedFunc SetBlockReferencedFunc,
 	serverMetrics *metrics.ServerMetrics,
-	forEachReferencedBlock func(blockMetadata *storage.CachedMetadata, index milestone.Index, confTime uint32),
+	onValidateReceipt func(r *utxo.ReceiptTuple) error,
 	onMilestoneConfirmed func(confirmation *Confirmation),
+	forEachReferencedBlock func(blockMetadata *storage.CachedMetadata, index milestone.Index, confTime uint32),
 	onLedgerUpdated func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents),
 	onTreasuryMutated func(index milestone.Index, tuple *utxo.TreasuryMutationTuple),
-	onReceipt func(r *utxo.ReceiptTuple) error) (*ConfirmedMilestoneStats, *ConfirmationMetrics, error) {
-
-	utxoManager.WriteLockLedger()
-	defer utxoManager.WriteUnlockLedger()
+) (*ConfirmedMilestoneStats, *ConfirmationMetrics, error) {
 
 	msID, err := milestonePayload.ID()
 	if err != nil {
@@ -88,109 +86,38 @@ func ConfirmMilestone(
 	milestoneTimestamp := milestonePayload.Timestamp
 	milestoneParents := milestonePayload.Parents
 
-	timeStart := time.Now()
+	var (
+		timeStart                                    time.Time
+		timeWhiteflag                                time.Time
+		timeReceipts                                 time.Time
+		timeConfirmation                             time.Time
+		timeApplyIncludedWithTransactions            time.Time
+		timeApplyExcludedWithoutTransactions         time.Time
+		timeApplyExcludedWithConflictingTransactions time.Time
+		timeOnMilestoneConfirmed                     time.Time
+		timeLedgerUpdatedStart                       time.Time
+		timeLedgerUpdatedEnd                         time.Time
+		timeTreasuryMutatedStart                     time.Time
+		timeTreasuryMutatedEnd                       time.Time
+	)
 
 	parentsTraverser := dag.NewParentsTraverser(parentsTraverserStorage)
 
-	// we pass a background context here to not cancel the whiteflag computation!
-	// otherwise the node could panic at shutdown.
-	mutations, err := ComputeWhiteFlagMutations(
-		context.Background(),
-		utxoManager,
-		parentsTraverser,
-		cachedBlockFunc,
-		milestoneIndex,
-		milestoneTimestamp,
-		milestoneParents,
-		previousMilestoneID,
-		whiteFlagTraversalCondition)
-	if err != nil {
-		// According to the RFC we should panic if we encounter any invalid blocks during confirmation
-		return nil, nil, fmt.Errorf("confirmMilestone: whiteflag.ComputeConfirmation failed with Error: %w", err)
-	}
+	newOutputs := make(utxo.Outputs, 0)
+	newSpents := make(utxo.Spents, 0)
+
+	var newReceipt *utxo.ReceiptTuple
+	var treasuryMutation *utxo.TreasuryMutationTuple
 
 	confirmation := &Confirmation{
 		MilestoneIndex:   milestoneIndex,
 		MilestoneID:      milestoneID,
 		MilestoneParents: milestoneParents,
-		Mutations:        mutations,
 	}
 
-	// Verify the calculated InclusionMerkleRoot with the one inside the milestone
-	inclusionMerkleTreeHash := milestonePayload.InclusionMerkleRoot
-	if mutations.InclusionMerkleRoot != inclusionMerkleTreeHash {
-		return nil, nil, fmt.Errorf("confirmMilestone: computed InclusionMerkleRoot %s does not match the value in the milestone %s", hex.EncodeToString(mutations.InclusionMerkleRoot[:]), hex.EncodeToString(inclusionMerkleTreeHash[:]))
+	confirmedMilestoneStats := &ConfirmedMilestoneStats{
+		Index: milestoneIndex,
 	}
-
-	// Verify the calculated AppliedMerkleRoot with the one inside the milestone
-	appliedMerkleTreeHash := milestonePayload.AppliedMerkleRoot
-	if mutations.AppliedMerkleRoot != appliedMerkleTreeHash {
-		return nil, nil, fmt.Errorf("confirmMilestone: computed AppliedMerkleRoot %s does not match the value in the milestone %s", hex.EncodeToString(mutations.AppliedMerkleRoot[:]), hex.EncodeToString(appliedMerkleTreeHash[:]))
-	}
-
-	timeWhiteflag := time.Now()
-
-	newOutputs := make(utxo.Outputs, 0, len(mutations.NewOutputs))
-	for _, output := range mutations.NewOutputs {
-		newOutputs = append(newOutputs, output)
-	}
-
-	var tm *utxo.TreasuryMutationTuple
-	var rt *utxo.ReceiptTuple
-
-	// validate receipt and extract migrated funds
-	opts, err := milestonePayload.Opts.Set()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	receipt := opts.Receipt()
-	if receipt != nil {
-		var err error
-
-		rt = &utxo.ReceiptTuple{
-			Receipt:        receipt,
-			MilestoneIndex: milestoneIndex,
-		}
-
-		// receipt validation is optional
-		if onReceipt != nil {
-			if err := onReceipt(rt); err != nil {
-				return nil, nil, err
-			}
-		}
-
-		unspentTreasuryOutput, err := utxoManager.UnspentTreasuryOutputWithoutLocking()
-		if err != nil {
-			return nil, nil, fmt.Errorf("unable to fetch previous unspent treasury output: %w", err)
-		}
-		if err := iotago.ValidateReceipt(receipt, &iotago.TreasuryOutput{Amount: unspentTreasuryOutput.Amount}, protoParas.TokenSupply); err != nil {
-			return nil, nil, fmt.Errorf("invalid receipt contained within milestone: %w", err)
-		}
-
-		migratedOutputs, err := utxo.ReceiptToOutputs(receipt, milestoneID, milestoneIndex, milestoneTimestamp)
-		if err != nil {
-			return nil, nil, fmt.Errorf("unable to extract migrated outputs from receipt: %w", err)
-		}
-
-		tm, err = utxo.ReceiptToTreasuryMutation(receipt, unspentTreasuryOutput, milestoneID)
-		if err != nil {
-			return nil, nil, fmt.Errorf("unable to convert receipt to treasury mutation tuple: %w", err)
-		}
-
-		newOutputs = append(newOutputs, migratedOutputs...)
-	}
-	timeReceipts := time.Now()
-
-	newSpents := make(utxo.Spents, 0, len(mutations.NewSpents))
-	for _, spent := range mutations.NewSpents {
-		newSpents = append(newSpents, spent)
-	}
-
-	if err = utxoManager.ApplyConfirmationWithoutLocking(milestoneIndex, newOutputs, newSpents, tm, rt); err != nil {
-		return nil, nil, fmt.Errorf("confirmMilestone: utxo.ApplyConfirmation failed: %w", err)
-	}
-	timeConfirmation := time.Now()
 
 	// load the block for the given id
 	forBlockMetadataWithBlockID := func(blockID iotago.BlockID, do func(meta *storage.CachedMetadata)) error {
@@ -206,94 +133,198 @@ func ConfirmMilestone(
 		return nil
 	}
 
-	confirmedMilestoneStats := &ConfirmedMilestoneStats{
-		Index: milestoneIndex,
+	// we use this inline function for easier unlocking of the ledger at the end
+	calculateAndApplyLedgerChanges := func() error {
+		utxoManager.WriteLockLedger()
+		defer utxoManager.WriteUnlockLedger()
+
+		timeStart = time.Now()
+
+		// we pass a background context here to not cancel the whiteflag computation!
+		// otherwise the node could panic at shutdown.
+		mutations, err := ComputeWhiteFlagMutations(
+			context.Background(),
+			utxoManager,
+			parentsTraverser,
+			cachedBlockFunc,
+			milestoneIndex,
+			milestoneTimestamp,
+			milestoneParents,
+			previousMilestoneID,
+			whiteFlagTraversalCondition)
+		if err != nil {
+			// According to the RFC we should panic if we encounter any invalid blocks during confirmation
+			return fmt.Errorf("confirmMilestone: whiteflag.ComputeConfirmation failed with Error: %w", err)
+		}
+		confirmation.Mutations = mutations
+
+		// Verify the calculated InclusionMerkleRoot with the one inside the milestone
+		inclusionMerkleTreeHash := milestonePayload.InclusionMerkleRoot
+		if mutations.InclusionMerkleRoot != inclusionMerkleTreeHash {
+			return fmt.Errorf("confirmMilestone: computed InclusionMerkleRoot %s does not match the value in the milestone %s", hex.EncodeToString(mutations.InclusionMerkleRoot[:]), hex.EncodeToString(inclusionMerkleTreeHash[:]))
+		}
+
+		// Verify the calculated AppliedMerkleRoot with the one inside the milestone
+		appliedMerkleTreeHash := milestonePayload.AppliedMerkleRoot
+		if mutations.AppliedMerkleRoot != appliedMerkleTreeHash {
+			return fmt.Errorf("confirmMilestone: computed AppliedMerkleRoot %s does not match the value in the milestone %s", hex.EncodeToString(mutations.AppliedMerkleRoot[:]), hex.EncodeToString(appliedMerkleTreeHash[:]))
+		}
+
+		for _, output := range mutations.NewOutputs {
+			newOutputs = append(newOutputs, output)
+		}
+
+		for _, spent := range mutations.NewSpents {
+			newSpents = append(newSpents, spent)
+		}
+
+		timeWhiteflag = time.Now()
+
+		// validate receipt and extract migrated funds
+		opts, err := milestonePayload.Opts.Set()
+		if err != nil {
+			return err
+		}
+
+		receipt := opts.Receipt()
+		if receipt != nil {
+			var err error
+
+			newReceipt = &utxo.ReceiptTuple{
+				Receipt:        receipt,
+				MilestoneIndex: milestoneIndex,
+			}
+
+			// receipt validation is optional
+			if onValidateReceipt != nil {
+				if err := onValidateReceipt(newReceipt); err != nil {
+					return err
+				}
+			}
+
+			unspentTreasuryOutput, err := utxoManager.UnspentTreasuryOutputWithoutLocking()
+			if err != nil {
+				return fmt.Errorf("unable to fetch previous unspent treasury output: %w", err)
+			}
+
+			if err := iotago.ValidateReceipt(receipt, &iotago.TreasuryOutput{Amount: unspentTreasuryOutput.Amount}, protoParas.TokenSupply); err != nil {
+				return fmt.Errorf("invalid receipt contained within milestone: %w", err)
+			}
+
+			migratedOutputs, err := utxo.ReceiptToOutputs(receipt, milestoneID, milestoneIndex, milestoneTimestamp)
+			if err != nil {
+				return fmt.Errorf("unable to extract migrated outputs from receipt: %w", err)
+			}
+
+			treasuryMutation, err = utxo.ReceiptToTreasuryMutation(receipt, unspentTreasuryOutput, milestoneID)
+			if err != nil {
+				return fmt.Errorf("unable to convert receipt to treasury mutation tuple: %w", err)
+			}
+
+			newOutputs = append(newOutputs, migratedOutputs...)
+		}
+		timeReceipts = time.Now()
+
+		if err = utxoManager.ApplyConfirmationWithoutLocking(milestoneIndex, newOutputs, newSpents, treasuryMutation, newReceipt); err != nil {
+			return fmt.Errorf("confirmMilestone: utxo.ApplyConfirmation failed: %w", err)
+		}
+		timeConfirmation = time.Now()
+
+		// confirm all included blocks
+		for _, blockID := range mutations.BlocksIncludedWithTransactions {
+			if err := forBlockMetadataWithBlockID(blockID, func(meta *storage.CachedMetadata) {
+				if !checkBlockReferencedFunc(meta.Metadata()) {
+					setBlockReferencedFunc(meta.Metadata(), true, milestoneIndex)
+					meta.Metadata().SetConeRootIndexes(milestoneIndex, milestoneIndex, milestoneIndex)
+					confirmedMilestoneStats.BlocksReferenced++
+					confirmedMilestoneStats.BlocksIncludedWithTransactions++
+					if serverMetrics != nil {
+						serverMetrics.IncludedTransactionBlocks.Inc()
+						serverMetrics.ReferencedBlocks.Inc()
+					}
+				}
+			}); err != nil {
+				return err
+			}
+		}
+		timeApplyIncludedWithTransactions = time.Now()
+
+		// confirm all excluded blocks not containing ledger transactions
+		for _, blockID := range mutations.BlocksExcludedWithoutTransactions {
+			if err := forBlockMetadataWithBlockID(blockID, func(meta *storage.CachedMetadata) {
+				meta.Metadata().SetIsNoTransaction(true)
+				if !checkBlockReferencedFunc(meta.Metadata()) {
+					setBlockReferencedFunc(meta.Metadata(), true, milestoneIndex)
+					meta.Metadata().SetConeRootIndexes(milestoneIndex, milestoneIndex, milestoneIndex)
+					confirmedMilestoneStats.BlocksReferenced++
+					confirmedMilestoneStats.BlocksExcludedWithoutTransactions++
+					if serverMetrics != nil {
+						serverMetrics.NoTransactionBlocks.Inc()
+						serverMetrics.ReferencedBlocks.Inc()
+					}
+				}
+			}); err != nil {
+				return err
+			}
+		}
+		timeApplyExcludedWithoutTransactions = time.Now()
+
+		// confirm all conflicting blocks
+		for _, conflictedBlock := range mutations.BlocksExcludedWithConflictingTransactions {
+			if err := forBlockMetadataWithBlockID(conflictedBlock.BlockID, func(meta *storage.CachedMetadata) {
+				meta.Metadata().SetConflictingTx(conflictedBlock.Conflict)
+				if !checkBlockReferencedFunc(meta.Metadata()) {
+					setBlockReferencedFunc(meta.Metadata(), true, milestoneIndex)
+					meta.Metadata().SetConeRootIndexes(milestoneIndex, milestoneIndex, milestoneIndex)
+					confirmedMilestoneStats.BlocksReferenced++
+					confirmedMilestoneStats.BlocksExcludedWithConflictingTransactions++
+					if serverMetrics != nil {
+						serverMetrics.ConflictingTransactionBlocks.Inc()
+						serverMetrics.ReferencedBlocks.Inc()
+					}
+				}
+			}); err != nil {
+				return err
+			}
+		}
+		timeApplyExcludedWithConflictingTransactions = time.Now()
+
+		if onMilestoneConfirmed != nil {
+			onMilestoneConfirmed(confirmation)
+		}
+
+		timeOnMilestoneConfirmed = time.Now()
+
+		return nil
 	}
 
-	confirmationTime := milestonePayload.Timestamp
+	err = calculateAndApplyLedgerChanges()
+	if err != nil {
+		return nil, nil, err
+	}
 
-	// confirm all included blocks
-	for _, blockID := range mutations.BlocksIncludedWithTransactions {
+	// fire all events after the ledger got unlocked
+	for _, blockID := range confirmation.Mutations.BlocksReferenced {
 		if err := forBlockMetadataWithBlockID(blockID, func(meta *storage.CachedMetadata) {
-			if !checkBlockReferencedFunc(meta.Metadata()) {
-				setBlockReferencedFunc(meta.Metadata(), true, milestoneIndex)
-				meta.Metadata().SetConeRootIndexes(milestoneIndex, milestoneIndex, milestoneIndex)
-				confirmedMilestoneStats.BlocksReferenced++
-				confirmedMilestoneStats.BlocksIncludedWithTransactions++
-				if serverMetrics != nil {
-					serverMetrics.IncludedTransactionBlocks.Inc()
-					serverMetrics.ReferencedBlocks.Inc()
-				}
-				if forEachReferencedBlock != nil {
-					forEachReferencedBlock(meta, milestoneIndex, confirmationTime)
-				}
+			if forEachReferencedBlock != nil {
+				forEachReferencedBlock(meta, milestoneIndex, milestonePayload.Timestamp)
 			}
 		}); err != nil {
 			return nil, nil, err
 		}
 	}
-	timeApplyIncludedWithTransactions := time.Now()
 
-	// confirm all excluded blocks not containing ledger transactions
-	for _, blockID := range mutations.BlocksExcludedWithoutTransactions {
-		if err := forBlockMetadataWithBlockID(blockID, func(meta *storage.CachedMetadata) {
-			meta.Metadata().SetIsNoTransaction(true)
-			if !checkBlockReferencedFunc(meta.Metadata()) {
-				setBlockReferencedFunc(meta.Metadata(), true, milestoneIndex)
-				meta.Metadata().SetConeRootIndexes(milestoneIndex, milestoneIndex, milestoneIndex)
-				confirmedMilestoneStats.BlocksReferenced++
-				confirmedMilestoneStats.BlocksExcludedWithoutTransactions++
-				if serverMetrics != nil {
-					serverMetrics.NoTransactionBlocks.Inc()
-					serverMetrics.ReferencedBlocks.Inc()
-				}
-				if forEachReferencedBlock != nil {
-					forEachReferencedBlock(meta, milestoneIndex, confirmationTime)
-				}
-			}
-		}); err != nil {
-			return nil, nil, err
-		}
-	}
-	timeApplyExcludedWithoutTransactions := time.Now()
-
-	// confirm all conflicting blocks
-	for _, conflictedBlock := range mutations.BlocksExcludedWithConflictingTransactions {
-		if err := forBlockMetadataWithBlockID(conflictedBlock.BlockID, func(meta *storage.CachedMetadata) {
-			meta.Metadata().SetConflictingTx(conflictedBlock.Conflict)
-			if !checkBlockReferencedFunc(meta.Metadata()) {
-				setBlockReferencedFunc(meta.Metadata(), true, milestoneIndex)
-				meta.Metadata().SetConeRootIndexes(milestoneIndex, milestoneIndex, milestoneIndex)
-				confirmedMilestoneStats.BlocksReferenced++
-				confirmedMilestoneStats.BlocksExcludedWithConflictingTransactions++
-				if serverMetrics != nil {
-					serverMetrics.ConflictingTransactionBlocks.Inc()
-					serverMetrics.ReferencedBlocks.Inc()
-				}
-				if forEachReferencedBlock != nil {
-					forEachReferencedBlock(meta, milestoneIndex, confirmationTime)
-				}
-			}
-		}); err != nil {
-			return nil, nil, err
-		}
-	}
-	timeApplyExcludedWithConflictingTransactions := time.Now()
-
-	if onMilestoneConfirmed != nil {
-		onMilestoneConfirmed(confirmation)
-	}
-	timeOnMilestoneConfirmed := time.Now()
-
+	timeLedgerUpdatedStart = time.Now()
 	if onLedgerUpdated != nil {
 		onLedgerUpdated(milestoneIndex, newOutputs, newSpents)
 	}
-	timeLedgerUpdated := time.Now()
+	timeLedgerUpdatedEnd = time.Now()
 
-	if onTreasuryMutated != nil && tm != nil {
-		onTreasuryMutated(milestoneIndex, tm)
+	if onTreasuryMutated != nil && treasuryMutation != nil {
+		timeTreasuryMutatedStart = time.Now()
+		onTreasuryMutated(milestoneIndex, treasuryMutation)
+		timeTreasuryMutatedEnd = time.Now()
 	}
-	timeTreasuryMutated := time.Now()
 
 	return confirmedMilestoneStats, &ConfirmationMetrics{
 		DurationWhiteflag:                                timeWhiteflag.Sub(timeStart),
@@ -303,7 +334,7 @@ func ConfirmMilestone(
 		DurationApplyExcludedWithoutTransactions:         timeApplyExcludedWithoutTransactions.Sub(timeApplyIncludedWithTransactions),
 		DurationApplyExcludedWithConflictingTransactions: timeApplyExcludedWithConflictingTransactions.Sub(timeApplyExcludedWithoutTransactions),
 		DurationOnMilestoneConfirmed:                     timeOnMilestoneConfirmed.Sub(timeApplyExcludedWithConflictingTransactions),
-		DurationLedgerUpdated:                            timeLedgerUpdated.Sub(timeOnMilestoneConfirmed),
-		DurationTreasuryMutated:                          timeTreasuryMutated.Sub(timeLedgerUpdated),
+		DurationLedgerUpdated:                            timeLedgerUpdatedEnd.Sub(timeLedgerUpdatedStart),
+		DurationTreasuryMutated:                          timeTreasuryMutatedEnd.Sub(timeTreasuryMutatedStart),
 	}, nil
 }

--- a/plugins/inx/server_blocks.go
+++ b/plugins/inx/server_blocks.go
@@ -118,7 +118,7 @@ func (s *INXServer) ListenToBlocks(_ *inx.NoParams, srv inx.INX_ListenToBlocksSe
 			cancel()
 		}
 		task.Return(nil)
-	})
+	}, workerpool.WorkerCount(workerCount), workerpool.QueueSize(workerQueueSize), workerpool.FlushTasksAtShutdown(true))
 	closure := events.NewClosure(func(cachedBlock *storage.CachedBlock, latestMilestoneIndex milestone.Index, confirmedMilestoneIndex milestone.Index) {
 		wp.Submit(cachedBlock)
 	})

--- a/plugins/inx/server_milestones.go
+++ b/plugins/inx/server_milestones.go
@@ -78,7 +78,7 @@ func (s *INXServer) ListenToLatestMilestones(_ *inx.NoParams, srv inx.INX_Listen
 			cancel()
 		}
 		task.Return(nil)
-	})
+	}, workerpool.WorkerCount(workerCount), workerpool.QueueSize(workerQueueSize), workerpool.FlushTasksAtShutdown(true))
 	closure := events.NewClosure(func(milestone *storage.CachedMilestone) {
 		wp.Submit(milestone)
 	})
@@ -166,7 +166,7 @@ func (s *INXServer) ListenToConfirmedMilestones(req *inx.MilestoneRangeRequest, 
 		}
 
 		task.Return(nil)
-	})
+	}, workerpool.WorkerCount(workerCount), workerpool.QueueSize(workerQueueSize), workerpool.FlushTasksAtShutdown(true))
 	closure := events.NewClosure(func(milestone *storage.CachedMilestone) {
 		wp.Submit(milestone)
 	})

--- a/plugins/inx/server_utxo.go
+++ b/plugins/inx/server_utxo.go
@@ -252,7 +252,7 @@ func (s *INXServer) ListenToLedgerUpdates(req *inx.MilestoneRangeRequest, srv in
 		}
 
 		task.Return(nil)
-	})
+	}, workerpool.WorkerCount(workerCount), workerpool.QueueSize(workerQueueSize), workerpool.FlushTasksAtShutdown(true))
 	closure := events.NewClosure(func(index milestone.Index, newOutputs utxo.Outputs, newSpents utxo.Spents) {
 		wp.Submit(index, newOutputs, newSpents)
 	})
@@ -369,7 +369,7 @@ func (s *INXServer) ListenToTreasuryUpdates(req *inx.MilestoneRangeRequest, srv 
 		}
 
 		task.Return(nil)
-	})
+	}, workerpool.WorkerCount(workerCount), workerpool.QueueSize(workerQueueSize), workerpool.FlushTasksAtShutdown(true))
 	closure := events.NewClosure(func(index milestone.Index, tuple *utxo.TreasuryMutationTuple) {
 		wp.Submit(index, tuple)
 	})
@@ -395,7 +395,7 @@ func (s *INXServer) ListenToMigrationReceipts(_ *inx.NoParams, srv inx.INX_Liste
 			cancel()
 		}
 		task.Return(nil)
-	})
+	}, workerpool.WorkerCount(workerCount), workerpool.QueueSize(workerQueueSize), workerpool.FlushTasksAtShutdown(true))
 	closure := events.NewClosure(func(receipt *iotago.ReceiptMilestoneOpt) {
 		wp.Submit(receipt)
 	})

--- a/plugins/prometheus/debug.go
+++ b/plugins/prometheus/debug.go
@@ -157,7 +157,6 @@ func collectDebug() {
 		milestoneConfirmationDurations.WithLabelValues("update_cone_root_indexes").Set(lastConfirmationMetrics.DurationUpdateConeRootIndexes.Seconds())
 		milestoneConfirmationDurations.WithLabelValues("confirmed_milestone_changed").Set(lastConfirmationMetrics.DurationConfirmedMilestoneChanged.Seconds())
 		milestoneConfirmationDurations.WithLabelValues("confirmed_milestone_index_changed").Set(lastConfirmationMetrics.DurationConfirmedMilestoneIndexChanged.Seconds())
-		milestoneConfirmationDurations.WithLabelValues("milestone_confirmed_sync_event").Set(lastConfirmationMetrics.DurationMilestoneConfirmedSyncEvent.Seconds())
 		milestoneConfirmationDurations.WithLabelValues("milestone_confirmed").Set(lastConfirmationMetrics.DurationMilestoneConfirmed.Seconds())
 		milestoneConfirmationDurations.WithLabelValues("total").Set(lastConfirmationMetrics.DurationTotal.Seconds())
 	}


### PR DESCRIPTION
Fixes #1557 

This PR fixes the deadlock by decouple firing of several tangle events from ledger write lock.

It is safe to fire several confirmation related events in the tangle package without holding the ledger lock. Comments were added to the events for better understanding. This was done in the first place to fix a race condition in INX, where the write lock of the ledger was deadlocked with the internal lock of gRPC due to asynchronous calls to outputById which acquires the ledger read lock.