### PR TITLE
Add genesis addresses to snap-gen tool

### DIFF
--- a/hornet-nest/Dockerfile
+++ b/hornet-nest/Dockerfile
@@ -51,7 +51,7 @@ RUN mkdir /app/hornet-coo/snapshots
 
 RUN /app/hornet-coo/hornet tool snap-gen \
 	--protocolParametersPath=/app/protocol_parameters.json \
-	--mintAddress=60200bad8137a704216e84f8f9acfe65b972d9f4155becb4815282b03cef99fe \
+	--mintAddress=15664f85080415d9081840367d6cea31885f5d929366dffdf063f1c0856baed1 \
 	--outputPath=/app/hornet-coo/snapshots/full_snapshot.bin
 
 RUN cp -R /app/hornet-coo/snapshots /app/hornet-2/

--- a/hornet-nest/supervisord.conf
+++ b/hornet-nest/supervisord.conf
@@ -67,7 +67,7 @@ priority=5
 
 [program:inx-faucet]
 command=/app/faucet/inx-faucet --faucet.bindAddress=0.0.0.0:8091 --faucet.amount=100000000000 --faucet.smallAmount=10000000000 --faucet.maxAddressBalance=200000000000
-environment=FAUCET_PRV_KEY="52d23081a626b1eca34b63f1eaeeafcbd66bf545635befc12cd0f19926efefb031f176dadf38cdec0eadd1d571394be78f0bbee3ed594316678dffc162a095cb"
+environment=FAUCET_PRV_KEY="887844b1e6bf9ca9e0b57584656add4370dbb49a8cb79e2e3032229f30fd80359e3df559ad0de8e5fa019b9ea46d1ee40879f3f3f74594a3306de9dfd43dcd25"
 autorestart=true
 startsecs=10
 directory = /app/faucet

--- a/pkg/toolset/snap_gen.go
+++ b/pkg/toolset/snap_gen.go
@@ -1,10 +1,13 @@
 package toolset
 
 import (
+	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 
 	"github.com/iotaledger/hive.go/configuration"
@@ -15,12 +18,78 @@ import (
 	iotago "github.com/iotaledger/iota.go/v3"
 )
 
+type AddressWithBalance struct {
+	Address iotago.Address
+	Balance uint64
+}
+
+type jsonGenesisAddresses struct {
+	Balances map[string]uint64 `json:"balances"`
+	Rewards  map[string]uint64 `json:"rewards"`
+}
+
+type GenesisAddresses struct {
+	Balances []*AddressWithBalance
+}
+
+func (g *GenesisAddresses) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
+func (g *GenesisAddresses) UnmarshalJSON(bytes []byte) error {
+	j := &jsonGenesisAddresses{}
+	if err := json.Unmarshal(bytes, j); err != nil {
+		return err
+	}
+
+	if len(j.Balances) != 0 && len(j.Rewards) != 0 {
+		return errors.New("cannot specify both balances and rewards")
+	}
+
+	parseBalance := func(bech32Address string, balance uint64) error {
+		_, address, err := iotago.ParseBech32(bech32Address)
+		if err != nil {
+			if len(bech32Address) != 64 {
+				return err
+			}
+
+			// try parsing as hex
+			address, err = iotago.ParseEd25519AddressFromHexString("0x" + bech32Address)
+			if err != nil {
+				return err
+			}
+		}
+
+		g.Balances = append(g.Balances, &AddressWithBalance{
+			Address: address,
+			Balance: balance,
+		})
+
+		return nil
+	}
+
+	for bech32Address, balance := range j.Balances {
+		if err := parseBalance(bech32Address, balance); err != nil {
+			return err
+		}
+	}
+
+	for bech32Address, balance := range j.Rewards {
+		if err := parseBalance(bech32Address, balance); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func snapshotGen(args []string) error {
 
 	fs := configuration.NewUnsortedFlagSet("", flag.ContinueOnError)
 	protocolParametersPathFlag := fs.String(FlagToolProtocolParametersPath, "", "the path to the initial protocol parameters file")
 	mintAddressFlag := fs.String(FlagToolSnapGenMintAddress, "", "the initial ed25519 address all the tokens will be minted to")
 	treasuryAllocationFlag := fs.Uint64(FlagToolSnapGenTreasuryAllocation, 0, "the amount of tokens to reside within the treasury, the delta from the supply will be allocated to 'mintAddress'")
+	genesisAddressesPathFlag := fs.String(FlagToolGenesisAddressesPath, "", "the file path to the genesis addresses file (optional)")
 	outputFilePathFlag := fs.String(FlagToolOutputPath, "", "the file path to the generated snapshot file")
 
 	fs.Usage = func() {
@@ -87,6 +156,19 @@ func snapshotGen(args []string) error {
 
 	treasury := *treasuryAllocationFlag
 
+	genesisAddresses := &GenesisAddresses{}
+	if len(*genesisAddressesPathFlag) > 0 {
+		genesisAddressesPath := *genesisAddressesPathFlag
+		if _, err := os.Stat(genesisAddressesPath); err != nil || os.IsNotExist(err) {
+			return fmt.Errorf("'%s' (%s) does not exist", FlagToolGenesisAddressesPath, genesisAddressesPath)
+		}
+
+		println("loading genesis addresses...")
+		if err := ioutils.ReadJSONFromFile(genesisAddressesPath, genesisAddresses); err != nil {
+			return fmt.Errorf("failed to load genesis addresses: %w", err)
+		}
+	}
+
 	// build temp file path
 	outputFilePathTmp := outputFilePath + "_tmp"
 
@@ -133,21 +215,65 @@ func snapshotGen(args []string) error {
 		return iotago.EmptyBlockID(), nil
 	}
 
+	// calculate total balance of all genesis addresses
+	genesisBalancesTotal := uint64(0)
+	for _, genesisAddress := range genesisAddresses.Balances {
+		genesisBalancesTotal += genesisAddress.Balance
+	}
+
 	// unspent transaction outputs
-	outputAdded := false
+	genesisBalancesIndex := int64(0)
+	genesisOutputAdded := false
 	outputProducerFunc := func() (*utxo.Output, error) {
-		if outputAdded {
-			return nil, nil
+		if !genesisOutputAdded {
+			genesisOutputAdded = true
+
+			// add the genesis output
+			remainingAmount := int64(protoParams.TokenSupply) - int64(treasury) - int64(genesisBalancesTotal)
+
+			switch {
+			case remainingAmount < 0:
+				return nil, fmt.Errorf("not enough funds to create genesis snapshot")
+
+			case remainingAmount == 0:
+				// no genesis output needed, all balances distributed
+				return nil, nil
+
+			default:
+				// add the genesis output with the remaining balance
+				return utxo.CreateOutput(
+					iotago.OutputID{},
+					iotago.EmptyBlockID(),
+					0,
+					0,
+					&iotago.BasicOutput{
+						Amount: uint64(remainingAmount),
+						Conditions: iotago.UnlockConditions{
+							&iotago.AddressUnlockCondition{Address: &address},
+						},
+					}), nil
+			}
 		}
 
-		outputAdded = true
+		if genesisBalancesIndex < int64(len(genesisAddresses.Balances)) {
+			genesisAddress := genesisAddresses.Balances[genesisBalancesIndex]
+			genesisBalancesIndex++
 
-		return utxo.CreateOutput(iotago.OutputID{}, iotago.EmptyBlockID(), 0, 0, &iotago.BasicOutput{
-			Amount: protoParams.TokenSupply - treasury,
-			Conditions: iotago.UnlockConditions{
-				&iotago.AddressUnlockCondition{Address: &address},
-			},
-		}), nil
+			return utxo.CreateOutput(
+				iotago.OutputIDFromTransactionIDAndIndex(TransactionIDFromIndex(int64(genesisBalancesIndex)), 0),
+				iotago.EmptyBlockID(),
+				0,
+				0,
+				&iotago.BasicOutput{
+					Amount: genesisAddress.Balance,
+					Conditions: iotago.UnlockConditions{
+						&iotago.AddressUnlockCondition{Address: genesisAddress.Address},
+					},
+				}), nil
+		}
+
+		// all outputs added
+		return nil, nil
 	}
 
 	// milestone diffs
@@ -178,4 +304,14 @@ func snapshotGen(args []string) error {
 
 	fmt.Println("Snapshot creation successful!")
 	return nil
+}
+
+func TransactionIDFromIndex(index int64) iotago.TransactionID {
+	txID := iotago.TransactionID{}
+
+	indexBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(indexBytes, uint64(index))
+	copy(txID[:8], indexBytes)
+
+	return txID
 }

--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -30,6 +30,7 @@ const (
 
 	FlagToolProtocolParametersPath = "protocolParametersPath"
 	FlagToolCoordinatorStatePath   = "cooStatePath"
+	FlagToolGenesisAddressesPath   = "genesisAddressesPath"
 
 	FlagToolSnapshotPath       = "snapshotPath"
 	FlagToolSnapshotPathFull   = "fullSnapshotPath"

--- a/private_tangle/config_private_tangle.json
+++ b/private_tangle/config_private_tangle.json
@@ -51,6 +51,7 @@
     "protectedRoutes": [],
     "pow": {
       "enabled": true
-    }
+    },
+    "debugRequestLoggerEnabled": false
   }
 }

--- a/private_tangle/config_spammer.json
+++ b/private_tangle/config_spammer.json
@@ -15,6 +15,7 @@
     "bpsRateLimit": 5.0,
     "workers": 0,
     "autostart": true,
+    "valueSpamEnabled": false,
     "nonLazyTipsThreshold": 0,
     "semiLazyTipsThreshold": 30
   },

--- a/private_tangle/docker-compose.yml
+++ b/private_tangle/docker-compose.yml
@@ -10,12 +10,14 @@ services:
         ipv4_address: 172.18.211.11
     volumes:
       - ./protocol_parameters.json:/app/protocol_parameters.json:ro
+      - ./genesis_addresses.json:/app/genesis_addresses.json:ro
       - ./snapshots:/app/snapshots
     command:
       - "tool"
       - "snap-gen"
       - "--protocolParametersPath=/app/protocol_parameters.json"
-      - "--mintAddress=60200bad8137a704216e84f8f9acfe65b972d9f4155becb4815282b03cef99fe"
+      - "--mintAddress=15664f85080415d9081840367d6cea31885f5d929366dffdf063f1c0856baed1"
+      - "--genesisAddressesPath=/app/genesis_addresses.json"
       - "--outputPath=/app/snapshots/coo/full_snapshot.bin"
     profiles:
       - snapshots
@@ -110,7 +112,7 @@ services:
     ports:
       - "8091:8091/tcp"
     environment:
-      - "FAUCET_PRV_KEY=52d23081a626b1eca34b63f1eaeeafcbd66bf545635befc12cd0f19926efefb031f176dadf38cdec0eadd1d571394be78f0bbee3ed594316678dffc162a095cb"
+      - "FAUCET_PRV_KEY=887844b1e6bf9ca9e0b57584656add4370dbb49a8cb79e2e3032229f30fd80359e3df559ad0de8e5fa019b9ea46d1ee40879f3f3f74594a3306de9dfd43dcd25"
     volumes:
       - ./config_faucet.json:/app/config.json:ro
     command:
@@ -155,6 +157,8 @@ services:
     restart: on-failure
     ports:
       - "9092:9092/tcp"
+    environment:
+      - "SPAMMER_MNEMONIC=reward addict anger tongue denial supply cattle lawn foot climb ask friend base spring ensure spike alien equal burst bitter crowd august ignore animal"
     volumes:
       - ./config_spammer.json:/app/config.json:ro
     command:

--- a/private_tangle/genesis_addresses.json
+++ b/private_tangle/genesis_addresses.json
@@ -1,0 +1,6 @@
+{
+  "balances": {
+    "tst1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vlupxvxq2": 1000000000000,
+    "tst1qqweu75ldpyann5jsthqsa6m0thx4tmqxncj6uqxf5q974pmqx30y5mcdp2": 1000000000000
+  }
+}

--- a/private_tangle/private_tangle_keys.md
+++ b/private_tangle/private_tangle_keys.md
@@ -14,6 +14,22 @@ token ed25519 public key:              31f176dadf38cdec0eadd1d571394be78f0bbee3e
 token ed25519 address:                 60200bad8137a704216e84f8f9acfe65b972d9f4155becb4815282b03cef99fe <br>
 token bech32 address with `tst` HRP:   tst1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vlupxvxq2
 
+## Faucet
+
+token mnemonic:            average day true meadow dawn pistol near vicious have ordinary sting fetch mobile month ladder explain tornado curious energy orange belt glue surge urban <br>
+token ed25519 private key: 887844b1e6bf9ca9e0b57584656add4370dbb49a8cb79e2e3032229f30fd80359e3df559ad0de8e5fa019b9ea46d1ee40879f3f3f74594a3306de9dfd43dcd25 <br>
+token ed25519 public key:              9e3df559ad0de8e5fa019b9ea46d1ee40879f3f3f74594a3306de9dfd43dcd25 <br>
+token ed25519 address:                 15664f85080415d9081840367d6cea31885f5d929366dffdf063f1c0856baed1 <br>
+token bech32 address with `tst` HRP:   tst1qq2kvnu9pqzptkggrpqrvltvagccsh6aj2fkdhla7p3lrsy9dwhdzu5l2ye
+
+## INX-Spammer
+
+token mnemonic:            reward addict anger tongue denial supply cattle lawn foot climb ask friend base spring ensure spike alien equal burst bitter crowd august ignore animal <br>
+token ed25519 private key: d50e772a711c3bf71ae676a8dc6a9726346c200d676a8fa7a6e254f341233115e073300fae90b10163e4b2b70c3fa8a93360992ed1a4cc2f6b386b5121c540a4 <br>
+token ed25519 public key:              e073300fae90b10163e4b2b70c3fa8a93360992ed1a4cc2f6b386b5121c540a4 <br>
+token ed25519 address:                 1d9e7a9f6849d9ce9282ee08775b7aee6aaf6034f12d70064d005f543b01a2f2 <br>
+token bech32 address with `tst` HRP:   tst1qqweu75ldpyann5jsthqsa6m0thx4tmqxncj6uqxf5q974pmqx30y5mcdp2
+
 ## P2P Identities
 
 ### Coordinator node

--- a/private_tangle/protocol_parameters.json
+++ b/private_tangle/protocol_parameters.json
@@ -1,13 +1,13 @@
 {
-    "version": 2,
-    "networkName": "private_tangle1",
-    "bech32HRP": "tst",
-    "minPoWScore": 0,
-    "belowMaxDepth": 15,
-    "rentStructure": {
-        "vByteCost": 500,
-        "vByteFactorData": 1,
-        "vByteFactorKey": 10
-    },
-    "tokenSupply": "2779530283277761"
+  "version": 2,
+  "networkName": "private_tangle1",
+  "bech32HRP": "tst",
+  "minPoWScore": 0,
+  "belowMaxDepth": 15,
+  "rentStructure": {
+    "vByteCost": 500,
+    "vByteFactorData": 1,
+    "vByteFactorKey": 10
+  },
+  "tokenSupply": "2779530283277761"
 }


### PR DESCRIPTION
This PR adds the possibility to pass an optional json file with genesis snapshot balances to the `snap-gen` tool.