### PR TITLE
Add linter ignore rules in the code

### DIFF
--- a/integration-tests/tester/framework/config.go
+++ b/integration-tests/tester/framework/config.go
@@ -1,3 +1,4 @@
+//nolint:forcetypeassert // we don't care about type assertions in tests
 package framework
 
 import (

--- a/integration-tests/tester/framework/network.go
+++ b/integration-tests/tester/framework/network.go
@@ -354,6 +354,7 @@ func (n *Network) Shutdown() error {
 
 // RandomNode returns a random peer out of the list of peers.
 func (n *Network) RandomNode() *Node {
+	//nolint:gosec // we do not care about weak random numbers here
 	return n.Nodes[rand.Intn(len(n.Nodes))]
 }
 

--- a/integration-tests/tester/framework/visualizer_test.go
+++ b/integration-tests/tester/framework/visualizer_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec // we do not care about weak random numbers here
 package framework
 
 import (

--- a/integration-tests/tester/tests/migration/migration_test.go
+++ b/integration-tests/tester/tests/migration/migration_test.go
@@ -1,3 +1,4 @@
+//nolint:forcetypeassert // we don't care about type assertions in tests
 package migration
 
 import (

--- a/integration-tests/tester/tests/snapshot/snapshot_test.go
+++ b/integration-tests/tester/tests/snapshot/snapshot_test.go
@@ -1,3 +1,4 @@
+//nolint:forcetypeassert // we don't care about type assertions in tests
 package snapshot
 
 import (

--- a/integration-tests/tester/tests/value/value_test.go
+++ b/integration-tests/tester/tests/value/value_test.go
@@ -1,3 +1,4 @@
+//nolint:forcetypeassert // we don't care about type assertions in tests
 package value
 
 import (

--- a/pkg/dag/concurrent_parents_traverser.go
+++ b/pkg/dag/concurrent_parents_traverser.go
@@ -190,14 +190,12 @@ func (t *ConcurrentParentsTraverser) Traverse(ctx context.Context, parents iotag
 func (t *ConcurrentParentsTraverser) processStack(doneChan chan struct{}, errChan chan error) {
 
 	wasProcessed := func(blockID iotago.BlockID) bool {
-
 		_, wasProcessed := t.processed.Load(blockID)
 
 		return wasProcessed
 	}
 
 	markAsProcessed := func(blockID iotago.BlockID) bool {
-
 		_, wasProcessed := t.processed.LoadOrStore(blockID, struct{}{})
 
 		return wasProcessed
@@ -313,7 +311,6 @@ func (t *ConcurrentParentsTraverser) processStack(doneChan chan struct{}, errCha
 				if errors.Is(err, ErrTraversalDone) {
 					return
 				}
-
 				errChan <- err
 
 				return

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -54,6 +54,7 @@ func (c *DatabaseCleanup) MarshalJSON() ([]byte, error) {
 }
 
 func DatabaseCleanupCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*DatabaseCleanup))(params[0].(*DatabaseCleanup))
 }
 

--- a/pkg/database/engine.go
+++ b/pkg/database/engine.go
@@ -142,7 +142,7 @@ func CheckDatabaseEngine(dbPath string, createDatabaseIfNotExists bool, dbEngine
 		if dbEngineSpecified {
 
 			if dbEngineFromInfoFile != dbEngine[0] {
-				//lint:ignore ST1005 this error message is shown to the user
+				//nolint:stylecheck // this error message is shown to the user
 				return EngineUnknown, fmt.Errorf(`database (%s) engine does not match the configuration: '%v' != '%v'
 
 If you want to use another database engine, you can use the tool './hornet tool db-migration' to convert the current database.`, dbPath, dbEngineFromInfoFile, dbEngine[0])

--- a/pkg/metrics/restapi_metrics.go
+++ b/pkg/metrics/restapi_metrics.go
@@ -9,6 +9,7 @@ import (
 )
 
 func PoWCompletedCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(blockSize int, duration time.Duration))(params[0].(int), params[1].(time.Duration))
 }
 

--- a/pkg/model/storage/blocks_memcache.go
+++ b/pkg/model/storage/blocks_memcache.go
@@ -41,6 +41,7 @@ func (c *BlocksMemcache) CachedBlock(blockID iotago.BlockID) (*CachedBlock, erro
 			return nil, err
 		}
 		if cachedBlock == nil {
+			//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 			return nil, nil
 		}
 

--- a/pkg/model/storage/blocks_storage.go
+++ b/pkg/model/storage/blocks_storage.go
@@ -11,22 +11,27 @@ import (
 )
 
 func BlockCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(cachedBlock *CachedBlock))(params[0].(*CachedBlock).Retain()) // block pass +1
 }
 
 func BlockMetadataCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(cachedBlockMeta *CachedMetadata))(params[0].(*CachedMetadata).Retain()) // block pass +1
 }
 
 func BlockIDCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(blockID iotago.BlockID))(params[0].(iotago.BlockID))
 }
 
 func NewBlockCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(cachedBlock *CachedBlock, latestMilestoneIndex iotago.MilestoneIndex, confirmedMilestoneIndex iotago.MilestoneIndex))(params[0].(*CachedBlock).Retain(), params[1].(iotago.MilestoneIndex), params[2].(iotago.MilestoneIndex)) // block pass +1
 }
 
 func BlockReferencedCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(cachedBlockMeta *CachedMetadata, msIndex iotago.MilestoneIndex, confTime uint32))(params[0].(*CachedMetadata).Retain(), params[1].(iotago.MilestoneIndex), params[2].(uint32)) // block pass +1
 }
 
@@ -75,6 +80,7 @@ func (cachedBlocks CachedBlocks) Release(force ...bool) {
 
 // Block retrieves the block, that is cached in this container.
 func (c *CachedBlock) Block() *Block {
+	//nolint:forcetypeassert // we will replace that with generics anyway
 	return c.block.Get().(*Block)
 }
 
@@ -86,11 +92,13 @@ func (c *CachedBlock) CachedMetadata() *CachedMetadata {
 
 // Metadata retrieves the metadata, that is cached in this container.
 func (c *CachedBlock) Metadata() *BlockMetadata {
+	//nolint:forcetypeassert // we will replace that with generics anyway
 	return c.metadata.Get().(*BlockMetadata)
 }
 
 // Metadata retrieves the metadata, that is cached in this container.
 func (c *CachedMetadata) Metadata() *BlockMetadata {
+	//nolint:forcetypeassert // we will replace that with generics anyway
 	return c.Get().(*BlockMetadata)
 }
 
@@ -122,6 +130,7 @@ func (c *CachedBlock) ConsumeBlockAndMetadata(consumer func(*Block, *BlockMetada
 
 	c.block.Consume(func(txObject objectstorage.StorableObject) { // block -1
 		c.metadata.Consume(func(metadataObject objectstorage.StorableObject) { // meta -1
+			//nolint:forcetypeassert // we will replace that with generics anyway
 			consumer(txObject.(*Block), metadataObject.(*BlockMetadata))
 		}, true)
 	}, true)
@@ -133,6 +142,7 @@ func (c *CachedBlock) ConsumeBlockAndMetadata(consumer func(*Block, *BlockMetada
 func (c *CachedBlock) ConsumeBlock(consumer func(*Block)) {
 	defer c.metadata.Release(true)                              // meta -1
 	c.block.Consume(func(object objectstorage.StorableObject) { // block -1
+		//nolint:forcetypeassert // we will replace that with generics anyway
 		consumer(object.(*Block))
 	}, true)
 }
@@ -143,6 +153,7 @@ func (c *CachedBlock) ConsumeBlock(consumer func(*Block)) {
 func (c *CachedBlock) ConsumeMetadata(consumer func(*BlockMetadata)) {
 	defer c.block.Release(true)                                    // block -1
 	c.metadata.Consume(func(object objectstorage.StorableObject) { // meta -1
+		//nolint:forcetypeassert // we will replace that with generics anyway
 		consumer(object.(*BlockMetadata))
 	}, true)
 }
@@ -151,6 +162,7 @@ func (c *CachedBlock) ConsumeMetadata(consumer func(*BlockMetadata)) {
 // meta -1.
 func (c *CachedMetadata) ConsumeMetadata(consumer func(*BlockMetadata)) {
 	c.Consume(func(object objectstorage.StorableObject) { // meta -1
+		//nolint:forcetypeassert // we will replace that with generics anyway
 		consumer(object.(*BlockMetadata))
 	}, true)
 }
@@ -270,6 +282,7 @@ func (s *Storage) Block(blockID iotago.BlockID) (*iotago.Block, error) {
 	}
 
 	if cachedBlock == nil {
+		//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 		return nil, nil
 	}
 
@@ -304,6 +317,7 @@ func (s *Storage) StoredMetadataOrNil(blockID iotago.BlockID) *BlockMetadata {
 		return nil
 	}
 
+	//nolint:forcetypeassert // we will replace that with generics anyway
 	return storedMeta.(*BlockMetadata)
 }
 

--- a/pkg/model/storage/children_storage.go
+++ b/pkg/model/storage/children_storage.go
@@ -43,6 +43,7 @@ func (c *CachedChild) Retain() *CachedChild {
 
 // Child retrieves the child, that is cached in this container.
 func (c *CachedChild) Child() *Child {
+	//nolint:forcetypeassert // we will replace that with generics anyway
 	return c.Get().(*Child)
 }
 

--- a/pkg/model/storage/metadata_memcache.go
+++ b/pkg/model/storage/metadata_memcache.go
@@ -41,6 +41,7 @@ func (c *MetadataMemcache) CachedBlockMetadata(blockID iotago.BlockID) (*CachedM
 			return nil, err
 		}
 		if cachedBlockMeta == nil {
+			//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 			return nil, nil
 		}
 

--- a/pkg/model/storage/milestones.go
+++ b/pkg/model/storage/milestones.go
@@ -3,13 +3,16 @@ package storage
 import iotago "github.com/iotaledger/iota.go/v3"
 
 func MilestoneCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(cachedMilestone *CachedMilestone))(params[0].(*CachedMilestone).Retain()) // milestone pass +1
 }
 
 func MilestoneIndexCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(index iotago.MilestoneIndex))(params[0].(iotago.MilestoneIndex))
 }
 
 func MilestoneWithBlockIDAndRequestedCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(blockID iotago.BlockID, cachedMilestone *CachedMilestone, requested bool))(params[0].(iotago.BlockID), params[1].(*CachedMilestone).Retain(), params[2].(bool)) // milestone pass +1
 }

--- a/pkg/model/storage/milestones_storage.go
+++ b/pkg/model/storage/milestones_storage.go
@@ -202,6 +202,7 @@ func (c *cachedMilestoneIndex) Retain() *cachedMilestoneIndex {
 
 // MilestoneIndex retrieves the milestone index, that is cached in this container.
 func (c *cachedMilestoneIndex) MilestoneIndex() *MilestoneIndex {
+	//nolint:forcetypeassert // we will replace that with generics anyway
 	return c.Get().(*MilestoneIndex)
 }
 
@@ -376,6 +377,7 @@ func (c *CachedMilestone) Retain() *CachedMilestone {
 
 // Milestone retrieves the milestone, that is cached in this container.
 func (c *CachedMilestone) Milestone() *Milestone {
+	//nolint:forcetypeassert // we will replace that with generics anyway
 	return c.Get().(*Milestone)
 }
 
@@ -522,7 +524,6 @@ func (s *Storage) StoreMilestoneIfAbsent(milestonePayload *iotago.Milestone, blo
 }
 
 // DeleteMilestone deletes the milestone in the cache/persistence layer.
-// +-0.
 func (s *Storage) DeleteMilestone(milestoneIndex iotago.MilestoneIndex) {
 	cachedMilestoneIdx := s.cachedMilestoneIndexOrNil(milestoneIndex) // milestone index +1
 	if cachedMilestoneIdx == nil {

--- a/pkg/model/storage/snapshot_db.go
+++ b/pkg/model/storage/snapshot_db.go
@@ -51,6 +51,7 @@ func (s *Storage) readSnapshotInfo() (*SnapshotInfo, error) {
 			return nil, errors.Wrap(NewDatabaseError(err), "failed to retrieve snapshot info")
 		}
 
+		//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 		return nil, nil
 	}
 
@@ -82,6 +83,7 @@ func (s *Storage) readSolidEntryPoints() (*SolidEntryPoints, error) {
 			return nil, errors.Wrap(NewDatabaseError(err), "failed to retrieve solid entry points")
 		}
 
+		//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 		return nil, nil
 	}
 

--- a/pkg/model/storage/storage.go
+++ b/pkg/model/storage/storage.go
@@ -181,6 +181,8 @@ func (s *Storage) SolidEntryPoints() *SolidEntryPoints {
 }
 
 // profileCachesDisabled returns a Caches profile with caching disabled.
+//
+//lint:ignore U1000 used for easier debugging
 func (s *Storage) profileCachesDisabled() *profile.Caches {
 	return &profile.Caches{
 		Addresses: &profile.CacheOpts{

--- a/pkg/model/storage/test/protocol_storage_test.go
+++ b/pkg/model/storage/test/protocol_storage_test.go
@@ -1,6 +1,5 @@
+//nolint:stylecheck // we do not care about the underlines in the test
 package storage_test
-
-//lint:file-ignore ST1003 we do not care about the underlines in the test
 
 import (
 	"testing"

--- a/pkg/model/storage/unreferenced_blocks_storage.go
+++ b/pkg/model/storage/unreferenced_blocks_storage.go
@@ -27,6 +27,7 @@ func (cachedUnreferencedBlocks CachedUnreferencedBlocks) Release(force ...bool) 
 
 // UnreferencedBlock retrieves the unreferenced block, that is cached in this container.
 func (c *CachedUnreferencedBlock) UnreferencedBlock() *UnreferencedBlock {
+	//nolint:forcetypeassert // we will replace that with generics anyway
 	return c.Get().(*UnreferencedBlock)
 }
 

--- a/pkg/model/utxo/test/output_test.go
+++ b/pkg/model/utxo/test/output_test.go
@@ -1,3 +1,4 @@
+//nolint:forcetypeassert // we don't care about type assertions in tests
 package utxo_test
 
 import (

--- a/pkg/p2p/autopeering/autopeering.go
+++ b/pkg/p2p/autopeering/autopeering.go
@@ -261,6 +261,7 @@ func ConvertLibP2PPrivateKeyToHive(key *crypto.Ed25519PrivateKey) (*ed25519.Priv
 // example: /ip4/127.0.0.1/udp/14626/autopeering/HmKTkSd9F6nnERBvVbr55FvL1hM5WfcLvsc9bc3hWxWc
 func parseEntryNode(entryNodeMultiAddrStr string, preferIPv6 bool) (entryNode *peer.Peer, err error) {
 	if entryNodeMultiAddrStr == "" {
+		//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 		return nil, nil
 	}
 
@@ -324,7 +325,6 @@ func NewAutopeeringManager(log *logger.Logger, bindAddress string, entryNodes []
 		discoveryProtocol:  nil,
 		selectionProtocol:  nil,
 	}
-
 }
 
 // P2PServiceKey is the peering service key.

--- a/pkg/p2p/manager.go
+++ b/pkg/p2p/manager.go
@@ -100,11 +100,13 @@ type ManagerEvents struct {
 
 // PeerCaller gets called with a Peer.
 func PeerCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*Peer))(params[0].(*Peer))
 }
 
 // PeerIDCaller gets called with a peer.ID.
 func PeerIDCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(peer.ID))(params[0].(peer.ID))
 }
 
@@ -116,26 +118,31 @@ type PeerOptError struct {
 
 // PeerOptErrorCaller gets called with a Peer and an error.
 func PeerOptErrorCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*PeerOptError))(params[0].(*PeerOptError))
 }
 
 // ManagerStateCaller gets called with a ManagerState.
 func ManagerStateCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(ManagerState))(params[0].(ManagerState))
 }
 
 // PeerDurationCaller gets called with a Peer and a time.Duration.
 func PeerDurationCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*Peer, time.Duration))(params[0].(*Peer), params[1].(time.Duration))
 }
 
 // PeerConnCaller gets called with a Peer and its associated network.Conn.
 func PeerConnCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*Peer, network.Conn))(params[0].(*Peer), params[1].(network.Conn))
 }
 
 // PeerRelationCaller gets called with a Peer and its old PeerRelation.
 func PeerRelationCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(p *Peer, old PeerRelation))(params[0].(*Peer), params[1].(PeerRelation))
 }
 
@@ -184,6 +191,7 @@ func (mo *ManagerOptions) apply(opts ...ManagerOption) {
 func (mo *ManagerOptions) reconnectDelay() time.Duration {
 	recInter := mo.reconnectInterval
 	jitter := mo.reconnectIntervalJitter
+	//nolint:gosec // we do not care about weak random numbers here
 	delayJitter := rand.Int63n(int64(jitter))
 
 	return recInter + time.Duration(delayJitter)

--- a/pkg/protocol/gossip/msg_proc.go
+++ b/pkg/protocol/gossip/msg_proc.go
@@ -37,6 +37,7 @@ var (
 )
 
 func BlockProcessedCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(block *storage.Block, requests Requests, proto *Protocol))(params[0].(*storage.Block), params[1].(Requests), params[2].(*Protocol))
 }
 
@@ -49,6 +50,7 @@ type Broadcast struct {
 }
 
 func BroadcastCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(b *Broadcast))(params[0].(*Broadcast))
 }
 

--- a/pkg/protocol/gossip/service.go
+++ b/pkg/protocol/gossip/service.go
@@ -35,11 +35,13 @@ type ServiceEvents struct {
 
 // ProtocolCaller gets called with a Protocol.
 func ProtocolCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*Protocol))(params[0].(*Protocol))
 }
 
 // StreamCancelCaller gets called with a network.Stream and its cancel reason.
 func StreamCancelCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(network.Stream, StreamCancelReason))(params[0].(network.Stream), params[1].(StreamCancelReason))
 }
 

--- a/pkg/protocol/gossip/sting.go
+++ b/pkg/protocol/gossip/sting.go
@@ -175,5 +175,6 @@ func ParseHeartbeat(data []byte) *Heartbeat {
 }
 
 func heartbeatCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(heartbeat *Heartbeat))(params[0].(*Heartbeat))
 }

--- a/pkg/protocol/gossip/warpsync.go
+++ b/pkg/protocol/gossip/warpsync.go
@@ -39,18 +39,22 @@ func NewWarpSync(advRange int, advanceCheckpointCriteriaFunc ...AdvanceCheckpoin
 }
 
 func SyncStartCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(target iotago.MilestoneIndex, newCheckpoint iotago.MilestoneIndex, msRange syncmanager.MilestoneIndexDelta))(params[0].(iotago.MilestoneIndex), params[1].(iotago.MilestoneIndex), params[2].(syncmanager.MilestoneIndexDelta))
 }
 
 func SyncDoneCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(delta int, referencedBlocksTotal int, dur time.Duration))(params[0].(int), params[1].(int), params[2].(time.Duration))
 }
 
 func CheckpointCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(newCheckpoint iotago.MilestoneIndex, oldCheckpoint iotago.MilestoneIndex, msRange syncmanager.MilestoneIndexDelta, target iotago.MilestoneIndex))(params[0].(iotago.MilestoneIndex), params[1].(iotago.MilestoneIndex), params[2].(syncmanager.MilestoneIndexDelta), params[3].(iotago.MilestoneIndex))
 }
 
 func TargetCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(checkpoint iotago.MilestoneIndex, target iotago.MilestoneIndex))(params[0].(iotago.MilestoneIndex), params[1].(iotago.MilestoneIndex))
 }
 

--- a/pkg/protocol/gossip/work_unit.go
+++ b/pkg/protocol/gossip/work_unit.go
@@ -37,6 +37,7 @@ type CachedWorkUnit struct {
 
 // WorkUnit retrieves the work unit, that is cached in this container.
 func (c *CachedWorkUnit) WorkUnit() *WorkUnit {
+	//nolint:forcetypeassert // we will replace that with generics anyway
 	return c.Get().(*WorkUnit)
 }
 

--- a/pkg/protocol/protocol_manager.go
+++ b/pkg/protocol/protocol_manager.go
@@ -11,6 +11,7 @@ import (
 )
 
 func protoParamsMsOptionCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(protoParamsMsOption *iotago.ProtocolParamsMilestoneOpt))(params[0].(*iotago.ProtocolParamsMilestoneOpt))
 }
 
@@ -102,6 +103,7 @@ func (m *Manager) Pending() []*iotago.ProtocolParamsMilestoneOpt {
 
 	cpy := make([]*iotago.ProtocolParamsMilestoneOpt, len(m.pending))
 	for i, ele := range m.pending {
+		//nolint:forcetypeassert // we will replace that with generics anyway
 		cpy[i] = ele.Clone().(*iotago.ProtocolParamsMilestoneOpt)
 	}
 

--- a/pkg/pruning/events.go
+++ b/pkg/pruning/events.go
@@ -6,6 +6,7 @@ import (
 
 // PruningMetricsCaller is used to signal updated pruning metrics.
 func PruningMetricsCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(metrics *PruningMetrics))(params[0].(*PruningMetrics))
 }
 

--- a/pkg/snapshot/events.go
+++ b/pkg/snapshot/events.go
@@ -6,6 +6,7 @@ import (
 
 // SnapshotMetricsCaller is used to signal updated snapshot metrics.
 func SnapshotMetricsCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(metrics *SnapshotMetrics))(params[0].(*SnapshotMetrics))
 }
 

--- a/pkg/snapshot/snapshot_write.go
+++ b/pkg/snapshot/snapshot_write.go
@@ -870,6 +870,7 @@ func CreateSnapshotFromStorage(
 
 	milestoneDiffProducer := func() (*MilestoneDiff, error) {
 		// we won't have any ms diffs within this merged full snapshot file
+		//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 		return nil, nil
 	}
 

--- a/pkg/snapshot/test/snapshot_file_test.go
+++ b/pkg/snapshot/test/snapshot_file_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec // we do not care about weak random numbers here
 package snapshot_test
 
 import (

--- a/pkg/tangle/events.go
+++ b/pkg/tangle/events.go
@@ -15,26 +15,32 @@ type BPSMetrics struct {
 
 // ConfirmationMetricsCaller is used to signal updated confirmation metrics.
 func ConfirmationMetricsCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(metrics *whiteflag.ConfirmationMetrics))(params[0].(*whiteflag.ConfirmationMetrics))
 }
 
 func BPSMetricsCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*BPSMetrics))(params[0].(*BPSMetrics))
 }
 
 func LedgerUpdatedCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(iotago.MilestoneIndex, utxo.Outputs, utxo.Spents))(params[0].(iotago.MilestoneIndex), params[1].(utxo.Outputs), params[2].(utxo.Spents))
 }
 
 func TreasuryMutationCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(iotago.MilestoneIndex, *utxo.TreasuryMutationTuple))(params[0].(iotago.MilestoneIndex), params[1].(*utxo.TreasuryMutationTuple))
 }
 
 func ReceiptCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*iotago.ReceiptMilestoneOpt))(params[0].(*iotago.ReceiptMilestoneOpt))
 }
 
 func ReferencedBlocksCountUpdatedCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(msIndex iotago.MilestoneIndex, referencedBlocksCount int))(params[0].(iotago.MilestoneIndex), params[1].(int))
 }
 

--- a/pkg/tangle/tangle_processor.go
+++ b/pkg/tangle/tangle_processor.go
@@ -23,11 +23,13 @@ const (
 func (t *Tangle) ConfigureTangleProcessor() {
 
 	t.receiveBlockWorkerPool = workerpool.New(func(task workerpool.Task) {
+		//nolint:forcetypeassert // we will replace that with generics anyway
 		t.processIncomingTx(task.Param(0).(*storage.Block), task.Param(1).(gossip.Requests), task.Param(2).(*gossip.Protocol))
 		task.Return(nil)
 	}, workerpool.WorkerCount(t.receiveBlockWorkerCount), workerpool.QueueSize(t.receiveBlockQueueSize))
 
 	t.futureConeSolidifierWorkerPool = workerpool.New(func(task workerpool.Task) {
+		//nolint:forcetypeassert // we will replace that with generics anyway
 		if err := t.futureConeSolidifier.SolidifyBlockAndFutureCone(t.shutdownCtx, task.Param(0).(*storage.CachedMetadata)); err != nil {
 			t.LogDebugf("SolidifyBlockAndFutureCone failed: %s", err)
 		}
@@ -35,11 +37,13 @@ func (t *Tangle) ConfigureTangleProcessor() {
 	}, workerpool.WorkerCount(t.futureConeSolidifierWorkerCount), workerpool.QueueSize(t.futureConeSolidifierQueueSize), workerpool.FlushTasksAtShutdown(true))
 
 	t.processValidMilestoneWorkerPool = workerpool.New(func(task workerpool.Task) {
+		//nolint:forcetypeassert // we will replace that with generics anyway
 		t.processValidMilestone(task.Param(0).(iotago.BlockID), task.Param(1).(*storage.CachedMilestone), task.Param(2).(bool)) // milestone pass +1
 		task.Return(nil)
 	}, workerpool.WorkerCount(t.processValidMilestoneWorkerCount), workerpool.QueueSize(t.processValidMilestoneQueueSize), workerpool.FlushTasksAtShutdown(true))
 
 	t.milestoneSolidifierWorkerPool = workerpool.New(func(task workerpool.Task) {
+		//nolint:forcetypeassert // we will replace that with generics anyway
 		t.solidifyMilestone(task.Param(0).(iotago.MilestoneIndex), task.Param(1).(bool))
 		task.Return(nil)
 	}, workerpool.WorkerCount(t.milestoneSolidifierWorkerCount), workerpool.QueueSize(t.milestoneSolidifierQueueSize))

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -1,3 +1,4 @@
+//nolint:forcetypeassert // we don't care about type assertions in tests
 package testsuite
 
 import (

--- a/pkg/testsuite/test_environment.go
+++ b/pkg/testsuite/test_environment.go
@@ -1,3 +1,4 @@
+//nolint:forcetypeassert,gosec // we don't care about type assertions and weak random numbers in tests
 package testsuite
 
 import (

--- a/pkg/testsuite/utils.go
+++ b/pkg/testsuite/utils.go
@@ -1,3 +1,4 @@
+//nolint:forcetypeassert // we don't care about type assertions in tests
 package testsuite
 
 import (

--- a/pkg/testsuite/utils/dot_file.go
+++ b/pkg/testsuite/utils/dot_file.go
@@ -57,6 +57,7 @@ func ShortenedTag(cachedBlock *storage.CachedBlock) string {
 // ShowDotFile creates a png file with dot and shows it in an external application.
 func ShowDotFile(testInterface testing.TB, dotCommand string, outFilePath string) {
 
+	//nolint:gosec // we control the input, no vulnerabilities here
 	cmd := exec.Command("dot", "-Tpng", "-o"+outFilePath)
 
 	stdin, err := cmd.StdinPipe()

--- a/pkg/tipselect/random.go
+++ b/pkg/tipselect/random.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	//nolint:gosec // we do not care about weak random numbers here
 	seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 	randLock   = &syncutils.Mutex{}
 )

--- a/pkg/tipselect/urts.go
+++ b/pkg/tipselect/urts.go
@@ -32,11 +32,13 @@ type TipSelStats struct {
 
 // TipCaller is used to signal tip events.
 func TipCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*Tip))(params[0].(*Tip))
 }
 
 // WalkerStatsCaller is used to signal tip selection events.
 func WalkerStatsCaller(handler interface{}, params ...interface{}) {
+	//nolint:forcetypeassert // we will replace that with generic events anyway
 	handler.(func(*TipSelStats))(params[0].(*TipSelStats))
 }
 

--- a/pkg/toolset/database_merge.go
+++ b/pkg/toolset/database_merge.go
@@ -706,6 +706,7 @@ func (s *ProxyStorage) CachedBlockMetadata(blockID iotago.BlockID) (*storage.Cac
 		return nil, err
 	}
 	if cachedBlock == nil {
+		//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 		return nil, nil
 	}
 	defer cachedBlock.Release(true) // block -1

--- a/pkg/toolset/snap_gen.go
+++ b/pkg/toolset/snap_gen.go
@@ -272,6 +272,7 @@ func snapshotGen(args []string) error {
 
 			case remainingAmount == 0:
 				// no genesis output needed, all balances distributed
+				//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 				return nil, nil
 
 			default:
@@ -308,12 +309,14 @@ func snapshotGen(args []string) error {
 		}
 
 		// all outputs added
+		//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 		return nil, nil
 	}
 
 	// milestone diffs
 	milestoneDiffProducerFunc := func() (*snapshot.MilestoneDiff, error) {
 		// no milestone diffs needed
+		//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 		return nil, nil
 	}
 

--- a/pkg/tpkg/random.go
+++ b/pkg/tpkg/random.go
@@ -172,6 +172,7 @@ func RandOutputOnAddressWithAmount(outputType iotago.OutputType, address iotago.
 
 	switch outputType {
 	case iotago.OutputBasic:
+		//nolint:forcetypeassert // we already checked the type
 		iotaOutput = &iotago.BasicOutput{
 			Amount: amount,
 			Conditions: iotago.UnlockConditions{
@@ -181,6 +182,7 @@ func RandOutputOnAddressWithAmount(outputType iotago.OutputType, address iotago.
 			},
 		}
 	case iotago.OutputAlias:
+		//nolint:forcetypeassert // we already checked the type
 		iotaOutput = &iotago.AliasOutput{
 			Amount:  amount,
 			AliasID: RandAliasID(),
@@ -198,6 +200,8 @@ func RandOutputOnAddressWithAmount(outputType iotago.OutputType, address iotago.
 			panic("not an alias address")
 		}
 		supply := new(big.Int).SetUint64(RandAmount())
+
+		//nolint:forcetypeassert // we already checked the type
 		iotaOutput = &iotago.FoundryOutput{
 			Amount:       amount,
 			SerialNumber: 0,
@@ -213,6 +217,7 @@ func RandOutputOnAddressWithAmount(outputType iotago.OutputType, address iotago.
 			},
 		}
 	case iotago.OutputNFT:
+		//nolint:forcetypeassert // we already checked the type
 		iotaOutput = &iotago.NFTOutput{
 			Amount: amount,
 			NFTID:  RandNFTID(),

--- a/pkg/whiteflag/test/white_flag_test.go
+++ b/pkg/whiteflag/test/white_flag_test.go
@@ -1,3 +1,4 @@
+//nolint:forcetypeassert // we don't care about type assertions in tests
 package test
 
 import (

--- a/tools/intsnap/main.go
+++ b/tools/intsnap/main.go
@@ -131,6 +131,7 @@ func writeFullSnapshot() *snapshot.FullSnapshotHeader {
 	var currentOutput int
 	fullSnapOutputProd := func() (*utxo.Output, error) {
 		if currentOutput == len(fullSnapshotOutputs) {
+			//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 			return nil, nil
 		}
 		out := fullSnapshotOutputs[currentOutput]
@@ -142,6 +143,7 @@ func writeFullSnapshot() *snapshot.FullSnapshotHeader {
 	var currentMsDiff int
 	fullSnapMsDiffProd := func() (*snapshot.MilestoneDiff, error) {
 		if currentMsDiff == len(fullSnapshotMsDiffs) {
+			//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 			return nil, nil
 		}
 		msDiff := fullSnapshotMsDiffs[currentMsDiff]
@@ -250,6 +252,7 @@ func writeDeltaSnapshot(fullSnapshotHeader *snapshot.FullSnapshotHeader) {
 	var currentMsDiff int
 	deltaSnapMsDiffProd := func() (*snapshot.MilestoneDiff, error) {
 		if currentMsDiff == len(deltaSnapshotMsDiffs) {
+			//nolint:nilnil // nil, nil is ok in this context, even if it is not go idiomatic
 			return nil, nil
 		}
 		msDiff := deltaSnapshotMsDiffs[currentMsDiff]


### PR DESCRIPTION
This PR adds several magic lines with linter ignore directives.

The reason for this is that we want the linters to pass, but sometimes code readability is also important (especially in the test cases).
Another reason is, that we want to change the code with generics anyway. No need to introduce new bugs by changing the logic for type assertions in events now.