### PR TITLE
Fix comma in private tangle config

### DIFF
--- a/private_tangle/config_private_tangle.json
+++ b/private_tangle/config_private_tangle.json
@@ -121,7 +121,7 @@
     "bindAddress": "0.0.0.0:14265",
     "publicRoutes": [
       "/health",
-      "/api/*",
+      "/api/*"
     ],
     "protectedRoutes": [
     ],


### PR DESCRIPTION
# Description

Removes an extra comma in private tangle config that crashes the hornet-coo node in private tangle.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


