### PR TITLE
Fix `final ledger index does not match target index`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [2.0.0-alpha.25] - 13.07.2022
 
+### Fixed
+    - Fixed `final ledger index does not match target index` (#1620)
+
 ### Changed
     - Removed `app.enablePlugins` and `app.disablePlugins` and replaced them with plugin-specific `enabled` settings (#1617)
 

--- a/pkg/snapshot/snapshot_file.go
+++ b/pkg/snapshot/snapshot_file.go
@@ -1240,7 +1240,7 @@ func StreamFullSnapshotDataFrom(
 
 		// we do not consume milestone diffs that are below the target milestone index.
 		// these additional milestone diffs are only used to get the protocol parameter updates.
-		if msDiff.Milestone.Index < fullHeader.TargetMilestoneIndex {
+		if msDiff.Milestone.Index <= fullHeader.TargetMilestoneIndex {
 			// we can break the loop here since we are walking backwards.
 			// we also need to jump to the end of the milestone diffs.
 			reader.Seek(msDiffsLength-msDiffsParsedLength, io.SeekCurrent)


### PR DESCRIPTION
- When the full snapshot contains more msdiff than necessary we apply… 1 msdiff too much, so the ledger index does not match the target index at the end.
