### PR TITLE
Rename fields in Output and Spent types

### DIFF
--- a/pkg/model/utxo/output.go
+++ b/pkg/model/utxo/output.go
@@ -30,10 +30,10 @@ func (l LexicalOrderedOutputs) Swap(i, j int) {
 type Output struct {
 	kvStorable
 
-	outputID           iotago.OutputID
-	blockID            iotago.BlockID
-	milestoneIndex     milestone.Index
-	milestoneTimestamp uint32
+	outputID          iotago.OutputID
+	blockID           iotago.BlockID
+	msIndexBooked     milestone.Index
+	msTimestampBooked uint32
 
 	output iotago.Output
 }
@@ -50,12 +50,12 @@ func (o *Output) BlockID() iotago.BlockID {
 	return o.blockID
 }
 
-func (o *Output) MilestoneIndex() milestone.Index {
-	return o.milestoneIndex
+func (o *Output) MilestoneIndexBooked() milestone.Index {
+	return o.msIndexBooked
 }
 
-func (o *Output) MilestoneTimestamp() uint32 {
-	return o.milestoneTimestamp
+func (o *Output) MilestoneTimestampBooked() uint32 {
+	return o.msTimestampBooked
 }
 
 func (o *Output) OutputType() iotago.OutputType {
@@ -80,17 +80,17 @@ func (o Outputs) ToOutputSet() iotago.OutputSet {
 	return outputSet
 }
 
-func CreateOutput(outputID iotago.OutputID, blockID iotago.BlockID, milestoneIndex milestone.Index, milestoneTimestamp uint32, output iotago.Output) *Output {
+func CreateOutput(outputID iotago.OutputID, blockID iotago.BlockID, msIndexBooked milestone.Index, msTimestampBooked uint32, output iotago.Output) *Output {
 	return &Output{
-		outputID:           outputID,
-		blockID:            blockID,
-		milestoneIndex:     milestoneIndex,
-		milestoneTimestamp: milestoneTimestamp,
-		output:             output,
+		outputID:          outputID,
+		blockID:           blockID,
+		msIndexBooked:     msIndexBooked,
+		msTimestampBooked: msTimestampBooked,
+		output:            output,
 	}
 }
 
-func NewOutput(blockID iotago.BlockID, milestoneIndex milestone.Index, milestoneTimestamp uint32, transaction *iotago.Transaction, index uint16) (*Output, error) {
+func NewOutput(blockID iotago.BlockID, msIndexBooked milestone.Index, msTimestampBooked uint32, transaction *iotago.Transaction, index uint16) (*Output, error) {
 
 	txID, err := transaction.ID()
 	if err != nil {
@@ -104,7 +104,7 @@ func NewOutput(blockID iotago.BlockID, milestoneIndex milestone.Index, milestone
 	output = transaction.Essence.Outputs[int(index)]
 	outputID := iotago.OutputIDFromTransactionIDAndIndex(txID, index)
 
-	return CreateOutput(outputID, blockID, milestoneIndex, milestoneTimestamp, output), nil
+	return CreateOutput(outputID, blockID, msIndexBooked, msTimestampBooked, output), nil
 }
 
 //- kvStorable
@@ -122,9 +122,9 @@ func (o *Output) KVStorableKey() (key []byte) {
 
 func (o *Output) KVStorableValue() (value []byte) {
 	ms := marshalutil.New(40)
-	ms.WriteBytes(o.blockID[:])              // 32 bytes
-	ms.WriteUint32(uint32(o.milestoneIndex)) // 4 bytes
-	ms.WriteUint32(o.milestoneTimestamp)     // 4 bytes
+	ms.WriteBytes(o.blockID[:])             // 32 bytes
+	ms.WriteUint32(uint32(o.msIndexBooked)) // 4 bytes
+	ms.WriteUint32(o.msTimestampBooked)     // 4 bytes
 
 	outputBytes, err := o.output.Serialize(serializer.DeSeriModeNoValidation, nil)
 	if err != nil {
@@ -160,11 +160,11 @@ func (o *Output) kvStorableLoad(_ *Manager, key []byte, value []byte) error {
 	}
 
 	// Read Milestone
-	if o.milestoneIndex, err = parseMilestoneIndex(valueUtil); err != nil {
+	if o.msIndexBooked, err = parseMilestoneIndex(valueUtil); err != nil {
 		return err
 	}
 
-	if o.milestoneTimestamp, err = valueUtil.ReadUint32(); err != nil {
+	if o.msTimestampBooked, err = valueUtil.ReadUint32(); err != nil {
 		return err
 	}
 

--- a/pkg/model/utxo/spent.go
+++ b/pkg/model/utxo/spent.go
@@ -30,10 +30,13 @@ func (l LexicalOrderedSpents) Swap(i, j int) {
 type Spent struct {
 	kvStorable
 
-	outputID            iotago.OutputID
-	targetTransactionID iotago.TransactionID
-	milestoneIndex      milestone.Index
-	milestoneTimestamp  uint32
+	outputID iotago.OutputID
+	// the ID of the transaction that spent the output
+	transactionIDSpent iotago.TransactionID
+	// the index of the milestone that spent the output
+	msIndexSpent milestone.Index
+	// the timestamp of the milestone that spent the output
+	msTimestampSpent uint32
 
 	output *Output
 }
@@ -62,27 +65,30 @@ func (s *Spent) Deposit() uint64 {
 	return s.output.Deposit()
 }
 
-func (s *Spent) TargetTransactionID() iotago.TransactionID {
-	return s.targetTransactionID
+// TransactionIDSpent returns the ID of the transaction that spent the output
+func (s *Spent) TransactionIDSpent() iotago.TransactionID {
+	return s.transactionIDSpent
 }
 
-func (s *Spent) MilestoneIndex() milestone.Index {
-	return s.milestoneIndex
+// MilestoneIndexSpent returns the index of the milestone that spent the output
+func (s *Spent) MilestoneIndexSpent() milestone.Index {
+	return s.msIndexSpent
 }
 
-func (s *Spent) MilestoneTimestamp() uint32 {
-	return s.milestoneTimestamp
+// MilestoneTimestampSpent returns the timestamp of the milestone that spent the output
+func (s *Spent) MilestoneTimestampSpent() uint32 {
+	return s.msTimestampSpent
 }
 
 type Spents []*Spent
 
-func NewSpent(output *Output, targetTransactionID iotago.TransactionID, confirmationIndex milestone.Index, confirmationTimestamp uint32) *Spent {
+func NewSpent(output *Output, transactionIDSpent iotago.TransactionID, msIndexSpent milestone.Index, msTimestampSpent uint32) *Spent {
 	return &Spent{
-		outputID:            output.outputID,
-		output:              output,
-		targetTransactionID: targetTransactionID,
-		milestoneIndex:      confirmationIndex,
-		milestoneTimestamp:  confirmationTimestamp,
+		outputID:           output.outputID,
+		output:             output,
+		transactionIDSpent: transactionIDSpent,
+		msIndexSpent:       msIndexSpent,
+		msTimestampSpent:   msTimestampSpent,
 	}
 }
 
@@ -99,9 +105,9 @@ func (s *Spent) KVStorableKey() (key []byte) {
 
 func (s *Spent) KVStorableValue() (value []byte) {
 	ms := marshalutil.New(40)
-	ms.WriteBytes(s.targetTransactionID[:])  // 32 bytes
-	ms.WriteUint32(uint32(s.milestoneIndex)) // 4 bytes
-	ms.WriteUint32(s.milestoneTimestamp)     // 4 bytes
+	ms.WriteBytes(s.transactionIDSpent[:]) // 32 bytes
+	ms.WriteUint32(uint32(s.msIndexSpent)) // 4 bytes
+	ms.WriteUint32(s.msTimestampSpent)     // 4 bytes
 	return ms.Bytes()
 }
 
@@ -125,7 +131,7 @@ func (s *Spent) kvStorableLoad(_ *Manager, key []byte, value []byte) error {
 	valueUtil := marshalutil.New(value)
 
 	// Read transaction ID
-	if s.targetTransactionID, err = parseTransactionID(valueUtil); err != nil {
+	if s.transactionIDSpent, err = parseTransactionID(valueUtil); err != nil {
 		return err
 	}
 
@@ -134,10 +140,10 @@ func (s *Spent) kvStorableLoad(_ *Manager, key []byte, value []byte) error {
 	if err != nil {
 		return err
 	}
-	s.milestoneIndex = milestone.Index(index)
+	s.msIndexSpent = milestone.Index(index)
 
 	// Read milestone timestamp
-	if s.milestoneTimestamp, err = valueUtil.ReadUint32(); err != nil {
+	if s.msTimestampSpent, err = valueUtil.ReadUint32(); err != nil {
 		return err
 	}
 

--- a/pkg/model/utxo/test/equal_test.go
+++ b/pkg/model/utxo/test/equal_test.go
@@ -23,6 +23,7 @@ func EqualSpent(t *testing.T, expected *utxo.Spent, actual *utxo.Spent) {
 	require.Equal(t, expected.OutputID(), actual.OutputID())
 	require.Equal(t, expected.TransactionIDSpent(), actual.TransactionIDSpent())
 	require.Equal(t, expected.MilestoneIndexSpent(), actual.MilestoneIndexSpent())
+	require.Equal(t, expected.MilestoneTimestampSpent(), actual.MilestoneTimestampSpent())
 	EqualOutput(t, expected.Output(), actual.Output())
 }
 

--- a/pkg/model/utxo/test/equal_test.go
+++ b/pkg/model/utxo/test/equal_test.go
@@ -13,7 +13,7 @@ import (
 func EqualOutput(t *testing.T, expected *utxo.Output, actual *utxo.Output) {
 	require.Equal(t, expected.OutputID(), actual.OutputID())
 	require.Equal(t, expected.BlockID(), actual.BlockID())
-	require.Equal(t, expected.MilestoneIndex(), actual.MilestoneIndex())
+	require.Equal(t, expected.MilestoneIndexBooked(), actual.MilestoneIndexBooked())
 	require.Equal(t, expected.OutputType(), actual.OutputType())
 	require.Equal(t, expected.Deposit(), actual.Deposit())
 	require.EqualValues(t, expected.Output(), actual.Output())
@@ -21,8 +21,8 @@ func EqualOutput(t *testing.T, expected *utxo.Output, actual *utxo.Output) {
 
 func EqualSpent(t *testing.T, expected *utxo.Spent, actual *utxo.Spent) {
 	require.Equal(t, expected.OutputID(), actual.OutputID())
-	require.Equal(t, expected.TargetTransactionID(), actual.TargetTransactionID())
-	require.Equal(t, expected.MilestoneIndex(), actual.MilestoneIndex())
+	require.Equal(t, expected.TransactionIDSpent(), actual.TransactionIDSpent())
+	require.Equal(t, expected.MilestoneIndexSpent(), actual.MilestoneIndexSpent())
 	EqualOutput(t, expected.Output(), actual.Output())
 }
 

--- a/pkg/model/utxo/test/output_test.go
+++ b/pkg/model/utxo/test/output_test.go
@@ -58,7 +58,7 @@ func AssertOutputUnspentAndSpentTransitions(t *testing.T, output *utxo.Output, s
 	require.True(t, has)
 
 	// Spend it with a milestone
-	require.NoError(t, manager.ApplyConfirmation(spent.MilestoneIndex(), utxo.Outputs{}, utxo.Spents{spent}, nil, nil))
+	require.NoError(t, manager.ApplyConfirmation(spent.MilestoneIndexSpent(), utxo.Outputs{}, utxo.Spents{spent}, nil, nil))
 
 	// Read Spent from DB and compare
 	readSpent, err := manager.ReadSpentForOutputIDWithoutLocking(outputID)
@@ -76,7 +76,7 @@ func AssertOutputUnspentAndSpentTransitions(t *testing.T, output *utxo.Output, s
 	require.False(t, has)
 
 	// Rollback milestone
-	require.NoError(t, manager.RollbackConfirmation(spent.MilestoneIndex(), utxo.Outputs{}, utxo.Spents{spent}, nil, nil))
+	require.NoError(t, manager.RollbackConfirmation(spent.MilestoneIndexSpent(), utxo.Outputs{}, utxo.Spents{spent}, nil, nil))
 
 	// Verify that it is unspent
 	unspent, err = manager.IsOutputIDUnspentWithoutLocking(outputID)

--- a/pkg/snapshot/snapshot_file_test.go
+++ b/pkg/snapshot/snapshot_file_test.go
@@ -345,7 +345,7 @@ func randLSTransactionSpents(msIndex milestone.Index) *utxo.Spent {
 func EqualOutput(t *testing.T, expected *utxo.Output, actual *utxo.Output) {
 	require.Equal(t, expected.OutputID(), actual.OutputID())
 	require.Equal(t, expected.BlockID(), actual.BlockID())
-	require.Equal(t, expected.MilestoneIndex(), actual.MilestoneIndex())
+	require.Equal(t, expected.MilestoneIndexBooked(), actual.MilestoneIndexBooked())
 	require.Equal(t, expected.OutputType(), actual.OutputType())
 	require.Equal(t, expected.Deposit(), actual.Deposit())
 	require.EqualValues(t, expected.Output(), actual.Output())
@@ -353,8 +353,9 @@ func EqualOutput(t *testing.T, expected *utxo.Output, actual *utxo.Output) {
 
 func EqualSpent(t *testing.T, expected *utxo.Spent, actual *utxo.Spent) {
 	require.Equal(t, expected.OutputID(), actual.OutputID())
-	require.Equal(t, expected.TargetTransactionID(), actual.TargetTransactionID())
-	require.Equal(t, expected.MilestoneIndex(), actual.MilestoneIndex())
+	require.Equal(t, expected.TransactionIDSpent(), actual.TransactionIDSpent())
+	require.Equal(t, expected.MilestoneIndexSpent(), actual.MilestoneIndexSpent())
+	require.Equal(t, expected.MilestoneTimestampSpent(), actual.MilestoneTimestampSpent())
 	EqualOutput(t, expected.Output(), actual.Output())
 }
 

--- a/pkg/snapshot/snapshot_file_test.go
+++ b/pkg/snapshot/snapshot_file_test.go
@@ -294,7 +294,7 @@ func newMsDiffGenerator(count int) (snapshot.MilestoneDiffProducerFunc, msDiffRe
 
 			consumedCount := rand.Intn(500) + 1
 			for i := 0; i < consumedCount; i++ {
-				msDiff.Consumed = append(msDiff.Consumed, randLSTransactionSpents(milestone.Index(milestonePayload.Index)))
+				msDiff.Consumed = append(msDiff.Consumed, randLSTransactionSpents(milestone.Index(milestonePayload.Index), milestonePayload.Timestamp))
 			}
 
 			msDiff.SpentTreasuryOutput = &utxo.TreasuryOutput{
@@ -338,8 +338,8 @@ func randLSTransactionUnspentOutputs() *utxo.Output {
 	return utxo.CreateOutput(utils.RandOutputID(), utils.RandBlockID(), utils.RandMilestoneIndex(), rand.Uint32(), utils.RandOutput(utils.RandOutputType()))
 }
 
-func randLSTransactionSpents(msIndex milestone.Index) *utxo.Spent {
-	return utxo.NewSpent(utxo.CreateOutput(utils.RandOutputID(), utils.RandBlockID(), utils.RandMilestoneIndex(), rand.Uint32(), utils.RandOutput(utils.RandOutputType())), utils.RandTransactionID(), msIndex, rand.Uint32())
+func randLSTransactionSpents(msIndexSpent milestone.Index, msTimestampSpent uint32) *utxo.Spent {
+	return utxo.NewSpent(utxo.CreateOutput(utils.RandOutputID(), utils.RandBlockID(), utils.RandMilestoneIndex(), rand.Uint32(), utils.RandOutput(utils.RandOutputType())), utils.RandTransactionID(), msIndexSpent, msTimestampSpent)
 }
 
 func EqualOutput(t *testing.T, expected *utxo.Output, actual *utxo.Output) {

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -26,12 +26,12 @@ func randomOutput(outputType iotago.OutputType, address ...iotago.Address) *utxo
 	return utxo.CreateOutput(utils.RandOutputID(), utils.RandBlockID(), utils.RandMilestoneIndex(), rand.Uint32(), output)
 }
 
-func randomSpent(output *utxo.Output, msIndex ...milestone.Index) *utxo.Spent {
-	confirmationIndex := utils.RandMilestoneIndex()
-	if len(msIndex) > 0 {
-		confirmationIndex = msIndex[0]
+func randomSpent(output *utxo.Output, msIndexSpent ...milestone.Index) *utxo.Spent {
+	milestoneIndexSpent := utils.RandMilestoneIndex()
+	if len(msIndexSpent) > 0 {
+		milestoneIndexSpent = msIndexSpent[0]
 	}
-	return utxo.NewSpent(output, utils.RandTransactionID(), confirmationIndex, rand.Uint32())
+	return utxo.NewSpent(output, utils.RandTransactionID(), milestoneIndexSpent, rand.Uint32())
 }
 
 func EqualOutput(t *testing.T, expected *utxo.Output, actual *utxo.Output) {
@@ -87,8 +87,9 @@ func EqualOutputs(t *testing.T, expected utxo.Outputs, actual utxo.Outputs) {
 
 func EqualSpent(t *testing.T, expected *utxo.Spent, actual *utxo.Spent) {
 	require.Equal(t, expected.OutputID(), actual.OutputID())
-	require.Equal(t, expected.TargetTransactionID(), actual.TargetTransactionID())
-	require.Equal(t, expected.MilestoneIndex(), actual.MilestoneIndex())
+	require.Equal(t, expected.TransactionIDSpent(), actual.TransactionIDSpent())
+	require.Equal(t, expected.MilestoneIndexSpent(), actual.MilestoneIndexSpent())
+	require.Equal(t, expected.MilestoneTimestampSpent(), actual.MilestoneTimestampSpent())
 	EqualOutput(t, expected.Output(), actual.Output())
 }
 

--- a/plugins/coreapi/utxo.go
+++ b/plugins/coreapi/utxo.go
@@ -19,8 +19,8 @@ func NewOutputMetadataResponse(output *utxo.Output, ledgerIndex milestone.Index)
 		TransactionID:            output.OutputID().TransactionID().ToHex(),
 		Spent:                    false,
 		OutputIndex:              output.OutputID().Index(),
-		MilestoneIndexBooked:     output.MilestoneIndex(),
-		MilestoneTimestampBooked: output.MilestoneTimestamp(),
+		MilestoneIndexBooked:     output.MilestoneIndexBooked(),
+		MilestoneTimestampBooked: output.MilestoneTimestampBooked(),
 		LedgerIndex:              ledgerIndex,
 	}
 }
@@ -37,9 +37,9 @@ func rawMessageForOutput(output *utxo.Output) (*json.RawMessage, error) {
 func NewSpentMetadataResponse(spent *utxo.Spent, ledgerIndex milestone.Index) *OutputMetadataResponse {
 	metadata := NewOutputMetadataResponse(spent.Output(), ledgerIndex)
 	metadata.Spent = true
-	metadata.MilestoneIndexSpent = spent.MilestoneIndex()
-	metadata.TransactionIDSpent = spent.TargetTransactionID().ToHex()
-	metadata.MilestoneTimestampSpent = spent.MilestoneTimestamp()
+	metadata.MilestoneTimestampSpent = spent.MilestoneTimestampSpent()
+	metadata.TransactionIDSpent = spent.TransactionIDSpent().ToHex()
+	metadata.MilestoneIndexSpent = spent.MilestoneIndexSpent()
 	return metadata
 }
 

--- a/plugins/inx/server_utxo.go
+++ b/plugins/inx/server_utxo.go
@@ -3,6 +3,7 @@ package inx
 import (
 	"context"
 	"fmt"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -22,8 +23,8 @@ func NewLedgerOutput(o *utxo.Output) (*inx.LedgerOutput, error) {
 	return &inx.LedgerOutput{
 		OutputId:                 inx.NewOutputId(o.OutputID()),
 		BlockId:                  inx.NewBlockId(o.BlockID()),
-		MilestoneIndexBooked:     uint32(o.MilestoneIndex()),
-		MilestoneTimestampBooked: o.MilestoneTimestamp(),
+		MilestoneIndexBooked:     uint32(o.MilestoneIndexBooked()),
+		MilestoneTimestampBooked: o.MilestoneTimestampBooked(),
 		Output:                   output,
 	}, nil
 }
@@ -35,9 +36,9 @@ func NewLedgerSpent(s *utxo.Spent) (*inx.LedgerSpent, error) {
 	}
 	l := &inx.LedgerSpent{
 		Output:                  output,
-		TransactionIdSpent:      inx.NewTransactionId(s.TargetTransactionID()),
-		MilestoneIndexSpent:     uint32(s.MilestoneIndex()),
-		MilestoneTimestampSpent: s.MilestoneTimestamp(),
+		TransactionIdSpent:      inx.NewTransactionId(s.TransactionIDSpent()),
+		MilestoneIndexSpent:     uint32(s.MilestoneIndexSpent()),
+		MilestoneTimestampSpent: s.MilestoneTimestampSpent(),
 	}
 
 	return l, nil

--- a/plugins/restapi/api.go
+++ b/plugins/restapi/api.go
@@ -27,7 +27,7 @@ func compileRoutesAsRegexes(routes []string) []*regexp.Regexp {
 	for _, route := range routes {
 		reg := compileRouteAsRegex(route)
 		if reg == nil {
-			Plugin.LogErrorAndExit("Invalid route in config: %s", route)
+			Plugin.LogErrorfAndExit("Invalid route in config: %s", route)
 			continue
 		}
 		regexes = append(regexes, reg)
@@ -65,7 +65,7 @@ func apiMiddleware() echo.MiddlewareFunc {
 	// configure JWT auth
 	salt := ParamsRestAPI.JWTAuth.Salt
 	if len(salt) == 0 {
-		Plugin.LogErrorAndExit("'%s' should not be empty", Plugin.App.Config().GetParameterPath(&(ParamsRestAPI.JWTAuth.Salt)))
+		Plugin.LogErrorfAndExit("'%s' should not be empty", Plugin.App.Config().GetParameterPath(&(ParamsRestAPI.JWTAuth.Salt)))
 	}
 
 	// API tokens do not expire.


### PR DESCRIPTION
This PR renames the milestone indexes and timestamps of outputs and spents to align with the names in the REST API.
This also makes the code a lot more understandable.