### PR TITLE
Block static peers in autopeering module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0-alpha.24] - 12.07.2022
+
+### Added
+    - Added Foundry, NativeTokens and NFT whiteflag tests (#1607)
+
+### Fixed
+    - Do not check storage deposits of full snapshot outputs (#1610)
+    - Avoid locking of the p2p Manager while connection attempts are performed (#1614)
+
+### Changed
+    - Renamed `config.json` to `config_alphanet.json` and added `config_defaults.json` (#1613)
+    - Renamed `-docker-example.tar.gz` release to `-docker.tar.gz` (#1615)
+    - Block static peers in autopeering module (#1608)
+
+### Chore
+    -  Update modules (#1606)
+
 ## [2.0.0-alpha.23] - 07.07.2022
 
 :warning: :warning: :warning: 

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -34,7 +34,7 @@ var (
 	Name = "HORNET"
 
 	// Version of the app.
-	Version = "2.0.0-alpha.23"
+	Version = "2.0.0-alpha.24"
 )
 
 func App() *app.App {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   hornet:
-    image: iotaledger/hornet:2.0.0-alpha.23
+    image: iotaledger/hornet:2.0.0-alpha.24
     ulimits:
       nofile:
         soft: 16384

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/iotaledger/go-ds-kvstore v0.0.0-20220404122649-445475b91fcf
-	github.com/iotaledger/hive.go v0.0.0-20220707144500-ae0ecb7af9bf
-	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220707144500-ae0ecb7af9bf
+	github.com/iotaledger/hive.go v0.0.0-20220711140510-725cf6cf0175
+	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220711140510-725cf6cf0175
 	github.com/iotaledger/inx/go v0.0.0-20220705124918-775bb201b49e
 	github.com/iotaledger/iota.go v1.0.0
 	github.com/iotaledger/iota.go/v3 v3.0.0-20220711112230-6619890cabe5

--- a/go.sum
+++ b/go.sum
@@ -413,10 +413,10 @@ github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/C
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/iotaledger/go-ds-kvstore v0.0.0-20220404122649-445475b91fcf h1:3LoDur2QvBLbyXrGubX6HmoP6x5pVn1KkheFonTa6Is=
 github.com/iotaledger/go-ds-kvstore v0.0.0-20220404122649-445475b91fcf/go.mod h1:KMsgDNZKM3kkaIAoIk/FZ6A1vfVPix91lx2dm3dA6g8=
-github.com/iotaledger/hive.go v0.0.0-20220707144500-ae0ecb7af9bf h1:OsPjzgYjLMmL4nrOsDcxCaz6TbxLHxEAE68yDyLK42Q=
-github.com/iotaledger/hive.go v0.0.0-20220707144500-ae0ecb7af9bf/go.mod h1:qY0Eg2w/r+Ot0KrocMQHrtHzrcYKxDAEf33c6nSd8mI=
-github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220707144500-ae0ecb7af9bf h1:O21flM4Kwj9zWgK/vpfgB6QYQLPN8jg39qXbAxIhjzE=
-github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220707144500-ae0ecb7af9bf/go.mod h1:7fVUqbLY+iBjCNjFwzbhOyS07OZJFIYJEDNJAItzMw8=
+github.com/iotaledger/hive.go v0.0.0-20220711140510-725cf6cf0175 h1:rzn7xqO2YlOlgYD0bSsA0lRacP5eu4W2pSDjaNw33mE=
+github.com/iotaledger/hive.go v0.0.0-20220711140510-725cf6cf0175/go.mod h1:qY0Eg2w/r+Ot0KrocMQHrtHzrcYKxDAEf33c6nSd8mI=
+github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220711140510-725cf6cf0175 h1:nTjXTmJG60E9to2/2jYbdJmPJZs9082PbLMMiVDmX+s=
+github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220711140510-725cf6cf0175/go.mod h1:7fVUqbLY+iBjCNjFwzbhOyS07OZJFIYJEDNJAItzMw8=
 github.com/iotaledger/inx/go v0.0.0-20220705124918-775bb201b49e h1:C8UvhK3nGrQoSwsngHBM6aRChiShbn3eWwxcmUQZg9w=
 github.com/iotaledger/inx/go v0.0.0-20220705124918-775bb201b49e/go.mod h1:oMnK53vBku3E0WbLgfrFdLZMAJJ4iT0CeRxd1xZJD4w=
 github.com/iotaledger/iota.go v1.0.0 h1:tqm1FxJ/zOdzbrAaQ5BQpVF8dUy2eeGlSeWlNG8GoXY=

--- a/pkg/p2p/autopeering/autopeering.go
+++ b/pkg/p2p/autopeering/autopeering.go
@@ -385,7 +385,13 @@ func (a *AutopeeringManager) Init(localPeerContainer *LocalPeerContainer, initSe
 		return true
 	}
 
-	a.selectionProtocol = selection.New(localPeerContainer.Local(), a.discoveryProtocol, selection.Logger(a.LoggerNamed("sel")), selection.NeighborValidator(selection.ValidatorFunc(isValidPeer)))
+	a.selectionProtocol = selection.New(
+		localPeerContainer.Local(),
+		a.discoveryProtocol,
+		selection.Logger(a.LoggerNamed("sel")),
+		selection.NeighborValidator(selection.ValidatorFunc(isValidPeer)),
+		selection.NeighborBlockDuration(0), // disable neighbor block duration (we manually block neighbors)
+	)
 }
 
 func (a *AutopeeringManager) Run(ctx context.Context) {

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -272,9 +272,7 @@ func configureEvents() {
 		// we block peers that are connected via manual peering in the autopeering module.
 		// this ensures that no additional connections are established via autopeering.
 		switch p.Relation {
-		case p2p.PeerRelationKnown:
-			deps.AutopeeringManager.Selection().BlockNeighbor(id.ID())
-		case p2p.PeerRelationUnknown:
+		case p2p.PeerRelationKnown, p2p.PeerRelationUnknown:
 			deps.AutopeeringManager.Selection().BlockNeighbor(id.ID())
 		}
 	})
@@ -298,7 +296,7 @@ func configureEvents() {
 			return
 		}
 
-		Plugin.LogInfof("removing: %s", peerOptErr.Peer.ID.ShortString())
+		Plugin.LogDebugf("removing: %s", peerOptErr.Peer.ID.ShortString())
 		deps.AutopeeringManager.Selection().RemoveNeighbor(id.ID())
 	})
 
@@ -317,9 +315,7 @@ func configureEvents() {
 		// this ensures that no additional connections are established via autopeering.
 		// if a peer gets updated to autopeered, we need to unblock it.
 		switch p.Relation {
-		case p2p.PeerRelationKnown:
-			deps.AutopeeringManager.Selection().BlockNeighbor(id.ID())
-		case p2p.PeerRelationUnknown:
+		case p2p.PeerRelationKnown, p2p.PeerRelationUnknown:
 			deps.AutopeeringManager.Selection().BlockNeighbor(id.ID())
 		case p2p.PeerRelationAutopeered:
 			deps.AutopeeringManager.Selection().UnblockNeighbor(id.ID())

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/network"
 	libp2p "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 	"go.uber.org/dig"
@@ -64,8 +65,9 @@ var (
 	onSelectionOutgoingPeering *events.Closure
 	onSelectionIncomingPeering *events.Closure
 	onSelectionDropped         *events.Closure
+	onPeerConnected            *events.Closure
 	onPeerDisconnected         *events.Closure
-	onAutopeerBecameKnown      *events.Closure
+	onPeeringRelationUpdated   *events.Closure
 )
 
 type dependencies struct {
@@ -256,29 +258,79 @@ func configureEvents() {
 		Plugin.LogInfof("removed offline: %s / %s", ev.Peer.Address(), peerID.ShortString())
 	})
 
+	onPeerConnected = events.NewClosure(func(p *p2p.Peer, conn network.Conn) {
+
+		if deps.AutopeeringManager.Selection() == nil {
+			return
+		}
+
+		id := autopeering.ConvertPeerIDToHiveIdentityOrLog(p, Plugin.LogWarnf)
+		if id == nil {
+			return
+		}
+
+		// we block peers that are connected via manual peering in the autopeering module.
+		// this ensures that no additional connections are established via autopeering.
+		switch p.Relation {
+		case p2p.PeerRelationKnown:
+			deps.AutopeeringManager.Selection().BlockNeighbor(id.ID())
+		case p2p.PeerRelationUnknown:
+			deps.AutopeeringManager.Selection().BlockNeighbor(id.ID())
+		}
+	})
+
 	onPeerDisconnected = events.NewClosure(func(peerOptErr *p2p.PeerOptError) {
+
+		if deps.AutopeeringManager.Selection() == nil {
+			return
+		}
+
+		id := autopeering.ConvertPeerIDToHiveIdentityOrLog(peerOptErr.Peer, Plugin.LogWarnf)
+		if id == nil {
+			return
+		}
+
+		// if a peer is disconnected, we need to remove it from the autopeering blacklist
+		// so that former known and unknown peers can be autopeered.
+		deps.AutopeeringManager.Selection().UnblockNeighbor(id.ID())
+
 		if peerOptErr.Peer.Relation != p2p.PeerRelationAutopeered {
 			return
 		}
 
-		if deps.AutopeeringManager.Selection() != nil {
-			if id := autopeering.ConvertPeerIDToHiveIdentityOrLog(peerOptErr.Peer, Plugin.LogWarnf); id != nil {
-				Plugin.LogInfof("removing: %s", peerOptErr.Peer.ID.ShortString())
-				deps.AutopeeringManager.Selection().RemoveNeighbor(id.ID())
-			}
-		}
+		Plugin.LogInfof("removing: %s", peerOptErr.Peer.ID.ShortString())
+		deps.AutopeeringManager.Selection().RemoveNeighbor(id.ID())
 	})
 
-	onAutopeerBecameKnown = events.NewClosure(func(p *p2p.Peer, oldRel p2p.PeerRelation) {
+	onPeeringRelationUpdated = events.NewClosure(func(p *p2p.Peer, oldRel p2p.PeerRelation) {
+
+		if deps.AutopeeringManager.Selection() == nil {
+			return
+		}
+
+		id := autopeering.ConvertPeerIDToHiveIdentityOrLog(p, Plugin.LogWarnf)
+		if id == nil {
+			return
+		}
+
+		// we block peers that are connected via manual peering in the autopeering module.
+		// this ensures that no additional connections are established via autopeering.
+		// if a peer gets updated to autopeered, we need to unblock it.
+		switch p.Relation {
+		case p2p.PeerRelationKnown:
+			deps.AutopeeringManager.Selection().BlockNeighbor(id.ID())
+		case p2p.PeerRelationUnknown:
+			deps.AutopeeringManager.Selection().BlockNeighbor(id.ID())
+		case p2p.PeerRelationAutopeered:
+			deps.AutopeeringManager.Selection().UnblockNeighbor(id.ID())
+		}
+
 		if oldRel != p2p.PeerRelationAutopeered {
 			return
 		}
-		if deps.AutopeeringManager.Selection() != nil {
-			if id := autopeering.ConvertPeerIDToHiveIdentityOrLog(p, Plugin.LogWarnf); id != nil {
-				Plugin.LogInfof("removing %s from autopeering selection protocol", p.ID.ShortString())
-				deps.AutopeeringManager.Selection().RemoveNeighbor(id.ID())
-			}
-		}
+
+		Plugin.LogInfof("removing %s from autopeering selection protocol", p.ID.ShortString())
+		deps.AutopeeringManager.Selection().RemoveNeighbor(id.ID())
 	})
 
 	onSelectionSaltUpdated = events.NewClosure(func(ev *selection.SaltUpdatedEvent) {
@@ -412,8 +464,9 @@ func attachEvents() {
 
 	if deps.AutopeeringManager.Selection() != nil {
 		// notify the selection when a connection is closed or failed.
+		deps.PeeringManager.Events.Connected.Attach(onPeerConnected)
 		deps.PeeringManager.Events.Disconnected.Attach(onPeerDisconnected)
-		deps.PeeringManager.Events.RelationUpdated.Attach(onAutopeerBecameKnown)
+		deps.PeeringManager.Events.RelationUpdated.Attach(onPeeringRelationUpdated)
 		deps.AutopeeringManager.Selection().Events().SaltUpdated.Attach(onSelectionSaltUpdated)
 		deps.AutopeeringManager.Selection().Events().OutgoingPeering.Attach(onSelectionOutgoingPeering)
 		deps.AutopeeringManager.Selection().Events().IncomingPeering.Attach(onSelectionIncomingPeering)
@@ -429,8 +482,9 @@ func detachEvents() {
 	}
 
 	if deps.AutopeeringManager.Selection() != nil {
+		deps.PeeringManager.Events.Connected.Detach(onPeerConnected)
 		deps.PeeringManager.Events.Disconnected.Detach(onPeerDisconnected)
-		deps.PeeringManager.Events.RelationUpdated.Detach(onAutopeerBecameKnown)
+		deps.PeeringManager.Events.RelationUpdated.Detach(onPeeringRelationUpdated)
 		deps.AutopeeringManager.Selection().Events().SaltUpdated.Detach(onSelectionSaltUpdated)
 		deps.AutopeeringManager.Selection().Events().OutgoingPeering.Detach(onSelectionOutgoingPeering)
 		deps.AutopeeringManager.Selection().Events().IncomingPeering.Detach(onSelectionIncomingPeering)


### PR DESCRIPTION
It may happen that static peers (known/unknown relation) are also found via autopeering.
If that happens, the autopeering module tries to establish another connection, which is dropped because the peer is already known.

This PR tries to avoid this problem by utilizing the blocklist of the autopeering module.
Static peers are added to the blocklist of the autopeering module, so that the selection protocol ignores connection request from these peers.