### PR TITLE
Do not check storage deposits of full snapshot outputs

### DIFF
--- a/pkg/snapshot/snapshot_file.go
+++ b/pkg/snapshot/snapshot_file.go
@@ -1186,6 +1186,11 @@ func StreamFullSnapshotDataFrom(
 		return err
 	}
 
+	// the outputs of the full snapshot are not checked for correct storage deposits,
+	// because there might be some outputs in the ledger that were created
+	// with different rent structure parameters.
+	fullHeaderProtoParams.RentStructure.VByteCost = 0
+
 	// initialize a temporary protocol storage in memory
 	protocolStorage := storage.NewProtocolStorage(mapdb.NewMapDB())
 


### PR DESCRIPTION
The outputs of the full snapshot are not checked for correct storage deposits, because there might be some outputs in the ledger that were created with different rent structure parameters.

The outputs that are contained in the milestone diffs on the other hand can be checked for correct storage, because there the correct protocol parameters are known.