### PR TITLE
Add dashboard metrics plugin

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/iotaledger/hornet/core/tangle"
 	"github.com/iotaledger/hornet/pkg/toolset"
 	"github.com/iotaledger/hornet/plugins/autopeering"
+	dashboard_metrics "github.com/iotaledger/hornet/plugins/dashboard-metrics"
 	"github.com/iotaledger/hornet/plugins/debug"
 	"github.com/iotaledger/hornet/plugins/inx"
 	"github.com/iotaledger/hornet/plugins/prometheus"
@@ -66,6 +67,7 @@ Command line flags:
 			receipt.Plugin,
 			prometheus.Plugin,
 			inx.Plugin,
+			dashboard_metrics.Plugin,
 			debug.Plugin,
 		}...),
 	)

--- a/core/profile/core.go
+++ b/core/profile/core.go
@@ -40,6 +40,12 @@ type dependencies struct {
 
 func provide(c *dig.Container) error {
 
+	if err := c.Provide(func() string {
+		return ParamsNode.Alias
+	}, dig.Name("nodeAlias")); err != nil {
+		CoreComponent.LogPanic(err)
+	}
+
 	type profileDeps struct {
 		dig.In
 		ProfilesConfig *configuration.Configuration `name:"profilesConfig"`

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -2,10 +2,11 @@ package autopeering
 
 import (
 	"context"
-	"github.com/iotaledger/hornet/core/protocfg"
-	"github.com/iotaledger/hornet/pkg/protocol"
 	"strings"
 	"time"
+
+	"github.com/iotaledger/hornet/core/protocfg"
+	"github.com/iotaledger/hornet/pkg/protocol"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
 	libp2p "github.com/libp2p/go-libp2p-core/peer"
@@ -27,6 +28,7 @@ import (
 	"github.com/iotaledger/hornet/pkg/database"
 	"github.com/iotaledger/hornet/pkg/p2p"
 	"github.com/iotaledger/hornet/pkg/p2p/autopeering"
+	dashboard_metrics "github.com/iotaledger/hornet/plugins/dashboard-metrics"
 	"github.com/iotaledger/hornet/plugins/debug"
 	"github.com/iotaledger/hornet/plugins/inx"
 	"github.com/iotaledger/hornet/plugins/prometheus"
@@ -127,6 +129,7 @@ func preProvide(c *dig.Container, _ *app.App, initConfig *app.InitConfig) error 
 		initConfig.ForceDisableComponent(receipt.Plugin.Identifier())
 		initConfig.ForceDisableComponent(prometheus.Plugin.Identifier())
 		initConfig.ForceDisableComponent(inx.Plugin.Identifier())
+		initConfig.ForceDisableComponent(dashboard_metrics.Plugin.Identifier())
 		initConfig.ForceDisableComponent(debug.Plugin.Identifier())
 	}
 

--- a/plugins/dashboard-metrics/metrics.go
+++ b/plugins/dashboard-metrics/metrics.go
@@ -54,7 +54,7 @@ func databaseSizesMetrics(c echo.Context) (*DatabaseSizesMetric, error) {
 		Tangle: tangleDatabaseSize,
 		UTXO:   utxoDatabaseSize,
 		Total:  tangleDatabaseSize + utxoDatabaseSize,
-		Time:   time.Now(),
+		Time:   time.Now().Unix(),
 	}, nil
 }
 

--- a/plugins/dashboard-metrics/metrics.go
+++ b/plugins/dashboard-metrics/metrics.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+
+	"github.com/iotaledger/hornet/pkg/tangle"
+)
+
+var (
+	nodeStartupTimestamp = time.Now()
+
+	lastGossipMetrics = &tangle.BPSMetrics{
+		Incoming: 0,
+		New:      0,
+		Outgoing: 0,
+	}
+	lastGossipMetricsLock = &sync.RWMutex{}
+)
+
+func nodeInfoExtended(c echo.Context) *NodeInfoExtended {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	status := &NodeInfoExtended{
+		Version:       deps.AppInfo.Version,
+		LatestVersion: deps.AppInfo.LatestGitHubVersion,
+		Uptime:        time.Since(nodeStartupTimestamp).Milliseconds(),
+		NodeID:        deps.Host.ID().String(),
+		NodeAlias:     deps.NodeAlias,
+		MemoryUsage:   int64(m.HeapAlloc + m.StackSys + m.MSpanSys + m.MCacheSys + m.BuckHashSys + m.GCSys + m.OtherSys),
+	}
+
+	return status
+}
+
+func databaseSizesMetrics(c echo.Context) (*DatabaseSizesMetric, error) {
+
+	tangleDatabaseSize, err := deps.TangleDatabase.Size()
+	if err != nil {
+		return nil, errors.WithMessagef(echo.ErrInternalServerError, "calculating tangle database size failed, error: %s", err)
+	}
+
+	utxoDatabaseSize, err := deps.UTXODatabase.Size()
+	if err != nil {
+		return nil, errors.WithMessagef(echo.ErrInternalServerError, "calculating UTXO database size failed, error: %s", err)
+	}
+
+	return &DatabaseSizesMetric{
+		Tangle: tangleDatabaseSize,
+		UTXO:   utxoDatabaseSize,
+		Total:  tangleDatabaseSize + utxoDatabaseSize,
+		Time:   time.Now(),
+	}, nil
+}
+
+func gossipMetrics(c echo.Context) *tangle.BPSMetrics {
+	lastGossipMetricsLock.RLock()
+	defer lastGossipMetricsLock.RUnlock()
+
+	return lastGossipMetrics
+}

--- a/plugins/dashboard-metrics/plugin.go
+++ b/plugins/dashboard-metrics/plugin.go
@@ -1,0 +1,108 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/libp2p/go-libp2p-core/host"
+	"go.uber.org/dig"
+
+	"github.com/iotaledger/hive.go/app"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hornet/pkg/daemon"
+	"github.com/iotaledger/hornet/pkg/database"
+	restapipkg "github.com/iotaledger/hornet/pkg/restapi"
+	"github.com/iotaledger/hornet/pkg/tangle"
+	"github.com/iotaledger/hornet/plugins/restapi"
+)
+
+const (
+	// RouteNodeInfoExtended is the route to get additional info about the node.
+	// GET returns the extended info of the node.
+	RouteNodeInfoExtended = "/info"
+
+	// RouteDatabaseSizes is the route to get the size of the databases.
+	// GET returns the sizes of the databases.
+	RouteDatabaseSizes = "/database/sizes"
+
+	// RouteGossipMetrics is the route to get metrics about gossip.
+	// GET returns the gossip metrics.
+	RouteGossipMetrics = "/gossip"
+)
+
+func init() {
+	Plugin = &app.Plugin{
+		Status: app.StatusEnabled,
+		Component: &app.Component{
+			Name:      "DashboardMetrics",
+			DepsFunc:  func(cDeps dependencies) { deps = cDeps },
+			Configure: configure,
+			Run:       run,
+		},
+	}
+}
+
+var (
+	Plugin *app.Plugin
+	deps   dependencies
+)
+
+type dependencies struct {
+	dig.In
+	RestPluginManager *restapi.RestPluginManager `optional:"true"`
+	AppInfo           *app.AppInfo
+	Host              host.Host
+	NodeAlias         string             `name:"nodeAlias"`
+	TangleDatabase    *database.Database `name:"tangleDatabase"`
+	UTXODatabase      *database.Database `name:"utxoDatabase"`
+	Tangle            *tangle.Tangle
+}
+
+func configure() error {
+	// check if RestAPI plugin is disabled
+	if Plugin.App.IsPluginSkipped(restapi.Plugin) {
+		Plugin.LogPanic("RestAPI plugin needs to be enabled to use the dashboard metrics plugin")
+	}
+
+	routeGroup := deps.RestPluginManager.AddPlugin("dashboard-metrics/v1")
+
+	routeGroup.GET(RouteNodeInfoExtended, func(c echo.Context) error {
+		return restapipkg.JSONResponse(c, http.StatusOK, nodeInfoExtended(c))
+	})
+
+	routeGroup.GET(RouteDatabaseSizes, func(c echo.Context) error {
+		resp, err := databaseSizesMetrics(c)
+		if err != nil {
+			return err
+		}
+
+		return restapipkg.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteGossipMetrics, func(c echo.Context) error {
+		return restapipkg.JSONResponse(c, http.StatusOK, gossipMetrics(c))
+	})
+
+	return nil
+}
+
+func run() error {
+
+	onBPSMetricsUpdated := events.NewClosure(func(gossipMetrics *tangle.BPSMetrics) {
+		lastGossipMetricsLock.Lock()
+		defer lastGossipMetricsLock.Unlock()
+
+		lastGossipMetrics = gossipMetrics
+	})
+
+	if err := Plugin.Daemon().BackgroundWorker("DashboardMetricsUpdater", func(ctx context.Context) {
+		deps.Tangle.Events.BPSMetricsUpdated.Attach(onBPSMetricsUpdated)
+		<-ctx.Done()
+		deps.Tangle.Events.BPSMetricsUpdated.Detach(onBPSMetricsUpdated)
+	}, daemon.PriorityMetricsUpdater); err != nil {
+		Plugin.LogPanicf("failed to start worker: %s", err)
+	}
+
+	return nil
+}

--- a/plugins/dashboard-metrics/types.go
+++ b/plugins/dashboard-metrics/types.go
@@ -1,0 +1,23 @@
+package metrics
+
+import (
+	"time"
+)
+
+// NodeInfoExtended represents extended information about the node.
+type NodeInfoExtended struct {
+	Version       string `json:"version"`
+	LatestVersion string `json:"latestVersion"`
+	Uptime        int64  `json:"uptime"`
+	NodeID        string `json:"nodeId"`
+	NodeAlias     string `json:"nodeAlias"`
+	MemoryUsage   int64  `json:"memUsage"`
+}
+
+// DatabaseSizesMetric represents database size metrics.
+type DatabaseSizesMetric struct {
+	Tangle int64     `json:"tangle"`
+	UTXO   int64     `json:"utxo"`
+	Total  int64     `json:"total"`
+	Time   time.Time `json:"ts"`
+}

--- a/plugins/dashboard-metrics/types.go
+++ b/plugins/dashboard-metrics/types.go
@@ -1,9 +1,5 @@
 package metrics
 
-import (
-	"time"
-)
-
 // NodeInfoExtended represents extended information about the node.
 type NodeInfoExtended struct {
 	Version       string `json:"version"`
@@ -16,8 +12,8 @@ type NodeInfoExtended struct {
 
 // DatabaseSizesMetric represents database size metrics.
 type DatabaseSizesMetric struct {
-	Tangle int64     `json:"tangle"`
-	UTXO   int64     `json:"utxo"`
-	Total  int64     `json:"total"`
-	Time   time.Time `json:"ts"`
+	Tangle int64 `json:"tangle"`
+	UTXO   int64 `json:"utxo"`
+	Total  int64 `json:"total"`
+	Time   int64 `json:"ts"`
 }


### PR DESCRIPTION
This PR adds a plugin that serves several REST routes that are necessary for INX-dashboard.

The plugin is enabled by default for easier configuration by the node owner.
The routes do not need to be exposed, because they are tunneled via INX
