### PR TITLE
Remove chronicle compatibility mode in toolset

### DIFF
--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -60,10 +60,8 @@ const (
 	FlagToolSnapGenMintAddress        = "mintAddress"
 	FlagToolSnapGenTreasuryAllocation = "treasuryAllocation"
 
-	FlagToolDatabaseTargetIndex            = "targetIndex"
-	FlagToolDatabaseMergeNodeURL           = "nodeURL"
-	FlagToolDatabaseMergeChronicle         = "chronicleMode"
-	FlagToolDatabaseMergeChronicleKeyspace = "chronicleKeySpace"
+	FlagToolDatabaseTargetIndex  = "targetIndex"
+	FlagToolDatabaseMergeNodeURL = "nodeURL"
 )
 
 const (


### PR DESCRIPTION
The special chronicle mode is not necessary anymore with the stardust API of chronicle.