### PR TITLE
Fix possible data races in INX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## [2.0.0-alpha19] - 14.06.2022
+
+### Fixed
+    - Fix INX deadlock #1560
+    - Fix possible data races in INX #1561
+
+### Changes
+    - Adds supported protocol versions to REST API and INX (#1552)
+
+
 ## [2.0.0-alpha18] - 08.06.2022
 
 ### Fixed

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -34,7 +34,7 @@ var (
 	Name = "HORNET"
 
 	// Version of the app.
-	Version = "2.0.0-alpha18"
+	Version = "2.0.0-alpha19"
 )
 
 func App() *app.App {

--- a/docker-example/docker-compose.yml
+++ b/docker-example/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   hornet:
-    image: iotaledger/hornet:2.0.0-alpha18
+    image: iotaledger/hornet:2.0.0-alpha19
     ulimits:
       nofile:
         soft: 16384

--- a/plugins/inx/server_milestones.go
+++ b/plugins/inx/server_milestones.go
@@ -224,6 +224,9 @@ func (s *INXServer) ListenToConfirmedMilestones(req *inx.MilestoneRangeRequest, 
 			return
 		}
 
+		// remember the last index we sent
+		lastSentIndex = index
+
 		if requestEndIndex > 0 && index >= requestEndIndex {
 			// We are done sending the updates
 			innerErr = nil

--- a/plugins/inx/server_utxo.go
+++ b/plugins/inx/server_utxo.go
@@ -295,6 +295,9 @@ func (s *INXServer) ListenToLedgerUpdates(req *inx.MilestoneRangeRequest, srv in
 			return
 		}
 
+		// remember the last index we sent
+		lastSentIndex = index
+
 		if requestEndIndex > 0 && index >= requestEndIndex {
 			// We are done sending the updates
 			innerErr = nil
@@ -490,6 +493,9 @@ func (s *INXServer) ListenToTreasuryUpdates(req *inx.MilestoneRangeRequest, srv 
 			task.Return(nil)
 			return
 		}
+
+		// remember the last index we sent
+		lastSentIndex = index
 
 		if requestEndIndex > 0 && index >= requestEndIndex {
 			// We are done sending the updates

--- a/plugins/inx/server_utxo.go
+++ b/plugins/inx/server_utxo.go
@@ -253,7 +253,7 @@ func (s *INXServer) ListenToLedgerUpdates(req *inx.MilestoneRangeRequest, srv in
 		}
 
 		if requestStartIndex > 0 && index-1 > lastSentIndex {
-			// we missed some ledger updated in between
+			// we missed some ledger updates in between
 			startIndex := requestStartIndex
 			if startIndex < lastSentIndex+1 {
 				startIndex = lastSentIndex + 1

--- a/plugins/inx/server_utxo.go
+++ b/plugins/inx/server_utxo.go
@@ -310,9 +310,7 @@ func (s *INXServer) ListenToLedgerUpdates(req *inx.MilestoneRangeRequest, srv in
 
 	wp.Start()
 	deps.Tangle.Events.LedgerUpdated.Attach(closure)
-
 	<-ctx.Done()
-
 	deps.Tangle.Events.LedgerUpdated.Detach(closure)
 	wp.Stop()
 
@@ -320,73 +318,124 @@ func (s *INXServer) ListenToLedgerUpdates(req *inx.MilestoneRangeRequest, srv in
 }
 
 func (s *INXServer) ListenToTreasuryUpdates(req *inx.MilestoneRangeRequest, srv inx.INX_ListenToTreasuryUpdatesServer) error {
-	var sentTreasuryUpdate bool
-	sendPreviousMilestoneDiffs := func(startIndex milestone.Index, endIndex milestone.Index) (milestone.Index, milestone.Index, error) {
-		deps.UTXOManager.ReadLockLedger()
-		defer deps.UTXOManager.ReadUnlockLedger()
 
-		ledgerIndex, err := deps.UTXOManager.ReadLedgerIndexWithoutLocking()
-		if err != nil {
-			return 0, 0, status.Error(codes.Unavailable, "error accessing the UTXO ledger")
+	var treasuryUpdateSent bool
+
+	createTreasuryUpdatePayloadAndSend := func(msIndex milestone.Index, treasuryOutput *utxo.TreasuryOutput, spentTreasuryOutput *utxo.TreasuryOutput) error {
+		if treasuryOutput != nil {
+			payload, err := NewTreasuryUpdate(msIndex, treasuryOutput, spentTreasuryOutput)
+			if err != nil {
+				return err
+			}
+			if err := srv.Send(payload); err != nil {
+				return fmt.Errorf("send error: %w", err)
+			}
+			treasuryUpdateSent = true
+		}
+		return nil
+	}
+
+	sendTreasuryUpdatesRange := func(startIndex milestone.Index, endIndex milestone.Index) error {
+		for currentIndex := startIndex; currentIndex <= endIndex; currentIndex++ {
+			msDiff, err := deps.UTXOManager.MilestoneDiff(currentIndex)
+			if err != nil {
+				return status.Errorf(codes.NotFound, "ledger update for milestoneIndex %d not found", currentIndex)
+			}
+
+			if err := createTreasuryUpdatePayloadAndSend(msDiff.Index, msDiff.TreasuryOutput, msDiff.SpentTreasuryOutput); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// if a startIndex is given, we send all available treasury updates including the start index.
+	// if an endIndex is given, we send all available treasury updates up to and including min(ledgerIndex, endIndex).
+	// if no startIndex is given, but an endIndex, we do not send previous treasury updates.
+	sendPreviousTreasuryUpdates := func(startIndex milestone.Index, endIndex milestone.Index) (milestone.Index, error) {
+		if startIndex == 0 {
+			// no need to send treasury updates diffs
+			return 0, nil
 		}
 
-		if endIndex == 0 || ledgerIndex < endIndex {
+		ledgerIndex, err := deps.UTXOManager.ReadLedgerIndex()
+		if err != nil {
+			return 0, status.Error(codes.Unavailable, "error accessing the UTXO ledger")
+		}
+
+		if startIndex > ledgerIndex {
+			// no need to send treasury updates diffs
+			return 0, nil
+		}
+
+		// Stream all available milestone diffs first
+		pruningIndex := deps.Storage.SnapshotInfo().PruningIndex
+		if startIndex <= pruningIndex {
+			return 0, status.Errorf(codes.InvalidArgument, "given startMilestoneIndex %d is older than the current pruningIndex %d", startIndex, pruningIndex)
+		}
+
+		if endIndex == 0 || endIndex > ledgerIndex {
 			endIndex = ledgerIndex
 		}
 
-		if startIndex > 0 && startIndex <= ledgerIndex {
-			// Stream all available milestone diffs first
-			pruningIndex := deps.Storage.SnapshotInfo().PruningIndex
-			if startIndex <= pruningIndex {
-				return 0, 0, status.Errorf(codes.InvalidArgument, "given startMilestoneIndex %d is older than the current pruningIndex %d", startIndex, pruningIndex)
+		if err := sendTreasuryUpdatesRange(startIndex, endIndex); err != nil {
+			return 0, err
+		}
+
+		return endIndex, nil
+	}
+
+	sendCurrentTreasuryOutput := func() (milestone.Index, error) {
+
+		getCurrentTreasuryOutputAndIndex := func() (milestone.Index, *utxo.TreasuryOutput, error) {
+			deps.UTXOManager.ReadLockLedger()
+			defer deps.UTXOManager.ReadUnlockLedger()
+
+			ledgerIndex, err := deps.UTXOManager.ReadLedgerIndexWithoutLocking()
+			if err != nil {
+				return 0, nil, status.Error(codes.Unavailable, "error accessing the UTXO ledger")
 			}
 
-			for currentIndex := startIndex; currentIndex <= endIndex; currentIndex++ {
-				msDiff, err := deps.UTXOManager.MilestoneDiffWithoutLocking(currentIndex)
-				if err != nil {
-					return 0, 0, status.Errorf(codes.NotFound, "treasury update for milestoneIndex %d not found", currentIndex)
-				}
-				if msDiff.TreasuryOutput != nil {
-					payload, err := NewTreasuryUpdate(msDiff.Index, msDiff.TreasuryOutput, msDiff.SpentTreasuryOutput)
-					if err != nil {
-						return 0, 0, err
-					}
-					if err := srv.Send(payload); err != nil {
-						return 0, 0, fmt.Errorf("send error: %w", err)
-					}
-					sentTreasuryUpdate = true
-				}
+			treasuryOutput, err := deps.UTXOManager.UnspentTreasuryOutputWithoutLocking()
+			if err != nil {
+				return 0, nil, status.Errorf(codes.Unavailable, "error accessing the UTXO ledger %s", err)
 			}
+
+			return ledgerIndex, treasuryOutput, nil
 		}
-		return ledgerIndex, endIndex, nil
+
+		ledgerIndex, treasuryOutput, err := getCurrentTreasuryOutputAndIndex()
+		if err != nil {
+			return 0, err
+		}
+
+		if err := createTreasuryUpdatePayloadAndSend(ledgerIndex, treasuryOutput, treasuryOutput); err != nil {
+			return 0, err
+		}
+
+		return ledgerIndex, nil
 	}
 
 	requestStartIndex := milestone.Index(req.GetStartMilestoneIndex())
 	requestEndIndex := milestone.Index(req.GetEndMilestoneIndex())
 
-	ledgerIndex, lastSentIndex, err := sendPreviousMilestoneDiffs(requestStartIndex, requestEndIndex)
+	lastSentIndex, err := sendPreviousTreasuryUpdates(requestStartIndex, requestEndIndex)
 	if err != nil {
 		return err
+	}
+
+	if !treasuryUpdateSent {
+		// Since treasury mutations do not happen on every milestone, send the stored unspent output that we have
+		ledgerIndex, err := sendCurrentTreasuryOutput()
+		if err != nil {
+			return err
+		}
+		lastSentIndex = ledgerIndex
 	}
 
 	if requestEndIndex > 0 && lastSentIndex >= requestEndIndex {
 		// We are done sending, so close the stream
 		return nil
-	}
-
-	if !sentTreasuryUpdate {
-		// Since treasury mutations do not happen on every milestone, send the stored unspent output that we have
-		treasuryOutput, err := deps.UTXOManager.UnspentTreasuryOutputWithoutLocking()
-		if err != nil {
-			return err
-		}
-		payload, err := NewTreasuryUpdate(ledgerIndex, treasuryOutput, treasuryOutput)
-		if err != nil {
-			return err
-		}
-		if err := srv.Send(payload); err != nil {
-			return fmt.Errorf("send error: %w", err)
-		}
 	}
 
 	var innerErr error
@@ -400,19 +449,44 @@ func (s *INXServer) ListenToTreasuryUpdates(req *inx.MilestoneRangeRequest, srv 
 			return
 		}
 
-		tm := task.Param(1).(*utxo.TreasuryMutationTuple)
-		payload, err := NewTreasuryUpdate(index, tm.NewOutput, tm.SpentOutput)
-		if err != nil {
-			Plugin.LogInfof("Send error: %v", err)
+		if requestStartIndex > 0 && index-1 > lastSentIndex {
+			// we missed some treasury updates in between
+			startIndex := requestStartIndex
+			if startIndex < lastSentIndex+1 {
+				startIndex = lastSentIndex + 1
+			}
+
+			endIndex := index - 1
+			if requestEndIndex > 0 && endIndex > requestEndIndex {
+				endIndex = requestEndIndex
+			}
+
+			if err := sendTreasuryUpdatesRange(startIndex, endIndex); err != nil {
+				Plugin.LogInfof("sendTreasuryUpdatesRange error: %v", err)
+				innerErr = err
+				cancel()
+				task.Return(nil)
+				return
+			}
+
+			// remember the last index we sent
+			lastSentIndex = endIndex
+		}
+
+		if requestEndIndex > 0 && index > requestEndIndex {
+			// We are done sending the updates
+			innerErr = nil
 			cancel()
-			innerErr = err
 			task.Return(nil)
 			return
 		}
-		if err := srv.Send(payload); err != nil {
+
+		tm := task.Param(1).(*utxo.TreasuryMutationTuple)
+
+		if err := createTreasuryUpdatePayloadAndSend(index, tm.NewOutput, tm.SpentOutput); err != nil {
 			Plugin.LogInfof("send error: %v", err)
-			cancel()
 			innerErr = err
+			cancel()
 			task.Return(nil)
 			return
 		}
@@ -425,14 +499,17 @@ func (s *INXServer) ListenToTreasuryUpdates(req *inx.MilestoneRangeRequest, srv 
 
 		task.Return(nil)
 	}, workerpool.WorkerCount(workerCount), workerpool.QueueSize(workerQueueSize), workerpool.FlushTasksAtShutdown(true))
+
 	closure := events.NewClosure(func(index milestone.Index, tuple *utxo.TreasuryMutationTuple) {
 		wp.Submit(index, tuple)
 	})
+
 	wp.Start()
 	deps.Tangle.Events.TreasuryMutated.Attach(closure)
 	<-ctx.Done()
 	deps.Tangle.Events.TreasuryMutated.Detach(closure)
 	wp.Stop()
+
 	return innerErr
 }
 


### PR DESCRIPTION
This PR fixes possible data races in INX.

It can happen that in INX endpoints with a `StartIndex` and an `EndIndex` parameter, new data is arriving between sending of the previous data and the start of the sending of the actual new data.

If that happened, new data was lost, because the previous data is sent while the events the streams are listening to are not subscribed to yet.

This PR fixes this by sending the data that arrived in the meantime at processing of the first element that hits the workerpool (after the previous data was sent completly).

Another optimization is that the read lock of the ledger is not hold permanently while the previous data is sent.
This caused a problem if a client wanted to request a lot of old data, while listening with another stream to the latest data. (chronicle does that)