### PR TITLE
Rename prometheus topics to fix linter warnings

### DIFF
--- a/plugins/prometheus/database.go
+++ b/plugins/prometheus/database.go
@@ -39,7 +39,7 @@ func configureStorage(storage *storage.Storage, metrics *metrics.StorageMetrics)
 		prometheus.CounterOpts{
 			Namespace: "iota",
 			Subsystem: "database",
-			Name:      "pruning_count",
+			Name:      "pruning_count_total",
 			Help:      "The total amount of database prunings.",
 		},
 	)
@@ -90,7 +90,7 @@ func configureDatabase(name string, db *database.Database) {
 		prometheus.CounterOpts{
 			Namespace: "iota",
 			Subsystem: "database",
-			Name:      fmt.Sprintf("%s_compaction_count", name),
+			Name:      fmt.Sprintf("%s_compaction_count_total", name),
 			Help:      fmt.Sprintf("The total amount of %s database compactions.", name),
 		},
 	)

--- a/plugins/prometheus/debug.go
+++ b/plugins/prometheus/debug.go
@@ -34,7 +34,7 @@ func configureDebug() {
 		prometheus.HistogramOpts{
 			Namespace: "iota",
 			Subsystem: "debug",
-			Name:      "snapshot_duration_total",
+			Name:      "snapshot_duration",
 			Help:      "Total duration for snapshot creation [s].",
 			Buckets:   snapshotBuckets,
 		})
@@ -53,7 +53,7 @@ func configureDebug() {
 		prometheus.HistogramOpts{
 			Namespace: "iota",
 			Subsystem: "debug",
-			Name:      "pruning_duration_total",
+			Name:      "pruning_duration",
 			Help:      "Total duration for database pruning [s].",
 			Buckets:   pruningBuckets,
 		})
@@ -72,7 +72,7 @@ func configureDebug() {
 		prometheus.HistogramOpts{
 			Namespace: "iota",
 			Subsystem: "debug",
-			Name:      "confirmation_duration_total",
+			Name:      "confirmation_duration",
 			Help:      "Total duration for milestone confirmation [s].",
 			Buckets:   confirmationBuckets,
 		})

--- a/plugins/prometheus/gossip_node.go
+++ b/plugins/prometheus/gossip_node.go
@@ -16,7 +16,7 @@ func configureGossipNode() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "gossip_node",
-			Name:      "block_count",
+			Name:      "blocks",
 			Help:      "Number of blocks.",
 		},
 		[]string{"type"},
@@ -26,7 +26,7 @@ func configureGossipNode() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "gossip_node",
-			Name:      "request_count",
+			Name:      "requests",
 			Help:      "Number of requests.",
 		},
 		[]string{"type"},
@@ -36,7 +36,7 @@ func configureGossipNode() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "gossip_node",
-			Name:      "heartbeat_count",
+			Name:      "heartbeats",
 			Help:      "Number of heartbeats.",
 		},
 		[]string{"type"},
@@ -46,7 +46,7 @@ func configureGossipNode() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "gossip_node",
-			Name:      "dropped_count",
+			Name:      "dropped_packets",
 			Help:      "Number of dropped packets.",
 		},
 		[]string{"type"},

--- a/plugins/prometheus/gossip_peers.go
+++ b/plugins/prometheus/gossip_peers.go
@@ -18,7 +18,7 @@ func configureGossipPeers() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "gossip_peers",
-			Name:      "block_count",
+			Name:      "blocks",
 			Help:      "Number of blocks by peer.",
 		},
 		[]string{"address", "alias", "id", "type"},
@@ -28,7 +28,7 @@ func configureGossipPeers() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "gossip_peers",
-			Name:      "request_count",
+			Name:      "requests",
 			Help:      "Number of requests by peer.",
 		},
 		[]string{"address", "alias", "id", "type"},
@@ -38,7 +38,7 @@ func configureGossipPeers() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "gossip_peers",
-			Name:      "heartbeat_count",
+			Name:      "heartbeats",
 			Help:      "Number of heartbeats by peer.",
 		},
 		[]string{"address", "alias", "id", "type"},
@@ -48,7 +48,7 @@ func configureGossipPeers() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "gossip_peers",
-			Name:      "dropped_count",
+			Name:      "dropped_packets",
 			Help:      "Number of dropped packets by peer.",
 		},
 		[]string{"address", "alias", "id", "type"},
@@ -58,7 +58,7 @@ func configureGossipPeers() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "gossip_peers",
-			Name:      "connected_count",
+			Name:      "connected_peers",
 			Help:      "Are peers connected?",
 		},
 		[]string{"address", "alias", "id"},

--- a/plugins/prometheus/inx.go
+++ b/plugins/prometheus/inx.go
@@ -20,7 +20,7 @@ func configureINX() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "inx",
-			Name:      "pow_count",
+			Name:      "pow_requests",
 			Help:      "The amount of completed INX PoW requests.",
 		},
 	)

--- a/plugins/prometheus/migrator.go
+++ b/plugins/prometheus/migrator.go
@@ -17,7 +17,7 @@ func configureReceipts() {
 		prometheus.CounterOpts{
 			Namespace: "iota",
 			Subsystem: "migrator",
-			Name:      "receipt_count",
+			Name:      "receipt_count_total",
 			Help:      "The count of encountered receipts.",
 		},
 	)
@@ -26,7 +26,7 @@ func configureReceipts() {
 		prometheus.CounterOpts{
 			Namespace: "iota",
 			Subsystem: "migrator",
-			Name:      "receipt_entries_applied_count",
+			Name:      "receipt_entries_applied_count_total",
 			Help:      "The count of migration entries applied through receipts.",
 		},
 	)

--- a/plugins/prometheus/node.go
+++ b/plugins/prometheus/node.go
@@ -74,7 +74,7 @@ func configureNode() {
 			prometheus.GaugeOpts{
 				Namespace: "iota",
 				Subsystem: "node",
-				Name:      "tip_count",
+				Name:      "tips",
 				Help:      "Number of tips.",
 			}, []string{"type"},
 		)
@@ -84,7 +84,7 @@ func configureNode() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "node",
-			Name:      "request_count",
+			Name:      "block_requests",
 			Help:      "Number of blocks to request.",
 		}, []string{"type"},
 	)

--- a/plugins/prometheus/rest_api.go
+++ b/plugins/prometheus/rest_api.go
@@ -22,7 +22,7 @@ func configureRestAPI() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "restapi",
-			Name:      "http_request_error_count",
+			Name:      "http_request_errors",
 			Help:      "The amount of encountered HTTP request errors.",
 		},
 	)
@@ -31,7 +31,7 @@ func configureRestAPI() {
 		prometheus.GaugeOpts{
 			Namespace: "iota",
 			Subsystem: "restapi",
-			Name:      "pow_count",
+			Name:      "pow_requests",
 			Help:      "The amount of completed REST API PoW requests.",
 		},
 	)


### PR DESCRIPTION
Although this is a breaking change, we should rename our topics to match certain standards for prometheus.

This PR fixes all the prometheus linter warnings.