### PR TITLE
Store protocol parameter updates for known tangle history

### DIFF
--- a/core/protocfg/core.go
+++ b/core/protocfg/core.go
@@ -10,8 +10,10 @@ import (
 	"github.com/iotaledger/hive.go/app"
 	"github.com/iotaledger/hive.go/app/core/shutdown"
 	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/serializer/v2"
 	"github.com/iotaledger/hornet/pkg/model/storage"
 	"github.com/iotaledger/hornet/pkg/model/syncmanager"
+	"github.com/iotaledger/hornet/pkg/model/utxo"
 	"github.com/iotaledger/hornet/pkg/protocol"
 	"github.com/iotaledger/hornet/pkg/tangle"
 	iotago "github.com/iotaledger/iota.go/v3"
@@ -27,6 +29,7 @@ func init() {
 			DepsFunc:       func(cDeps dependencies) { deps = cDeps },
 			Params:         params,
 			InitConfigPars: initConfigPars,
+			Provide:        provide,
 			Configure:      configure,
 		},
 	}
@@ -63,29 +66,13 @@ func initConfigPars(c *dig.Container) error {
 		dig.Out
 		KeyManager              *keymanager.KeyManager
 		MilestonePublicKeyCount int `name:"milestonePublicKeyCount"`
-		ProtocolManager         *protocol.Manager
 		BaseToken               *BaseToken
 	}
 
 	if err := c.Provide(func(deps cfgDeps) cfgResult {
 
-		protoParas := &iotago.ProtocolParameters{
-			Version:       ParamsProtocol.Parameters.Version,
-			NetworkName:   ParamsProtocol.Parameters.NetworkName,
-			Bech32HRP:     iotago.NetworkPrefix(ParamsProtocol.Parameters.Bech32HRP),
-			MinPoWScore:   ParamsProtocol.Parameters.MinPoWScore,
-			BelowMaxDepth: ParamsProtocol.Parameters.BelowMaxDepth,
-			RentStructure: iotago.RentStructure{
-				VByteCost:    ParamsProtocol.Parameters.RentStructureVByteCost,
-				VBFactorData: iotago.VByteCostFactor(ParamsProtocol.Parameters.RentStructureVByteFactorData),
-				VBFactorKey:  iotago.VByteCostFactor(ParamsProtocol.Parameters.RentStructureVByteFactorKey),
-			},
-			TokenSupply: ParamsProtocol.Parameters.TokenSupply,
-		}
-
 		res := cfgResult{
 			MilestonePublicKeyCount: ParamsProtocol.MilestonePublicKeyCount,
-			ProtocolManager:         protocol.NewManager(deps.Storage, protoParas),
 			BaseToken: &BaseToken{
 				Name:            ParamsProtocol.BaseToken.Name,
 				TickerSymbol:    ParamsProtocol.BaseToken.TickerSymbol,
@@ -118,9 +105,62 @@ func initConfigPars(c *dig.Container) error {
 	return nil
 }
 
-func configure() error {
-	deps.ProtocolManager.LoadPending(deps.SyncManager)
+func provide(c *dig.Container) error {
 
+	type protocolManagerDeps struct {
+		dig.In
+		Storage     *storage.Storage
+		UTXOManager *utxo.Manager
+	}
+
+	if err := c.Provide(func(deps protocolManagerDeps) *protocol.Manager {
+
+		protoParas := &iotago.ProtocolParameters{
+			Version:       ParamsProtocol.Parameters.Version,
+			NetworkName:   ParamsProtocol.Parameters.NetworkName,
+			Bech32HRP:     iotago.NetworkPrefix(ParamsProtocol.Parameters.Bech32HRP),
+			MinPoWScore:   ParamsProtocol.Parameters.MinPoWScore,
+			BelowMaxDepth: ParamsProtocol.Parameters.BelowMaxDepth,
+			RentStructure: iotago.RentStructure{
+				VByteCost:    ParamsProtocol.Parameters.RentStructureVByteCost,
+				VBFactorData: iotago.VByteCostFactor(ParamsProtocol.Parameters.RentStructureVByteFactorData),
+				VBFactorKey:  iotago.VByteCostFactor(ParamsProtocol.Parameters.RentStructureVByteFactorKey),
+			},
+			TokenSupply: ParamsProtocol.Parameters.TokenSupply,
+		}
+
+		protoParasBytes, err := protoParas.Serialize(serializer.DeSeriModeNoValidation, nil)
+		if err != nil {
+			CoreComponent.LogPanic(err)
+		}
+
+		// store the initial protocol parameters as milestone 0 for now
+		if err := deps.Storage.StoreProtocolParameters(&iotago.ProtocolParamsMilestoneOpt{
+			TargetMilestoneIndex: 0,
+			ProtocolVersion:      protoParas.Version,
+			Params:               protoParasBytes,
+		}); err != nil {
+			CoreComponent.LogPanic(err)
+		}
+
+		ledgerIndex, err := deps.UTXOManager.ReadLedgerIndex()
+		if err != nil {
+			CoreComponent.LogPanicf("can't initialize protocol manager: %s", err)
+		}
+
+		protocolManager, err := protocol.NewManager(deps.Storage, ledgerIndex)
+		if err != nil {
+			CoreComponent.LogPanic(err)
+		}
+		return protocolManager
+	}); err != nil {
+		CoreComponent.LogPanic(err)
+	}
+
+	return nil
+}
+
+func configure() error {
 	deps.Tangle.Events.ConfirmedMilestoneChanged.Attach(events.NewClosure(deps.ProtocolManager.HandleConfirmedMilestone))
 
 	unsuppProtoParasClosure := events.NewClosure(func(unsupportedProtocolParas *iotago.ProtocolParamsMilestoneOpt) {

--- a/pkg/dag/cone_root_indexes_test.go
+++ b/pkg/dag/cone_root_indexes_test.go
@@ -14,13 +14,14 @@ import (
 )
 
 const (
-	BelowMaxDepth = 5
-	MinPoWScore   = 10.0
+	ProtocolVersion = 2
+	BelowMaxDepth   = 5
+	MinPoWScore     = 10
 )
 
 func TestConeRootIndexes(t *testing.T) {
 
-	te := testsuite.SetupTestEnvironment(t, &iotago.Ed25519Address{}, 0, BelowMaxDepth, MinPoWScore, false)
+	te := testsuite.SetupTestEnvironment(t, &iotago.Ed25519Address{}, 0, ProtocolVersion, BelowMaxDepth, MinPoWScore, false)
 	defer te.CleanupTestEnvironment(true)
 
 	initBlocksCount := 10

--- a/pkg/model/milestonemanager/milestones_manager_test.go
+++ b/pkg/model/milestonemanager/milestones_manager_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	ProtocolVersion         = 2
 	BelowMaxDepth           = 15
 	MinPoWScore             = 1.0
 	MilestonePublicKeyCount = 2
@@ -58,7 +59,7 @@ var (
 
 func initTest(testInterface testing.TB) (*testsuite.TestEnvironment, *milestonemanager.MilestoneManager) {
 
-	te := testsuite.SetupTestEnvironment(testInterface, &iotago.Ed25519Address{}, 0, BelowMaxDepth, MinPoWScore, false)
+	te := testsuite.SetupTestEnvironment(testInterface, &iotago.Ed25519Address{}, 0, ProtocolVersion, BelowMaxDepth, MinPoWScore, false)
 
 	getKeyManager := func() *keymanager.KeyManager {
 		var coordinatorPublicKeyRanges protocfg.ConfigPublicKeyRanges

--- a/pkg/model/storage/protocol_storage.go
+++ b/pkg/model/storage/protocol_storage.go
@@ -1,42 +1,115 @@
 package storage
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/serializer/v2"
+	"github.com/iotaledger/hornet/pkg/model/milestone"
 	iotago "github.com/iotaledger/iota.go/v3"
-	"github.com/pkg/errors"
 )
 
-const (
-	protocolParasStorageKey = "protoParas"
-)
+// ProtocolParametersConsumer consumes the given protocol parameter during looping through all protocol parameters.
+type ProtocolParametersConsumer func(*iotago.ProtocolParamsMilestoneOpt) bool
 
-func (s *Storage) StoreProtocolParameters(protoPras *iotago.ProtocolParameters) error {
-	data, err := protoPras.Serialize(serializer.DeSeriModeNoValidation, nil)
+func (s *Storage) StoreProtocolParameters(protoParsMsOpt *iotago.ProtocolParamsMilestoneOpt) error {
+	data, err := protoParsMsOpt.Serialize(serializer.DeSeriModeNoValidation, nil)
 	if err != nil {
 		return errors.Wrap(NewDatabaseError(err), "failed to serialize protocol parameters")
 	}
 
-	if err := s.protocolStore.Set([]byte(protocolParasStorageKey), data); err != nil {
-		return errors.Wrap(NewDatabaseError(err), "failed to protocol parameters")
+	if err := s.protocolStore.Set(databaseKeyForMilestoneIndex(milestone.Index(protoParsMsOpt.TargetMilestoneIndex)), data); err != nil {
+		return errors.Wrap(NewDatabaseError(err), "failed to store protocol parameters")
 	}
 
 	return nil
 }
 
-func (s *Storage) ProtocolParameters() (*iotago.ProtocolParameters, error) {
-	data, err := s.protocolStore.Get([]byte(protocolParasStorageKey))
+func (s *Storage) ProtocolParameters(msIndex milestone.Index) (*iotago.ProtocolParamsMilestoneOpt, error) {
+
+	// search the smallest activation index that is smaller than or equal to the given milestone index
+	// to get the valid protocol parameters for the given milestone index.
+	var smallestIndex milestone.Index
+	if err := s.protocolStore.IterateKeys(kvstore.EmptyPrefix, func(key kvstore.Key) bool {
+		activationIndex := milestoneIndexFromDatabaseKey(key)
+
+		if activationIndex >= smallestIndex && activationIndex <= msIndex {
+			smallestIndex = activationIndex
+		}
+
+		return true
+	}); err != nil {
+		return nil, err
+	}
+
+	data, err := s.protocolStore.Get(databaseKeyForMilestoneIndex(smallestIndex))
 	if err != nil {
 		if !errors.Is(err, kvstore.ErrKeyNotFound) {
 			return nil, errors.Wrap(NewDatabaseError(err), "failed to retrieve protocol parameters")
 		}
-		return nil, nil
+		return nil, err
 	}
 
-	protoParas := &iotago.ProtocolParameters{}
-	if _, err := protoParas.Deserialize(data, serializer.DeSeriModeNoValidation, nil); err != nil {
+	protoParsMsOpt := &iotago.ProtocolParamsMilestoneOpt{}
+	if _, err := protoParsMsOpt.Deserialize(data, serializer.DeSeriModeNoValidation, nil); err != nil {
 		return nil, errors.Wrap(NewDatabaseError(err), "failed to deserialize protocol parameters")
 	}
 
-	return protoParas, nil
+	return protoParsMsOpt, nil
+}
+
+func (s *Storage) ForEachProtocolParameters(consumer ProtocolParametersConsumer) error {
+
+	var innerErr error
+	if err := s.protocolStore.Iterate(kvstore.EmptyPrefix, func(_ kvstore.Key, value kvstore.Value) bool {
+		protoParsMsOpt := &iotago.ProtocolParamsMilestoneOpt{}
+		if _, err := protoParsMsOpt.Deserialize(value, serializer.DeSeriModeNoValidation, nil); err != nil {
+			innerErr = errors.Wrap(NewDatabaseError(err), "failed to deserialize protocol parameters")
+			return false
+		}
+
+		return consumer(protoParsMsOpt)
+	}); err != nil {
+		return err
+	}
+
+	return innerErr
+}
+
+func (s *Storage) PruneProtocolParameters(pruningIndex milestone.Index) error {
+
+	// we will prune all protocol parameters that are smaller than the given pruning index,
+	// except the last one, which is still valid.
+	var biggestIndexBeforePruningIndex milestone.Index
+	if err := s.protocolStore.IterateKeys(kvstore.EmptyPrefix, func(key kvstore.Key) bool {
+		activationIndex := milestoneIndexFromDatabaseKey(key)
+
+		if activationIndex >= biggestIndexBeforePruningIndex && activationIndex <= pruningIndex {
+			biggestIndexBeforePruningIndex = activationIndex
+		}
+
+		return true
+	}); err != nil {
+		return err
+	}
+
+	var innerErr error
+
+	// we loop again to delete all protocol parameters that are smaller than the found index.
+	if err := s.protocolStore.IterateKeys(kvstore.EmptyPrefix, func(key kvstore.Key) bool {
+		activationIndex := milestoneIndexFromDatabaseKey(key)
+
+		if activationIndex < biggestIndexBeforePruningIndex {
+			if err := s.protocolStore.Delete(key); err != nil {
+				innerErr = err
+				return false
+			}
+		}
+
+		return true
+	}); err != nil {
+		return err
+	}
+
+	return innerErr
 }

--- a/pkg/protocol/protocol_manager.go
+++ b/pkg/protocol/protocol_manager.go
@@ -8,49 +8,8 @@ import (
 	"github.com/iotaledger/hive.go/serializer/v2"
 	"github.com/iotaledger/hornet/pkg/model/milestone"
 	"github.com/iotaledger/hornet/pkg/model/storage"
-	"github.com/iotaledger/hornet/pkg/model/syncmanager"
 	iotago "github.com/iotaledger/iota.go/v3"
 )
-
-var (
-	supportedVersions = Versions{2} // make sure to add the versions sorted asc
-)
-
-// Versions is a slice of protocol versions.
-type Versions []uint32
-
-// Highest returns the highest version.
-func (ver Versions) Highest() byte {
-	return byte(ver[len(ver)-1])
-}
-
-// Lowest returns the lowest version.
-func (ver Versions) Lowest() byte {
-	return byte(ver[0])
-}
-
-// Supports tells whether the given version is supported.
-func (ver Versions) Supports(v byte) bool {
-	for _, value := range ver {
-		if value == uint32(v) {
-			return true
-		}
-	}
-	return false
-}
-
-// NewManager creates a new Manager.
-func NewManager(storage *storage.Storage, initProtoParas *iotago.ProtocolParameters) *Manager {
-	return &Manager{
-		Events: &Events{
-			NextMilestoneUnsupported: events.NewEvent(protoParasMsOptCaller),
-			CriticalErrors:           events.NewEvent(events.ErrorCaller),
-		},
-		storage: storage,
-		current: initProtoParas,
-		pending: nil,
-	}
-}
 
 func protoParasMsOptCaller(handler interface{}, params ...interface{}) {
 	handler.(func(protoParas *iotago.ProtocolParamsMilestoneOpt))(params[0].(*iotago.ProtocolParamsMilestoneOpt))
@@ -64,60 +23,68 @@ type Events struct {
 	CriticalErrors *events.Event
 }
 
+// NewManager creates a new Manager.
+func NewManager(storage *storage.Storage, ledgerIndex milestone.Index) (*Manager, error) {
+	manager := &Manager{
+		Events: &Events{
+			NextMilestoneUnsupported: events.NewEvent(protoParasMsOptCaller),
+			CriticalErrors:           events.NewEvent(events.ErrorCaller),
+		},
+		storage: storage,
+		current: nil,
+		pending: nil,
+	}
+
+	if err := manager.init(ledgerIndex); err != nil {
+		return nil, err
+	}
+
+	return manager, nil
+}
+
 // Manager handles the knowledge about current, pending and supported protocol versions and parameters.
 type Manager struct {
 	// Events holds the events happening within the Manager.
 	Events      *Events
 	storage     *storage.Storage
-	syncManager *syncmanager.SyncManager
-	currentRWMu sync.RWMutex
+	currentLock sync.RWMutex
 	current     *iotago.ProtocolParameters
-	pendingRWMu sync.RWMutex
+	pendingLock sync.RWMutex
 	pending     []*iotago.ProtocolParamsMilestoneOpt
 }
 
-// Init initialises the Manager by loading the last stored or persisting the parameters passed in via constructor.
-// If the Manager got initialised with no storage, then Manager.Init() is a no-op and initProtoParas are used instead.
-func (m *Manager) Init() error {
-	// can only run with provided protocol parameters
-	if m.storage == nil {
-		return nil
-	}
+// init initialises the Manager by loading the last stored parameters and pending parameters.
+func (m *Manager) init(ledgerIndex milestone.Index) error {
+	m.currentLock.Lock()
+	defer m.currentLock.Unlock()
 
-	m.currentRWMu.Lock()
-	defer m.currentRWMu.Unlock()
-
-	currentProtoParas, err := m.storage.ProtocolParameters()
+	currentProtoParas, err := m.storage.ProtocolParameters(ledgerIndex)
 	if err != nil {
 		return err
 	}
 
-	// aka store therefore what the manager was initialised with
-	if currentProtoParas == nil {
-		if err := m.storage.StoreProtocolParameters(m.current); err != nil {
-			return fmt.Errorf("unable to persist init protocol parameters: %w", err)
-		}
-		return nil
+	protoParas := &iotago.ProtocolParameters{}
+	if _, err := protoParas.Deserialize(currentProtoParas.Params, serializer.DeSeriModeNoValidation, nil); err != nil {
+		return fmt.Errorf("failed to deserialize protocol parameters: %w", err)
 	}
 
-	m.current = currentProtoParas
+	m.current = protoParas
+	m.loadPending(ledgerIndex)
 
 	return nil
 }
 
-// LoadPending examines the database back to below max depth for pending protocol parameter changes.
-func (m *Manager) LoadPending(syncManager *syncmanager.SyncManager) {
-	m.pendingRWMu.Lock()
-	defer m.pendingRWMu.Unlock()
+// loadPending initializes the pending protocol parameter changes from database.
+func (m *Manager) loadPending(ledgerIndex milestone.Index) {
+	m.pendingLock.Lock()
+	defer m.pendingLock.Unlock()
 
-	// examine below max depth milestone to reconstruct pending protocol changes
-	confMsIndex := syncManager.ConfirmedMilestoneIndex()
-	belowMaxDepthTarget := confMsIndex - milestone.Index(m.current.BelowMaxDepth)
-	for i := belowMaxDepthTarget; i < confMsIndex; i-- {
-		if protoParasMsOpt := m.readProtocolParasFromMilestone(i); protoParasMsOpt != nil {
-			m.pending = append(m.pending, protoParasMsOpt)
+	m.storage.ForEachProtocolParameters(func(protoParsMsOpt *iotago.ProtocolParamsMilestoneOpt) bool {
+		if milestone.Index(protoParsMsOpt.TargetMilestoneIndex) > ledgerIndex {
+			m.pending = append(m.pending, protoParsMsOpt)
 		}
-	}
+		return true
+	})
 }
 
 func (m *Manager) readProtocolParasFromMilestone(index milestone.Index) *iotago.ProtocolParamsMilestoneOpt {
@@ -131,20 +98,20 @@ func (m *Manager) readProtocolParasFromMilestone(index milestone.Index) *iotago.
 
 // SupportedVersions returns a slice of supported protocol versions.
 func (m *Manager) SupportedVersions() Versions {
-	return supportedVersions
+	return SupportedVersions
 }
 
 // Current returns the current protocol parameters under which the node is operating.
 func (m *Manager) Current() *iotago.ProtocolParameters {
-	m.currentRWMu.RLock()
-	defer m.currentRWMu.RUnlock()
+	m.currentLock.RLock()
+	defer m.currentLock.RUnlock()
 	return m.current
 }
 
 // Pending returns the currently pending protocol changes.
 func (m *Manager) Pending() []*iotago.ProtocolParamsMilestoneOpt {
-	m.pendingRWMu.RLock()
-	defer m.pendingRWMu.RUnlock()
+	m.pendingLock.RLock()
+	defer m.pendingLock.RUnlock()
 	cpy := make([]*iotago.ProtocolParamsMilestoneOpt, len(m.pending))
 	for i, ele := range m.pending {
 		cpy[i] = ele.Clone().(*iotago.ProtocolParamsMilestoneOpt)
@@ -154,8 +121,8 @@ func (m *Manager) Pending() []*iotago.ProtocolParamsMilestoneOpt {
 
 // NextPendingSupported tells whether the next pending protocol parameters changes are supported.
 func (m *Manager) NextPendingSupported() bool {
-	m.pendingRWMu.RLock()
-	defer m.pendingRWMu.RUnlock()
+	m.pendingLock.RLock()
+	defer m.pendingLock.RUnlock()
 	if len(m.pending) == 0 {
 		return true
 	}
@@ -168,9 +135,14 @@ func (m *Manager) HandleConfirmedMilestone(cachedMilestone *storage.CachedMilest
 	ms := cachedMilestone.Milestone()
 
 	if msProtoParas := ms.Milestone().Opts.MustSet().ProtocolParams(); msProtoParas != nil {
-		m.pendingRWMu.Lock()
+		m.pendingLock.Lock()
 		m.pending = append(m.pending, msProtoParas)
-		m.pendingRWMu.Unlock()
+		m.pendingLock.Unlock()
+
+		if err := m.storage.StoreProtocolParameters(msProtoParas); err != nil {
+			m.Events.CriticalErrors.Trigger(fmt.Errorf("unable to persist new protocol parameters: %w", err))
+			return
+		}
 	}
 
 	if !m.currentShouldChange(ms) {
@@ -185,8 +157,8 @@ func (m *Manager) HandleConfirmedMilestone(cachedMilestone *storage.CachedMilest
 
 // checks whether the current protocol parameters need to be updated.
 func (m *Manager) currentShouldChange(milestone *storage.Milestone) bool {
-	m.pendingRWMu.RLock()
-	defer m.pendingRWMu.RUnlock()
+	m.pendingLock.RLock()
+	defer m.pendingLock.RUnlock()
 	if len(m.pending) == 0 {
 		return false
 	}
@@ -207,10 +179,10 @@ func (m *Manager) currentShouldChange(milestone *storage.Milestone) bool {
 }
 
 func (m *Manager) updateCurrent() error {
-	m.currentRWMu.Lock()
-	defer m.currentRWMu.Unlock()
-	m.pendingRWMu.Lock()
-	defer m.pendingRWMu.Unlock()
+	m.currentLock.Lock()
+	defer m.currentLock.Unlock()
+	m.pendingLock.Lock()
+	defer m.pendingLock.Unlock()
 
 	nextMsProtoParamOpt := m.pending[0]
 	nextParams := nextMsProtoParamOpt.Params
@@ -223,10 +195,6 @@ func (m *Manager) updateCurrent() error {
 
 	m.current = nextProtoParams
 	m.pending = m.pending[1:]
-
-	if err := m.storage.StoreProtocolParameters(m.current); err != nil {
-		return fmt.Errorf("unable to persist new protocol parameters: %w", err)
-	}
 
 	return nil
 }

--- a/pkg/protocol/version.go
+++ b/pkg/protocol/version.go
@@ -1,0 +1,28 @@
+package protocol
+
+var (
+	SupportedVersions = Versions{2} // make sure to add the versions sorted asc
+)
+
+// Versions is a slice of protocol versions.
+type Versions []uint32
+
+// Highest returns the highest version.
+func (v Versions) Highest() byte {
+	return byte(v[len(v)-1])
+}
+
+// Lowest returns the lowest version.
+func (v Versions) Lowest() byte {
+	return byte(v[0])
+}
+
+// Supports tells whether the given version is supported.
+func (v Versions) Supports(ver byte) bool {
+	for _, value := range v {
+		if value == uint32(ver) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/pruning/pruning.go
+++ b/pkg/pruning/pruning.go
@@ -430,6 +430,10 @@ func (p *Manager) pruneDatabase(ctx context.Context, targetIndex milestone.Index
 	}
 	p.storage.WriteUnlockSolidEntryPoints()
 
+	if err := p.storage.PruneProtocolParameters(targetIndex); err != nil {
+		return 0, err
+	}
+
 	return targetIndex, nil
 }
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -58,7 +58,7 @@ type Manager struct {
 	storage                              *storage.Storage
 	syncManager                          *syncmanager.SyncManager
 	utxoManager                          *utxo.Manager
-	protoMng                             *protocol.Manager
+	protocolManager                      *protocol.Manager
 	snapshotFullPath                     string
 	snapshotDeltaPath                    string
 	deltaSnapshotSizeThresholdPercentage float64
@@ -80,7 +80,7 @@ func NewSnapshotManager(
 	storage *storage.Storage,
 	syncManager *syncmanager.SyncManager,
 	utxoManager *utxo.Manager,
-	protoMng *protocol.Manager,
+	protocolManager *protocol.Manager,
 	snapshotFullPath string,
 	snapshotDeltaPath string,
 	deltaSnapshotSizeThresholdPercentage float64,
@@ -96,7 +96,7 @@ func NewSnapshotManager(
 		storage:                              storage,
 		syncManager:                          syncManager,
 		utxoManager:                          utxoManager,
-		protoMng:                             protoMng,
+		protocolManager:                      protocolManager,
 		snapshotFullPath:                     snapshotFullPath,
 		snapshotDeltaPath:                    snapshotDeltaPath,
 		deltaSnapshotSizeThresholdPercentage: deltaSnapshotSizeThresholdPercentage,

--- a/pkg/snapshot/snapshot_write.go
+++ b/pkg/snapshot/snapshot_write.go
@@ -460,7 +460,7 @@ func (s *Manager) createSnapshotWithoutLocking(
 		default:
 			// as the needed milestone diffs are pruned from the database, we need to use
 			// the previous delta snapshot file to extract those in conjunction with what the database has available
-			milestoneDiffProducer, err = newMsDiffsProducerDeltaFileAndDatabase(s.snapshotDeltaPath, s.storage, s.utxoManager, header.LedgerMilestoneIndex, targetIndex, s.protoMng.Current())
+			milestoneDiffProducer, err = newMsDiffsProducerDeltaFileAndDatabase(s.snapshotDeltaPath, s.storage, s.utxoManager, header.LedgerMilestoneIndex, targetIndex, s.protocolManager.Current())
 			if err != nil {
 				return err
 			}

--- a/pkg/tangle/attacher.go
+++ b/pkg/tangle/attacher.go
@@ -115,7 +115,7 @@ func (a *BlockAttacher) AttachBlock(ctx context.Context, iotaBlock *iotago.Block
 				return iotago.EmptyBlockID(), errors.WithMessagef(ErrBlockAttacherInvalidBlock, err.Error())
 			}
 
-			if score < float64(a.tangle.protoMng.Current().MinPoWScore) {
+			if score < float64(a.tangle.protocolManager.Current().MinPoWScore) {
 				if a.opts.powHandler == nil {
 					return iotago.EmptyBlockID(), ErrBlockAttacherPoWNotAvailable
 				}
@@ -140,7 +140,7 @@ func (a *BlockAttacher) AttachBlock(ctx context.Context, iotaBlock *iotago.Block
 		}
 	}
 
-	block, err := storage.NewBlock(iotaBlock, serializer.DeSeriModePerformValidation, a.tangle.protoMng.Current())
+	block, err := storage.NewBlock(iotaBlock, serializer.DeSeriModePerformValidation, a.tangle.protocolManager.Current())
 	if err != nil {
 		return iotago.EmptyBlockID(), errors.WithMessagef(ErrBlockAttacherInvalidBlock, err.Error())
 	}

--- a/pkg/tangle/health.go
+++ b/pkg/tangle/health.go
@@ -26,7 +26,7 @@ func (t *Tangle) IsNodeHealthy() bool {
 		return false
 	}
 
-	if !t.protoMng.NextPendingSupported() {
+	if !t.protocolManager.NextPendingSupported() {
 		return false
 	}
 

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -337,7 +337,7 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 		t.storage.UTXOManager(),
 		memcachedTraverserStorage,
 		blocksMemcache.CachedBlock,
-		t.protoMng.Current(),
+		t.protocolManager.Current(),
 		milestonePayloadToSolidify,
 		whiteflag.DefaultWhiteFlagTraversalCondition,
 		whiteflag.DefaultCheckBlockReferencedFunc,

--- a/pkg/tangle/tangle.go
+++ b/pkg/tangle/tangle.go
@@ -49,7 +49,7 @@ type Tangle struct {
 	// used to persist and validate batches of receipts.
 	receiptService *migrator.ReceiptService
 	// the protocol manager
-	protoMng *protocol.Manager
+	protocolManager *protocol.Manager
 
 	milestoneTimeout             time.Duration
 	whiteFlagParentsSolidTimeout time.Duration
@@ -121,7 +121,7 @@ func New(
 	serverMetrics *metrics.ServerMetrics,
 	requester *gossip.Requester,
 	receiptService *migrator.ReceiptService,
-	protoMng *protocol.Manager,
+	protocolManager *protocol.Manager,
 	milestoneTimeout time.Duration,
 	whiteFlagParentsSolidTimeout time.Duration,
 	updateSyncedAtStartup bool) *Tangle {
@@ -139,7 +139,7 @@ func New(
 		serverMetrics:                serverMetrics,
 		requester:                    requester,
 		receiptService:               receiptService,
-		protoMng:                     protoMng,
+		protocolManager:              protocolManager,
 		milestoneTimeout:             milestoneTimeout,
 		whiteFlagParentsSolidTimeout: whiteFlagParentsSolidTimeout,
 		updateSyncedAtStartup:        updateSyncedAtStartup,

--- a/pkg/tipselect/test/urts_test.go
+++ b/pkg/tipselect/test/urts_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	ProtocolVersion                         = 2
 	MaxDeltaBlockYoungestConeRootIndexToCMI = 8
 	MaxDeltaBlockOldestConeRootIndexToCMI   = 13
 	BelowMaxDepth                           = 15
@@ -33,7 +34,7 @@ const (
 
 func TestTipSelect(t *testing.T) {
 
-	te := testsuite.SetupTestEnvironment(t, &iotago.Ed25519Address{}, 0, BelowMaxDepth, MinPoWScore, false)
+	te := testsuite.SetupTestEnvironment(t, &iotago.Ed25519Address{}, 0, ProtocolVersion, BelowMaxDepth, MinPoWScore, false)
 	defer te.CleanupTestEnvironment(true)
 
 	serverMetrics := metrics.ServerMetrics{}

--- a/pkg/whiteflag/test/white_flag_test.go
+++ b/pkg/whiteflag/test/white_flag_test.go
@@ -13,15 +13,18 @@ import (
 	iotago "github.com/iotaledger/iota.go/v3"
 )
 
+const (
+	ShowConfirmationGraphs = false
+	ProtocolVersion        = 2
+	MinPoWScore            = 1
+	BelowMaxDepth          = 15
+)
+
 var (
 	seed1, _ = hex.DecodeString("96d9ff7a79e4b0a5f3e5848ae7867064402da92a62eabb4ebbe463f12d1f3b1aace1775488f51cb1e3a80732a03ef60b111d6833ab605aa9f8faebeb33bbe3d9")
 	seed2, _ = hex.DecodeString("b15209ddc93cbdb600137ea6a8f88cdd7c5d480d5815c9352a0fb5c4e4b86f7151dcb44c2ba635657a2df5a8fd48cb9bab674a9eceea527dbbb254ef8c9f9cd7")
 	seed3, _ = hex.DecodeString("d5353ceeed380ab89a0f6abe4630c2091acc82617c0edd4ff10bd60bba89e2ed30805ef095b989c2bf208a474f8748d11d954aade374380422d4d812b6f1da90")
 	seed4, _ = hex.DecodeString("bd6fe09d8a309ca309c5db7b63513240490109cd0ac6b123551e9da0d5c8916c4a5a4f817e4b4e9df89885ce1af0986da9f1e56b65153c2af1e87ab3b11dabb4")
-
-	showConfirmationGraphs        = false
-	MinPoWScore            uint32 = 1
-	BelowMaxDepth          uint8  = 15
 )
 
 func TestWhiteFlagSendAllCoins(t *testing.T) {
@@ -31,8 +34,8 @@ func TestWhiteFlagSendAllCoins(t *testing.T) {
 
 	genesisAddress := seed1Wallet.Address()
 
-	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, BelowMaxDepth, MinPoWScore, showConfirmationGraphs)
-	defer te.CleanupTestEnvironment(!showConfirmationGraphs)
+	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, ProtocolVersion, BelowMaxDepth, MinPoWScore, ShowConfirmationGraphs)
+	defer te.CleanupTestEnvironment(!ShowConfirmationGraphs)
 
 	//Add token supply to our local HDWallet
 	seed1Wallet.BookOutput(te.GenesisOutput)
@@ -94,8 +97,8 @@ func TestWhiteFlagWithMultipleConflicting(t *testing.T) {
 
 	genesisAddress := seed1Wallet.Address()
 
-	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, BelowMaxDepth, MinPoWScore, showConfirmationGraphs)
-	defer te.CleanupTestEnvironment(!showConfirmationGraphs)
+	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, ProtocolVersion, BelowMaxDepth, MinPoWScore, ShowConfirmationGraphs)
+	defer te.CleanupTestEnvironment(!ShowConfirmationGraphs)
 
 	//Add token supply to our local HDWallet
 	seed1Wallet.BookOutput(te.GenesisOutput)
@@ -259,8 +262,8 @@ func TestWhiteFlagWithOnlyZeroTx(t *testing.T) {
 	genesisWallet := utils.NewHDWallet("Seed1", seed1, 0)
 	genesisAddress := genesisWallet.Address()
 
-	te := testsuite.SetupTestEnvironment(t, genesisAddress, 3, BelowMaxDepth, MinPoWScore, showConfirmationGraphs)
-	defer te.CleanupTestEnvironment(!showConfirmationGraphs)
+	te := testsuite.SetupTestEnvironment(t, genesisAddress, 3, ProtocolVersion, BelowMaxDepth, MinPoWScore, ShowConfirmationGraphs)
+	defer te.CleanupTestEnvironment(!ShowConfirmationGraphs)
 
 	//Add token supply to our local HDWallet
 	genesisWallet.BookOutput(te.GenesisOutput)
@@ -298,8 +301,8 @@ func TestWhiteFlagLastMilestoneNotInPastCone(t *testing.T) {
 
 	genesisAddress := seed1Wallet.Address()
 
-	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, BelowMaxDepth, MinPoWScore, showConfirmationGraphs)
-	defer te.CleanupTestEnvironment(!showConfirmationGraphs)
+	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, ProtocolVersion, BelowMaxDepth, MinPoWScore, ShowConfirmationGraphs)
+	defer te.CleanupTestEnvironment(!ShowConfirmationGraphs)
 
 	//Add token supply to our local HDWallet
 	seed1Wallet.BookOutput(te.GenesisOutput)
@@ -352,8 +355,8 @@ func TestWhiteFlagConfirmWithReattachedMilestone(t *testing.T) {
 
 	genesisAddress := seed1Wallet.Address()
 
-	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, BelowMaxDepth, MinPoWScore, showConfirmationGraphs)
-	defer te.CleanupTestEnvironment(!showConfirmationGraphs)
+	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, ProtocolVersion, BelowMaxDepth, MinPoWScore, ShowConfirmationGraphs)
+	defer te.CleanupTestEnvironment(!ShowConfirmationGraphs)
 
 	//Add token supply to our local HDWallet
 	seed1Wallet.BookOutput(te.GenesisOutput)
@@ -454,8 +457,8 @@ func TestWhiteFlagAliasOutput(t *testing.T) {
 
 	genesisAddress := seed1Wallet.Address()
 
-	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, BelowMaxDepth, MinPoWScore, showConfirmationGraphs)
-	defer te.CleanupTestEnvironment(!showConfirmationGraphs)
+	te := testsuite.SetupTestEnvironment(t, genesisAddress, 2, ProtocolVersion, BelowMaxDepth, MinPoWScore, ShowConfirmationGraphs)
+	defer te.CleanupTestEnvironment(!ShowConfirmationGraphs)
 
 	//Add token supply to our local HDWallet
 	seed1Wallet.BookOutput(te.GenesisOutput)

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -5,10 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/iotaledger/hornet/core/protocfg"
-	"github.com/iotaledger/hornet/core/pruning"
-	"github.com/iotaledger/hornet/pkg/protocol"
-
 	"github.com/libp2p/go-libp2p-core/crypto"
 	libp2p "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
@@ -23,6 +19,8 @@ import (
 	databaseCore "github.com/iotaledger/hornet/core/database"
 	"github.com/iotaledger/hornet/core/gossip"
 	"github.com/iotaledger/hornet/core/pow"
+	"github.com/iotaledger/hornet/core/protocfg"
+	"github.com/iotaledger/hornet/core/pruning"
 	"github.com/iotaledger/hornet/core/snapshot"
 	"github.com/iotaledger/hornet/core/tangle"
 	"github.com/iotaledger/hornet/pkg/daemon"
@@ -157,7 +155,7 @@ func provide(c *dig.Container) error {
 
 	type autopeeringDeps struct {
 		dig.In
-		ProtocolManager *protocol.Manager
+		TargetNetworkName string `name:"targetNetworkName"`
 	}
 
 	if err := c.Provide(func(deps autopeeringDeps) *autopeering.AutopeeringManager {
@@ -166,7 +164,7 @@ func provide(c *dig.Container) error {
 			ParamsAutopeering.BindAddress,
 			ParamsAutopeering.EntryNodes,
 			ParamsAutopeering.EntryNodesPreferIPv6,
-			service.Key(deps.ProtocolManager.Current().NetworkName),
+			service.Key(deps.TargetNetworkName),
 		)
 	}); err != nil {
 		Plugin.LogPanic(err)


### PR DESCRIPTION
This PR changes the logic of the protocol manager.

We now do store all protocol parameter changes in the database instead of only storing the latest active protocol parameter set.
This is necessary to have the correct protocol parameters for every milestone of the tangle.
For example in the event of pruning, we need to recalculate the solid entry points with the active "below max depth" for that milestone.

The changes are not stored with every milestone, but with every change to reduce disc space.
Old parameter changes are pruned.