### PR TITLE
Fix forcetypeassert linter warnings

### DIFF
--- a/pkg/dag/children_traverser.go
+++ b/pkg/dag/children_traverser.go
@@ -3,6 +3,7 @@ package dag
 import (
 	"container/list"
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -93,7 +94,10 @@ func (t *ChildrenTraverser) processStackChildren() error {
 
 	// load candidate block
 	ele := t.stack.Front()
-	currentBlockID := ele.Value.(iotago.BlockID)
+	currentBlockID, ok := ele.Value.(iotago.BlockID)
+	if !ok {
+		return fmt.Errorf("expected iotago.BlockID, got %T", ele.Value)
+	}
 
 	// remove the block from the stack
 	t.stack.Remove(ele)

--- a/pkg/dag/parents_traverser.go
+++ b/pkg/dag/parents_traverser.go
@@ -110,7 +110,10 @@ func (t *ParentsTraverser) processStackParents() error {
 
 	// load candidate block
 	ele := t.stack.Front()
-	currentBlockID := ele.Value.(iotago.BlockID)
+	currentBlockID, ok := ele.Value.(iotago.BlockID)
+	if !ok {
+		return fmt.Errorf("expected iotago.BlockID, got %T", ele.Value)
+	}
 
 	if _, wasProcessed := t.processed[currentBlockID]; wasProcessed {
 		// block was already processed

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -89,7 +89,10 @@ func (j *JWTAuth) Middleware(skipper middleware.Skipper, allow func(c echo.Conte
 				return err
 			}
 
-			token := c.Get("jwt").(*jwt.Token)
+			token, ok := c.Get("jwt").(*jwt.Token)
+			if !ok {
+				return fmt.Errorf("expected *jwt.Token, got %T", c.Get("jwt"))
+			}
 
 			// validate the signing method we expect
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {

--- a/pkg/protocol/gossip/msg_proc.go
+++ b/pkg/protocol/gossip/msg_proc.go
@@ -152,10 +152,23 @@ func NewMessageProcessor(
 	)
 
 	proc.wp = workerpool.New(func(task workerpool.Task) {
-		p := task.Param(0).(*Protocol)
-		data := task.Param(2).([]byte)
 
-		switch task.Param(1).(message.Type) {
+		p, ok := task.Param(0).(*Protocol)
+		if !ok {
+			panic(fmt.Sprintf("invalid type: expected *Protocol, got %T", task.Param(0)))
+		}
+
+		data, ok := task.Param(2).([]byte)
+		if !ok {
+			panic(fmt.Sprintf("invalid type: expected []byte, got %T", task.Param(2)))
+		}
+
+		msgType, ok := task.Param(1).(message.Type)
+		if !ok {
+			panic(fmt.Sprintf("invalid type: expected message.Type, got %T", task.Param(1)))
+		}
+
+		switch msgType {
 		case MessageTypeBlock:
 			proc.processBlockData(p, data)
 		case MessageTypeBlockRequest:

--- a/pkg/snapshot/snapshot_write.go
+++ b/pkg/snapshot/snapshot_write.go
@@ -117,7 +117,12 @@ func NewSEPsProducer(
 			return iotago.EmptyBlockID(), ErrNoMoreSEPToProduce
 		}
 
-		return obj.(iotago.BlockID), nil
+		blockID, ok := obj.(iotago.BlockID)
+		if !ok {
+			return iotago.EmptyBlockID(), fmt.Errorf("expected iotago.BlockID, got %T", obj)
+		}
+
+		return blockID, nil
 	}
 }
 
@@ -147,7 +152,12 @@ func NewCMIUTXOProducer(utxoManager *utxo.Manager) OutputProducerFunc {
 			return nil, err
 		}
 
-		return obj.(*utxo.Output), nil
+		output, ok := obj.(*utxo.Output)
+		if !ok {
+			return nil, fmt.Errorf("expected *utxo.Output, got %T", obj)
+		}
+
+		return output, nil
 	}
 }
 
@@ -264,7 +274,12 @@ func NewMsDiffsProducer(mrf MilestoneRetrieverFunc, utxoManager *utxo.Manager, d
 			return nil, err
 		}
 
-		return obj.(*MilestoneDiff), nil
+		msdiff, ok := obj.(*MilestoneDiff)
+		if !ok {
+			return nil, fmt.Errorf("expected *MilestoneDiff, got %T", obj)
+		}
+
+		return msdiff, nil
 	}
 }
 
@@ -689,7 +704,12 @@ func createFullSnapshotFromMergedSnapshotStorageState(dbStorage *storage.Storage
 			}
 			sepsCount++
 
-			return obj.(iotago.BlockID), nil
+			blockID, ok := obj.(iotago.BlockID)
+			if !ok {
+				return iotago.EmptyBlockID(), fmt.Errorf("expected iotago.BlockID, got %T", obj)
+			}
+
+			return blockID, nil
 		}
 	}()
 

--- a/pkg/toolset/network_bootstrap.go
+++ b/pkg/toolset/network_bootstrap.go
@@ -303,7 +303,10 @@ func createInitialMilestone(dbStorage *storage.Storage, signer signingprovider.M
 		return nil, fmt.Errorf("failed to create milestone: %w", err)
 	}
 
-	milestonePayload := milestoneBlock.Payload.(*iotago.Milestone)
+	milestonePayload, ok := milestoneBlock.Payload.(*iotago.Milestone)
+	if !ok {
+		return nil, fmt.Errorf("wrong milestone payload type: (expected *iotago.Milestone, got %T)", milestoneBlock.Payload)
+	}
 
 	milestoneID, err := milestonePayload.ID()
 	if err != nil {


### PR DESCRIPTION
This PR fixes parts of the code where type assertions are forced.
Instead of forcing them, we check if the correct type was passed.