### PR TITLE
Disable endpoints when an unsupported protocol version was detected

### DIFF
--- a/pkg/protocol/protocol_manager.go
+++ b/pkg/protocol/protocol_manager.go
@@ -2,13 +2,14 @@ package protocol
 
 import (
 	"fmt"
+	"sync"
+
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/serializer/v2"
 	"github.com/iotaledger/hornet/pkg/model/milestone"
 	"github.com/iotaledger/hornet/pkg/model/storage"
 	"github.com/iotaledger/hornet/pkg/model/syncmanager"
-	"github.com/iotaledger/iota.go/v3"
-	"sync"
+	iotago "github.com/iotaledger/iota.go/v3"
 )
 
 var (

--- a/plugins/restapi/api.go
+++ b/plugins/restapi/api.go
@@ -109,21 +109,3 @@ func apiMiddleware() echo.MiddlewareFunc {
 		}
 	}
 }
-
-func checkAllowedAPIRoute(context echo.Context, allowedRoutes map[string][]string) bool {
-
-	// Check for which route we will allow to access the API
-	routesForMethod, exists := allowedRoutes[context.Request().Method]
-	if !exists {
-		return false
-	}
-
-	path := context.Request().URL.EscapedPath()
-	for _, prefix := range routesForMethod {
-		if strings.HasPrefix(path, prefix) {
-			return true
-		}
-	}
-
-	return false
-}

--- a/plugins/restapi/v2/blocks.go
+++ b/plugins/restapi/v2/blocks.go
@@ -22,11 +22,6 @@ var (
 )
 
 func blockMetadataByID(c echo.Context) (*blockMetadataResponse, error) {
-
-	if !deps.SyncManager.IsNodeAlmostSynced() {
-		return nil, errors.WithMessage(echo.ErrServiceUnavailable, "node is not synced")
-	}
-
 	blockID, err := restapi.ParseBlockIDParam(c)
 	if err != nil {
 		return nil, err
@@ -138,11 +133,6 @@ func blockBytesByID(c echo.Context) ([]byte, error) {
 }
 
 func sendBlock(c echo.Context) (*blockCreatedResponse, error) {
-
-	if !deps.SyncManager.IsNodeAlmostSynced() {
-		return nil, errors.WithMessage(echo.ErrServiceUnavailable, "node is not synced")
-	}
-
 	mimeType, err := restapi.GetRequestContentType(c, restapi.MIMEApplicationVendorIOTASerializerV1, echo.MIMEApplicationJSON)
 	if err != nil {
 		return nil, err

--- a/plugins/restapi/v2/plugin.go
+++ b/plugins/restapi/v2/plugin.go
@@ -204,7 +204,7 @@ func configure() error {
 				return err
 			}
 			return restapipkg.JSONResponse(c, http.StatusOK, resp)
-		})
+		}, checkNodeAlmostSynced(), checkUpcomingUnsupportedProtocolVersion())
 	}
 
 	routeGroup.GET(RouteBlockMetadata, func(c echo.Context) error {
@@ -415,15 +415,6 @@ func configure() error {
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
-	routeGroup.POST(RouteComputeWhiteFlagMutations, func(c echo.Context) error {
-		resp, err := computeWhiteFlagMutations(c)
-		if err != nil {
-			return err
-		}
-
-		return restapipkg.JSONResponse(c, http.StatusOK, resp)
-	})
-
 	routeGroup.POST(RoutePeers, func(c echo.Context) error {
 		resp, err := addPeer(c)
 		if err != nil {
@@ -431,6 +422,14 @@ func configure() error {
 		}
 		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
+
+	routeGroup.POST(RouteComputeWhiteFlagMutations, func(c echo.Context) error {
+		resp, err := computeWhiteFlagMutations(c)
+		if err != nil {
+			return err
+		}
+		return restapipkg.JSONResponse(c, http.StatusOK, resp)
+	}, checkNodeAlmostSynced(), checkUpcomingUnsupportedProtocolVersion())
 
 	routeGroup.POST(RouteControlDatabasePrune, func(c echo.Context) error {
 		resp, err := pruneDatabase(c)


### PR DESCRIPTION
- Added new echo middleware that checks for an unsupported upcoming protocol upgrade and marks the endpoints using it as unavailable
- Use this new middleware for POST /api/v2/blocks (#1564)
- Refactored the IsNodeAlmostSynced checks in the api to use a new echo middleware
- Removed unused code from the dashboard removal