### PR TITLE
fixed cannot start private tangle

### DIFF
--- a/private_tangle/docker-compose.yml
+++ b/private_tangle/docker-compose.yml
@@ -242,7 +242,6 @@ services:
       - "--dashboard.bindAddress=172.18.211.33:8081"
       - "--dashboard.auth.identityPrivateKey=5126767a84e1ced849dbbf2be809fd40f90bcfb81bd0d3309e2e25e34f803bf265500854f1f0e8fd3c389cf7b6b59cfd422b9319f257e2a8d3a772973560acdd"
     profiles:
-      - 2-nodes
       - 3-nodes
       - 4-nodes
 
@@ -265,8 +264,6 @@ services:
       - "--dashboard.bindAddress=172.18.211.34:8081"
       - "--dashboard.auth.identityPrivateKey=996dceaeddcb5fc21480646f38ac53c4f5668fd33f3c0bfecfd004861d4a9dc722355dabd7f31a1266423abcf6c1db6228eb8283deb55731915ed06bd2ca387e"
     profiles:
-      - 2-nodes
-      - 3-nodes
       - 4-nodes
 
   hornet-coo:


### PR DESCRIPTION
# Description

This PR fixes unable to start private tangle with 2-nodes and 3-nodes profile.

```bash
$ sudo ./run.sh 
ERROR: Service "hornet-3" was pulled in as a dependency of service "inx-dashboard-3" but is not enabled by the active profiles. You may fix this by adding a common profile to "hornet-3" and "inx-dashboard-3".
$ sudo ./run.sh 3
ERROR: Service "hornet-4" was pulled in as a dependency of service "inx-dashboard-4" but is not enabled by the active profiles. You may fix this by adding a common profile to "hornet-4" and "inx-dashboard-4".
```
