### PR TITLE
Fix linter warnings and improve code readability

### DIFF
--- a/core/profile/component.go
+++ b/core/profile/component.go
@@ -12,6 +12,15 @@ import (
 	"github.com/iotaledger/hornet/v2/pkg/profile"
 )
 
+const (
+	ProfileNameAuto  = "auto"
+	ProfileNameLight = "light"
+	ProfileName1GB   = "1gb"
+	ProfileName2GB   = "2gb"
+	ProfileName4GB   = "4gb"
+	ProfileName8GB   = "8gb"
+)
+
 var (
 	ErrNotEnoughMemory = errors.New("not enough system memory")
 )
@@ -81,13 +90,13 @@ func loadProfile(profilesConfig *configuration.Configuration) *profile.Profile {
 		}
 
 		if v.Total >= 8000000000*0.95 {
-			profileName = "8gb"
+			profileName = ProfileName8GB
 		} else if v.Total >= 4000000000*0.95 {
-			profileName = "4gb"
+			profileName = ProfileName4GB
 		} else if v.Total >= 2000000000*0.95 {
-			profileName = "2gb"
+			profileName = ProfileName2GB
 		} else if v.Total >= 1000000000*0.95 {
-			profileName = "1gb"
+			profileName = ProfileName1GB
 		} else {
 			CoreComponent.LogPanic(ErrNotEnoughMemory)
 		}
@@ -95,18 +104,18 @@ func loadProfile(profilesConfig *configuration.Configuration) *profile.Profile {
 
 	var p *profile.Profile
 	switch profileName {
-	case "8gb":
+	case ProfileName8GB:
 		p = Profile8GB
-		p.Name = "8gb"
-	case "4gb":
+		p.Name = ProfileName8GB
+	case ProfileName4GB:
 		p = Profile4GB
-		p.Name = "4gb"
-	case "2gb":
+		p.Name = ProfileName4GB
+	case ProfileName2GB:
 		p = Profile2GB
-		p.Name = "2gb"
-	case "1gb", "light":
+		p.Name = ProfileName2GB
+	case ProfileName1GB, ProfileNameLight:
 		p = Profile1GB
-		p.Name = "1gb"
+		p.Name = ProfileName1GB
 	default:
 		p = &profile.Profile{}
 		if !profilesConfig.Exists(profileName) {

--- a/integration-tests/tester/framework/autopeered_network.go
+++ b/integration-tests/tester/framework/autopeered_network.go
@@ -40,9 +40,11 @@ func (n *AutopeeredNetwork) createEntryNode(privKey ed25519.PrivateKey) error {
 	if err := n.entryNode.CreateNodeContainer(cfg); err != nil {
 		return err
 	}
+
 	if err := n.entryNode.ConnectToNetwork(n.ID); err != nil {
 		return err
 	}
+
 	if err := n.entryNode.Start(); err != nil {
 		return err
 	}
@@ -100,6 +102,7 @@ func (n *AutopeeredNetwork) CreatePeer(cfg *AppConfig) (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	cfg.Autopeering.EntryNodes = []string{
 		fmt.Sprintf("/ip4/%s/udp/14626/autopeering/%s", ip, n.entryNodePublicKey()),
 	}
@@ -118,6 +121,7 @@ func (n *AutopeeredNetwork) Shutdown() error {
 	if err != nil {
 		return err
 	}
+
 	if err := createContainerLogFile(n.PrefixName(containerNameEntryNode), logs); err != nil {
 		return err
 	}

--- a/integration-tests/tester/framework/network.go
+++ b/integration-tests/tester/framework/network.go
@@ -57,6 +57,7 @@ func (n *Network) AwaitOnline(ctx context.Context) error {
 			if err := returnErrIfCtxDone(ctx, ErrNodesNotOnlineInTime); err != nil {
 				return err
 			}
+
 			if _, err := node.DebugNodeAPIClient.Info(context.Background()); err != nil {
 				continue
 			}
@@ -76,10 +77,12 @@ func (n *Network) AwaitAllSync(ctx context.Context) error {
 			if err := returnErrIfCtxDone(ctx, ErrNodesDidNotSyncInTime); err != nil {
 				return err
 			}
+
 			info, err := node.DebugNodeAPIClient.Info(context.Background())
 			if err != nil {
 				continue
 			}
+
 			if info.Status.IsHealthy {
 				break
 			}
@@ -114,6 +117,7 @@ func generatePrivateKey(optPrvKey ...crypto.PrivKey) (crypto.PrivKey, error) {
 	if len(optPrvKey) > 0 && optPrvKey[0] != nil {
 		return optPrvKey[0], nil
 	}
+
 	privateKey, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
 	if err != nil {
 		return nil, err
@@ -144,9 +148,11 @@ func (n *Network) CreateNode(cfg *AppConfig, optPrvKey ...crypto.PrivKey) (*Node
 	if err := container.CreateNodeContainer(cfg); err != nil {
 		return nil, err
 	}
+
 	if err := container.ConnectToNetwork(n.ID); err != nil {
 		return nil, err
 	}
+
 	if err := container.Start(); err != nil {
 		return nil, err
 	}
@@ -161,6 +167,7 @@ func (n *Network) CreateNode(cfg *AppConfig, optPrvKey ...crypto.PrivKey) (*Node
 	if err != nil {
 		return nil, err
 	}
+
 	n.Nodes = append(n.Nodes, node)
 
 	return node, nil
@@ -177,9 +184,11 @@ func (n *Network) CreateCoordinator(cfg *INXCoordinatorConfig) (*INXExtension, e
 	if err := container.CreateCoordinatorContainer(cfg); err != nil {
 		return nil, err
 	}
+
 	if err := container.ConnectToNetwork(n.ID); err != nil {
 		return nil, err
 	}
+
 	if err := container.Start(); err != nil {
 		return nil, err
 	}
@@ -211,9 +220,11 @@ func (n *Network) CreateIndexer(cfg *INXIndexerConfig) (*INXExtension, error) {
 	if err := container.CreateIndexerContainer(cfg); err != nil {
 		return nil, err
 	}
+
 	if err := container.ConnectToNetwork(n.ID); err != nil {
 		return nil, err
 	}
+
 	if err := container.Start(); err != nil {
 		return nil, err
 	}
@@ -268,6 +279,7 @@ func (n *Network) Shutdown() error {
 		if err != nil {
 			return err
 		}
+
 		if err = createContainerLogFile(p.Name, logs); err != nil {
 			return err
 		}
@@ -278,6 +290,7 @@ func (n *Network) Shutdown() error {
 		if err != nil {
 			return err
 		}
+
 		if err = createContainerLogFile(p.Name, logs); err != nil {
 			return err
 		}
@@ -352,8 +365,10 @@ func (n *Network) Coordinator() *Node {
 // TakeCPUProfiles takes a CPU profile on all nodes within the network.
 func (n *Network) TakeCPUProfiles(dur time.Duration) error {
 	log.Printf("taking CPU profile (%v) on all nodes", dur)
+
 	var wg sync.WaitGroup
 	wg.Add(len(n.Nodes))
+
 	var profErr error
 	for _, n := range n.Nodes {
 		go func(node *Node) {
@@ -362,6 +377,7 @@ func (n *Network) TakeCPUProfiles(dur time.Duration) error {
 					fmt.Println(r)
 				}
 			}()
+
 			defer wg.Done()
 			if err := node.TakeCPUProfile(dur); err != nil {
 				profErr = err
@@ -376,8 +392,10 @@ func (n *Network) TakeCPUProfiles(dur time.Duration) error {
 // TakeHeapSnapshots takes a heap snapshot on all nodes within the network.
 func (n *Network) TakeHeapSnapshots() error {
 	log.Printf("taking heap snapshot on all nodes")
+
 	var wg sync.WaitGroup
 	wg.Add(len(n.Nodes))
+
 	var profErr error
 	for _, n := range n.Nodes {
 		go func(n *Node) {

--- a/integration-tests/tester/framework/profiling.go
+++ b/integration-tests/tester/framework/profiling.go
@@ -10,9 +10,8 @@ import (
 )
 
 const (
-	cpuProfilePrefix   = "cpu_profile"
-	heapProfilePrefix  = "heap_profile"
-	metricsChartPrefix = "metrics_charts"
+	cpuProfilePrefix  = "cpu_profile"
+	heapProfilePrefix = "heap_profile"
 
 	timeoutProfilingQuery = 1 * time.Minute
 )

--- a/integration-tests/tester/tests/migration/batch_test.go
+++ b/integration-tests/tester/tests/migration/batch_test.go
@@ -40,7 +40,7 @@ func TestBatch(t *testing.T) {
 		cfg.Receipts.Validate = true
 		cfg.Receipts.Validator.APIAddress = "http://wfmock_batch:14265"
 		cfg.Receipts.Validator.APITimeout = 5 * time.Second
-		cfg.Receipts.Validator.CoordinatorAddress = "QYO9OXGLVLUKMCEONVAPEWXUFQTGTTHPZZOTOFHYUFVPJJLLFAYBIOFMTUSVXVRQFSUIQXJUGZQDDDULY"
+		cfg.Receipts.Validator.CoordinatorAddress = CoordinatorAddress
 		cfg.Receipts.Validator.CoordinatorMerkleTreeDepth = 8
 
 		switch {
@@ -52,8 +52,8 @@ func TestBatch(t *testing.T) {
 			cfg.Receipts.Enabled = true
 		}
 
-		cfg.Snapshot.FullSnapshotFilePath = "/assets/migration_full_snapshot.bin"
-		cfg.Snapshot.DeltaSnapshotFilePath = "/assets/migration_delta_snapshot.bin" // doesn't exist so the node will only load the full one
+		cfg.Snapshot.FullSnapshotFilePath = FullSnapshotPath
+		cfg.Snapshot.DeltaSnapshotFilePath = DeltaSnapshotPath // doesn't exist so the node will only load the full one
 	})
 	require.NoError(t, err)
 	defer framework.ShutdownNetwork(t, n)

--- a/integration-tests/tester/tests/migration/migration_test.go
+++ b/integration-tests/tester/tests/migration/migration_test.go
@@ -13,6 +13,12 @@ import (
 	iotago "github.com/iotaledger/iota.go/v3"
 )
 
+const (
+	FullSnapshotPath   = "/assets/migration_full_snapshot.bin"
+	DeltaSnapshotPath  = "/assets/migration_delta_snapshot.bin"
+	CoordinatorAddress = "QYO9OXGLVLUKMCEONVAPEWXUFQTGTTHPZZOTOFHYUFVPJJLLFAYBIOFMTUSVXVRQFSUIQXJUGZQDDDULY"
+)
+
 // TestMigration boots up a statically peered network which runs with a white-flag mock server
 // in order to validate an entire migration flow.
 // The migration full snapshot used to bootstrap the C2 network has 10000000000 allocated on the treasury.
@@ -45,7 +51,7 @@ func TestMigration(t *testing.T) {
 		cfg.Receipts.Validate = true
 		cfg.Receipts.Validator.APIAddress = "http://wfmock:14265"
 		cfg.Receipts.Validator.APITimeout = 5 * time.Second
-		cfg.Receipts.Validator.CoordinatorAddress = "QYO9OXGLVLUKMCEONVAPEWXUFQTGTTHPZZOTOFHYUFVPJJLLFAYBIOFMTUSVXVRQFSUIQXJUGZQDDDULY"
+		cfg.Receipts.Validator.CoordinatorAddress = CoordinatorAddress
 		cfg.Receipts.Validator.CoordinatorMerkleTreeDepth = 8
 
 		switch {
@@ -57,8 +63,8 @@ func TestMigration(t *testing.T) {
 			cfg.Receipts.Enabled = true
 		}
 
-		cfg.Snapshot.FullSnapshotFilePath = "/assets/migration_full_snapshot.bin"
-		cfg.Snapshot.DeltaSnapshotFilePath = "/assets/migration_delta_snapshot.bin" // doesn't exist so the node will only load the full one
+		cfg.Snapshot.FullSnapshotFilePath = FullSnapshotPath
+		cfg.Snapshot.DeltaSnapshotFilePath = DeltaSnapshotPath // doesn't exist so the node will only load the full one
 	})
 	require.NoError(t, err)
 	defer framework.ShutdownNetwork(t, n)
@@ -128,7 +134,7 @@ func TestAPIError(t *testing.T) {
 			cfg.Receipts.Validate = true
 			cfg.Receipts.Validator.APIAddress = "http://localhost:14265"
 			cfg.Receipts.Validator.APITimeout = 5 * time.Second
-			cfg.Receipts.Validator.CoordinatorAddress = "QYO9OXGLVLUKMCEONVAPEWXUFQTGTTHPZZOTOFHYUFVPJJLLFAYBIOFMTUSVXVRQFSUIQXJUGZQDDDULY"
+			cfg.Receipts.Validator.CoordinatorAddress = CoordinatorAddress
 			cfg.Receipts.Validator.CoordinatorMerkleTreeDepth = 8
 
 			switch {
@@ -139,8 +145,8 @@ func TestAPIError(t *testing.T) {
 			default:
 				cfg.Receipts.Enabled = true
 			}
-			cfg.Snapshot.FullSnapshotFilePath = "/assets/migration_full_snapshot.bin"
-			cfg.Snapshot.DeltaSnapshotFilePath = "/assets/migration_delta_snapshot.bin" // doesn't exist so the node will only load the full one
+			cfg.Snapshot.FullSnapshotFilePath = FullSnapshotPath
+			cfg.Snapshot.DeltaSnapshotFilePath = DeltaSnapshotPath // doesn't exist so the node will only load the full one
 		})
 	require.NoError(t, err)
 	defer framework.ShutdownNetwork(t, n)

--- a/pkg/dag/helper.go
+++ b/pkg/dag/helper.go
@@ -24,7 +24,6 @@ type OnSolidEntryPoint func(blockID iotago.BlockID) error
 // It is a DFS of the paths of the parents one after another.
 // Caution: condition func is not in DFS order.
 func TraverseParents(ctx context.Context, parentsTraverserStorage ParentsTraverserStorage, parents iotago.BlockIDs, condition Predicate, consumer Consumer, onMissingParent OnMissingParent, onSolidEntryPoint OnSolidEntryPoint, traverseSolidEntryPoints bool) error {
-
 	t := NewParentsTraverser(parentsTraverserStorage)
 
 	return t.Traverse(ctx, parents, condition, consumer, onMissingParent, onSolidEntryPoint, traverseSolidEntryPoints)
@@ -35,7 +34,6 @@ func TraverseParents(ctx context.Context, parentsTraverserStorage ParentsTravers
 // It is a DFS of the paths of the parents one after another.
 // Caution: condition func is not in DFS order.
 func TraverseParentsOfBlock(ctx context.Context, parentsTraverserStorage ParentsTraverserStorage, startBlockID iotago.BlockID, condition Predicate, consumer Consumer, onMissingParent OnMissingParent, onSolidEntryPoint OnSolidEntryPoint, traverseSolidEntryPoints bool) error {
-
 	t := NewParentsTraverser(parentsTraverserStorage)
 
 	return t.Traverse(ctx, iotago.BlockIDs{startBlockID}, condition, consumer, onMissingParent, onSolidEntryPoint, traverseSolidEntryPoints)
@@ -45,7 +43,6 @@ func TraverseParentsOfBlock(ctx context.Context, parentsTraverserStorage Parents
 // the traversal stops due to no more blocks passing the given condition.
 // It is unsorted BFS because the children are not ordered in the database.
 func TraverseChildren(ctx context.Context, childrenTraverserStorage ChildrenTraverserStorage, startBlockID iotago.BlockID, condition Predicate, consumer Consumer, walkAlreadyDiscovered bool) error {
-
 	t := NewChildrenTraverser(childrenTraverserStorage)
 
 	return t.Traverse(ctx, startBlockID, condition, consumer, walkAlreadyDiscovered)

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Errors.
 var (
 	ErrJWTInvalidClaims = echo.NewHTTPError(http.StatusUnauthorized, "invalid jwt claims")
 )

--- a/pkg/model/migrator/validator.go
+++ b/pkg/model/migrator/validator.go
@@ -99,6 +99,7 @@ func (m *Validator) QueryNextMigratedFunds(startIndex iotago.MilestoneIndex) (io
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed to query migration funds: %w", err)
 		}
+
 		if len(migrated) > 0 {
 			return index, migrated, nil
 		}
@@ -113,6 +114,7 @@ func (m *Validator) queryLatestMilestoneIndex() (iotago.MilestoneIndex, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	index := info.LatestSolidSubtangleMilestoneIndex
 	// do some sanity checks
 	if index < 0 || index >= math.MaxUint32 {
@@ -133,14 +135,17 @@ func (m *Validator) validateMilestoneBundle(ms bundle.Bundle, msIndex iotago.Mil
 	if head.Address != m.coordinatorAddress {
 		return legacy.ErrInvalidAddress
 	}
+
 	// the milestone must be a 0-value transaction
 	if head.Value != 0 {
 		return legacy.ErrInvalidValue
 	}
+
 	// the tag must match the milestone index
 	if head.ObsoleteTag != tag || head.Tag != tag {
 		return legacy.ErrInvalidTag
 	}
+
 	// the head transaction must indeed be the last transaction in the bundle
 	if head.CurrentIndex != lastIndex || head.LastIndex != lastIndex {
 		return legacy.ErrInvalidIndex
@@ -169,6 +174,7 @@ func (m *Validator) validateMilestoneSignature(ms bundle.Bundle) error {
 	if err != nil {
 		return fmt.Errorf("failed to validate signature: %w", err)
 	}
+
 	if !valid {
 		return legacy.ErrInvalidSignature
 	}
@@ -181,6 +187,7 @@ func (m *Validator) whiteFlagMerkleTreeHash(ms bundle.Bundle) ([]byte, error) {
 	head := ms[len(ms)-1]
 	data := head.SignatureMessageFragment[m.coordinatorMerkleTreeDepth*legacy.HashTrytesSize:]
 	trytesLen := b1t6.EncodedLen(hasher.Size()) / legacy.TritsPerTryte
+
 	hash, err := b1t6.DecodeTrytes(data[:trytesLen])
 	if err != nil {
 		return nil, err
@@ -199,10 +206,12 @@ func asBundle(rawTrytes []trinary.Trytes) (bundle.Bundle, error) {
 	if len(rawTrytes) == 0 {
 		return nil, ErrEmptyBundle
 	}
+
 	txs, err := transaction.AsTransactionObjects(rawTrytes, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	// validate the bundle, but also accept non-migration milestone bundles
 	if err := bundle.ValidBundle(txs, false); err != nil {
 		return nil, err
@@ -230,6 +239,7 @@ func (m *Validator) validateConfirmation(confirmation *api.WhiteFlagConfirmation
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse included bundle %d: %w", i, err)
 		}
+
 		if err := bundle.ValidBundle(bndl, true); err != nil {
 			return nil, fmt.Errorf("invalid included bundle %d: %w", i, err)
 		}
@@ -245,6 +255,7 @@ func (m *Validator) validateConfirmation(confirmation *api.WhiteFlagConfirmation
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Merkle tree hash: %w", err)
 	}
+
 	merkleHash := hasher.Hash(includedTails)
 	if !bytes.Equal(msMerkleHash, merkleHash) {
 		return nil, fmt.Errorf("invalid MerkleTreeHash %s", merkleHash)

--- a/pkg/model/storage/block_metadata.go
+++ b/pkg/model/storage/block_metadata.go
@@ -120,27 +120,27 @@ type BlockMetadata struct {
 
 	blockID iotago.BlockID
 
-	// Metadata
+	// Metadata.
 	metadata bitmask.BitMask
 
-	// The index of the milestone which referenced this block
+	// The index of the milestone which referenced this block.
 	referencedIndex iotago.MilestoneIndex
 
-	// The index of this block inside the milestone given the whiteflag ordering
+	// The index of this block inside the milestone given the whiteflag ordering.
 	whiteFlagIndex uint32
 
 	conflict Conflict
 
-	// youngestConeRootIndex is the highest referenced index of the past cone of this block
+	// youngestConeRootIndex is the highest referenced index of the past cone of this block.
 	youngestConeRootIndex iotago.MilestoneIndex
 
-	// oldestConeRootIndex is the lowest referenced index of the past cone of this block
+	// oldestConeRootIndex is the lowest referenced index of the past cone of this block.
 	oldestConeRootIndex iotago.MilestoneIndex
 
-	// coneRootCalculationIndex is the confirmed milestone index ycri and ocri were calculated at
+	// coneRootCalculationIndex is the confirmed milestone index ycri and ocri were calculated at.
 	coneRootCalculationIndex iotago.MilestoneIndex
 
-	// parents are the parents of the block
+	// parents are the parents of the block.
 	parents iotago.BlockIDs
 }
 
@@ -307,7 +307,7 @@ func (m *BlockMetadata) Metadata() byte {
 	return byte(m.metadata)
 }
 
-// ObjectStorage interface
+// ObjectStorage interface.
 
 func (m *BlockMetadata) Update(_ objectstorage.StorableObject) {
 	panic(fmt.Sprintf("BlockMetadata should never be updated: %v", m.blockID.ToHex()))

--- a/pkg/model/storage/blocks_storage.go
+++ b/pkg/model/storage/blocks_storage.go
@@ -116,7 +116,7 @@ func (c *CachedBlock) Exists() bool {
 }
 
 // ConsumeBlockAndMetadata consumes the underlying block and metadata.
-// block -1
+// block -1.
 // meta -1.
 func (c *CachedBlock) ConsumeBlockAndMetadata(consumer func(*Block, *BlockMetadata)) {
 
@@ -128,7 +128,7 @@ func (c *CachedBlock) ConsumeBlockAndMetadata(consumer func(*Block, *BlockMetada
 }
 
 // ConsumeBlock consumes the underlying block.
-// block -1
+// block -1.
 // meta -1.
 func (c *CachedBlock) ConsumeBlock(consumer func(*Block)) {
 	defer c.metadata.Release(true)                              // meta -1
@@ -138,7 +138,7 @@ func (c *CachedBlock) ConsumeBlock(consumer func(*Block)) {
 }
 
 // ConsumeMetadata consumes the underlying metadata.
-// block -1
+// block -1.
 // meta -1.
 func (c *CachedBlock) ConsumeMetadata(consumer func(*BlockMetadata)) {
 	defer c.block.Release(true)                                    // block -1

--- a/pkg/model/utxo/milestone_diff.go
+++ b/pkg/model/utxo/milestone_diff.go
@@ -188,7 +188,7 @@ func (ms *MilestoneDiff) SHA256Sum() ([]byte, error) {
 	return msDiffHash.Sum(nil), nil
 }
 
-//- DB helpers
+// DB helper functions.
 
 func storeDiff(diff *MilestoneDiff, mutations kvstore.BatchedMutations) error {
 	return mutations.Set(diff.KVStorableKey(), diff.KVStorableValue())
@@ -198,7 +198,7 @@ func deleteDiff(msIndex iotago.MilestoneIndex, mutations kvstore.BatchedMutation
 	return mutations.Delete(milestoneDiffKeyForIndex(msIndex))
 }
 
-//- Manager
+// Manager functions.
 
 func (u *Manager) MilestoneDiffWithoutLocking(msIndex iotago.MilestoneIndex) (*MilestoneDiff, error) {
 

--- a/pkg/p2p/manager.go
+++ b/pkg/p2p/manager.go
@@ -268,7 +268,7 @@ type Manager struct {
 	forEachChan            chan *foreachmsg
 	callChan               chan *callmsg
 
-	// closures
+	// closures.
 	onP2PManagerConnect            *events.Closure
 	onP2PManagerConnected          *events.Closure
 	onP2PManagerDisconnect         *events.Closure
@@ -876,15 +876,19 @@ func (m *Manager) updateRelation(peerID peer.ID, newRelation PeerRelation) {
 	}
 	oldRelation := p.Relation
 	p.Relation = newRelation
+
 	switch newRelation {
 	case PeerRelationUnknown:
 		p.reconnectTimer.Stop()
 		p.reconnectTimer = nil
+
 	case PeerRelationAutopeered:
 		fallthrough
+
 	case PeerRelationKnown:
 		m.host.ConnManager().Protect(peerID, PeerConnectivityProtectionTag)
 	}
+
 	m.Events.RelationUpdated.Trigger(p, oldRelation)
 }
 

--- a/pkg/protocol/gossip/msg_proc.go
+++ b/pkg/protocol/gossip/msg_proc.go
@@ -28,10 +28,10 @@ import (
 
 const (
 	WorkerQueueSize = 50000
+	WorkerCount     = 64
 )
 
 var (
-	workerCount           = 64
 	ErrBlockNotSolid      = errors.New("block is not solid")
 	ErrBlockBelowMaxDepth = errors.New("block is below max depth")
 )
@@ -163,7 +163,7 @@ func NewMessageProcessor(
 		}
 
 		task.Return(nil)
-	}, workerpool.WorkerCount(workerCount), workerpool.QueueSize(WorkerQueueSize))
+	}, workerpool.WorkerCount(WorkerCount), workerpool.QueueSize(WorkerQueueSize))
 
 	return proc, nil
 }

--- a/pkg/protocol/gossip/protocol.go
+++ b/pkg/protocol/gossip/protocol.go
@@ -235,7 +235,7 @@ func (p *Protocol) IsSynced(cmi iotago.MilestoneIndex) bool {
 	return true
 }
 
-// Info returns.
+// Info returns the info about the protocol.
 func (p *Protocol) Info() *Info {
 	return &Info{
 		Heartbeat: p.LatestHeartbeat,

--- a/pkg/protocol/gossip/service.go
+++ b/pkg/protocol/gossip/service.go
@@ -179,13 +179,13 @@ type Service struct {
 	streamReqChan       chan *streamreqmsg
 	forEachChan         chan *foreachmsg
 
-	// closures
-	// peering manager
+	// closures.
+	// peering manager.
 	onPeeringManagerConnected       *events.Closure
 	onPeeringManagerDisconnected    *events.Closure
 	onPeeringManagerRelationUpdated *events.Closure
 
-	// logger
+	// logger.
 	onGossipServiceProtocolStarted       *events.Closure
 	onGossipServiceProtocolTerminated    *events.Closure
 	onGossipServiceInboundStreamCanceled *events.Closure
@@ -648,6 +648,7 @@ func (s *Service) configureEvents() {
 	// peering manager
 	s.peeringMngWP = workerpool.New(func(task workerpool.Task) {
 		defer task.Return(nil)
+
 		switch req := task.Param(0).(type) {
 		case *connectionmsg:
 			if req.conn == nil {

--- a/pkg/protocol/protocol_manager.go
+++ b/pkg/protocol/protocol_manager.go
@@ -52,7 +52,7 @@ type Manager struct {
 	pending     []*iotago.ProtocolParamsMilestoneOpt
 }
 
-// init initialises the Manager by loading the last stored parameters and pending parameters.
+// init initializes the Manager by loading the last stored parameters and pending parameters.
 func (m *Manager) init(ledgerIndex iotago.MilestoneIndex) error {
 	m.currentLock.Lock()
 	defer m.currentLock.Unlock()
@@ -99,6 +99,7 @@ func (m *Manager) Current() *iotago.ProtocolParameters {
 func (m *Manager) Pending() []*iotago.ProtocolParamsMilestoneOpt {
 	m.pendingLock.RLock()
 	defer m.pendingLock.RUnlock()
+
 	cpy := make([]*iotago.ProtocolParamsMilestoneOpt, len(m.pending))
 	for i, ele := range m.pending {
 		cpy[i] = ele.Clone().(*iotago.ProtocolParamsMilestoneOpt)

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -322,7 +322,6 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex iotago.MilestoneIndex, forc
 		}
 		// rerun to solidify the older one
 		t.setSolidifierMilestoneIndex(0)
-
 		t.milestoneSolidifierWorkerPool.TrySubmit(SolidifierTriggerSignal, true)
 
 		return
@@ -577,7 +576,6 @@ func (t *Tangle) searchMissingMilestones(ctx context.Context, confirmedMilestone
 
 			// milestone found!
 			t.milestoneManager.StoreMilestone(cachedBlock.Retain(), milestonePayload, false) // block pass +1
-
 			milestoneFound = true
 
 			return true, nil // we keep searching for all missing milestones

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -22,11 +22,11 @@ var (
 )
 
 type ConfirmedMilestoneMetric struct {
-	MilestoneIndex         iotago.MilestoneIndex `json:"ms_index"`
-	BPS                    float64               `json:"bps"`
-	RBPS                   float64               `json:"rbps"`
-	ReferencedRate         float64               `json:"referenced_rate"`
-	TimeSinceLastMilestone float64               `json:"time_since_last_ms"`
+	MilestoneIndex         iotago.MilestoneIndex
+	BPS                    float64
+	RBPS                   float64
+	ReferencedRate         float64
+	TimeSinceLastMilestone float64
 }
 
 // TriggerSolidifier can be used to manually trigger the solidifier from other plugins.

--- a/pkg/tpkg/random.go
+++ b/pkg/tpkg/random.go
@@ -135,10 +135,13 @@ func RandAddress(addressType iotago.AddressType) iotago.Address {
 		copy(address[:], addressBytes)
 
 		return address
+
 	case iotago.AddressNFT:
 		return RandNFTID().ToAddress()
+
 	case iotago.AddressAlias:
 		return RandAliasID().ToAddress()
+
 	default:
 		panic("unknown address type")
 	}

--- a/plugins/coreapi/blocks.go
+++ b/plugins/coreapi/blocks.go
@@ -155,8 +155,8 @@ func sendBlock(c echo.Context) (*blockCreatedResponse, error) {
 
 	case httpserver.MIMEApplicationVendorIOTASerializerV1:
 		if c.Request().Body == nil {
-			return nil, errors.WithMessage(httpserver.ErrInvalidParameter, "invalid block, error: request body missing")
 			// bad request
+			return nil, errors.WithMessage(httpserver.ErrInvalidParameter, "invalid block, error: request body missing")
 		}
 
 		bytes, err := io.ReadAll(c.Request().Body)

--- a/plugins/coreapi/component.go
+++ b/plugins/coreapi/component.go
@@ -37,7 +37,7 @@ const (
 
 	// RouteBlock is the route for getting a block by its blockID.
 	// GET returns the block based on the given type in the request "Accept" header.
-	// MIMEApplicationJSON => json
+	// MIMEApplicationJSON => json.
 	// MIMEVendorIOTASerializer => bytes.
 	RouteBlock = "/blocks/:" + restapipkg.ParameterBlockID
 
@@ -48,19 +48,19 @@ const (
 	// RouteBlocks is the route for creating new blocks.
 	// POST creates a single new block and returns the new block ID.
 	// The block is parsed based on the given type in the request "Content-Type" header.
-	// MIMEApplicationJSON => json
+	// MIMEApplicationJSON => json.
 	// MIMEVendorIOTASerializer => bytes.
 	RouteBlocks = "/blocks"
 
 	// RouteTransactionsIncludedBlock is the route for getting the block that was included in the ledger for a given transaction ID.
 	// GET returns the block based on the given type in the request "Accept" header.
-	// MIMEApplicationJSON => json
+	// MIMEApplicationJSON => json.
 	// MIMEVendorIOTASerializer => bytes.
 	RouteTransactionsIncludedBlock = "/transactions/:" + restapipkg.ParameterTransactionID + "/included-block"
 
 	// RouteMilestoneByID is the route for getting a milestone by its ID.
 	// GET returns the milestone.
-	// MIMEApplicationJSON => json
+	// MIMEApplicationJSON => json.
 	// MIMEVendorIOTASerializer => bytes.
 	RouteMilestoneByID = "/milestones/:" + restapipkg.ParameterMilestoneID
 
@@ -70,7 +70,7 @@ const (
 
 	// RouteMilestoneByIndex is the route for getting a milestone by its milestoneIndex.
 	// GET returns the milestone.
-	// MIMEApplicationJSON => json
+	// MIMEApplicationJSON => json.
 	// MIMEVendorIOTASerializer => bytes.
 	RouteMilestoneByIndex = "/milestones/by-index/:" + restapipkg.ParameterMilestoneIndex
 
@@ -80,7 +80,7 @@ const (
 
 	// RouteOutput is the route for getting an output by its outputID (transactionHash + outputIndex).
 	// GET returns the output based on the given type in the request "Accept" header.
-	// MIMEApplicationJSON => json
+	// MIMEApplicationJSON => json.
 	// MIMEVendorIOTASerializer => bytes.
 	RouteOutput = "/outputs/:" + restapipkg.ParameterOutputID
 

--- a/plugins/inx/server_blocks.go
+++ b/plugins/inx/server_blocks.go
@@ -173,6 +173,7 @@ func (s *INXServer) ListenToSolidBlocks(_ *inx.NoParams, srv inx.INX_ListenToSol
 
 			return
 		}
+
 		if err := srv.Send(payload); err != nil {
 			Plugin.LogInfof("Send error: %v", err)
 			cancel()

--- a/plugins/inx/server_utxo.go
+++ b/plugins/inx/server_utxo.go
@@ -35,6 +35,7 @@ func NewLedgerSpent(s *utxo.Spent) (*inx.LedgerSpent, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	l := &inx.LedgerSpent{
 		Output:                  output,
 		TransactionIdSpent:      inx.NewTransactionId(s.TransactionIDSpent()),
@@ -105,6 +106,7 @@ func NewTreasuryUpdate(index iotago.MilestoneIndex, created *utxo.TreasuryOutput
 			Amount:      created.Amount,
 		},
 	}
+
 	if consumed != nil {
 		u.Consumed = &inx.TreasuryOutput{
 			MilestoneId: inx.NewMilestoneId(consumed.MilestoneID),
@@ -137,6 +139,7 @@ func (s *INXServer) ReadOutput(_ context.Context, id *inx.OutputId) (*inx.Output
 		if err != nil {
 			return nil, err
 		}
+
 		ledgerOutput, err := NewLedgerOutput(output)
 		if err != nil {
 			return nil, err
@@ -154,6 +157,7 @@ func (s *INXServer) ReadOutput(_ context.Context, id *inx.OutputId) (*inx.Output
 	if err != nil {
 		return nil, err
 	}
+
 	ledgerSpent, err := NewLedgerSpent(spent)
 	if err != nil {
 		return nil, err
@@ -185,10 +189,12 @@ func (s *INXServer) ReadUnspentOutputs(_ *inx.NoParams, srv inx.INX_ReadUnspentO
 
 			return false
 		}
+
 		payload := &inx.UnspentOutput{
 			LedgerIndex: ledgerIndex,
 			Output:      ledgerOutput,
 		}
+
 		if err := srv.Send(payload); err != nil {
 			innerErr = fmt.Errorf("send error: %w", err)
 
@@ -224,6 +230,7 @@ func (s *INXServer) ListenToLedgerUpdates(req *inx.MilestoneRangeRequest, srv in
 			if err != nil {
 				return err
 			}
+
 			if err := srv.Send(payload); err != nil {
 				return fmt.Errorf("send error: %w", err)
 			}
@@ -235,6 +242,7 @@ func (s *INXServer) ListenToLedgerUpdates(req *inx.MilestoneRangeRequest, srv in
 			if err != nil {
 				return err
 			}
+
 			if err := srv.Send(payload); err != nil {
 				return fmt.Errorf("send error: %w", err)
 			}
@@ -381,9 +389,11 @@ func (s *INXServer) ListenToTreasuryUpdates(req *inx.MilestoneRangeRequest, srv 
 			if err != nil {
 				return err
 			}
+
 			if err := srv.Send(payload); err != nil {
 				return fmt.Errorf("send error: %w", err)
 			}
+
 			treasuryUpdateSent = true
 		}
 
@@ -489,6 +499,7 @@ func (s *INXServer) ListenToTreasuryUpdates(req *inx.MilestoneRangeRequest, srv 
 		if err != nil {
 			return err
 		}
+
 		stream.lastSent = ledgerIndex
 	}
 
@@ -555,6 +566,7 @@ func (s *INXServer) ListenToMigrationReceipts(_ *inx.NoParams, srv inx.INX_Liste
 			Plugin.LogInfof("send error: %v", err)
 			cancel()
 		}
+
 		if err := srv.Send(payload); err != nil {
 			Plugin.LogInfof("send error: %v", err)
 			cancel()
@@ -564,6 +576,7 @@ func (s *INXServer) ListenToMigrationReceipts(_ *inx.NoParams, srv inx.INX_Liste
 	closure := events.NewClosure(func(receipt *iotago.ReceiptMilestoneOpt) {
 		wp.Submit(receipt)
 	})
+
 	wp.Start()
 	deps.Tangle.Events.NewReceipt.Hook(closure)
 	<-ctx.Done()

--- a/plugins/restapi/route_manager.go
+++ b/plugins/restapi/route_manager.go
@@ -43,6 +43,7 @@ func (p *RestRouteManager) AddRoute(route string) *echo.Group {
 	if !found {
 		p.routes = append(p.routes, route)
 	}
+
 	// existing groups get overwritten (necessary if last plugin was not cleaned up properly)
 	return p.proxy.AddGroup(route)
 }
@@ -63,6 +64,7 @@ func (p *RestRouteManager) AddProxyRoute(route string, host string, port uint32)
 	if !found {
 		p.routes = append(p.routes, route)
 	}
+
 	// existing proxies get overwritten (necessary if last plugin was not cleaned up properly)
 	return p.proxy.AddReverseProxy(route, host, port)
 }


### PR DESCRIPTION
This PR fixes some linter warnings where "magic strings" are reused several times in the code (e.g. CoordinatorAddress in test cases etc).

It also improves the code readability by adding some newlines.