### PR TITLE
Store additional peers on startup and fix peering.json ownership

### DIFF
--- a/core/p2p/component.go
+++ b/core/p2p/component.go
@@ -202,6 +202,7 @@ func provide(c *dig.Container) error {
 			applyAliases = false
 		}
 
+		peerAdded := false
 		for i, peerIDStr := range peerIDsStr {
 			multiAddr, err := multiaddr.NewMultiaddr(peerIDStr)
 			if err != nil {
@@ -216,9 +217,17 @@ func provide(c *dig.Container) error {
 			if err = p2pConfigManager.AddPeer(multiAddr, alias); err != nil {
 				CoreComponent.LogWarnf("unable to add peer to config manager %s: %s", peerIDStr, err)
 			}
+
+			peerAdded = true
 		}
 
 		p2pConfigManager.StoreOnChange(true)
+
+		if peerAdded {
+			if err := p2pConfigManager.Store(); err != nil {
+				CoreComponent.LogWarnf("failed to store peering config: %s", err)
+			}
+		}
 
 		return p2pConfigManager
 	}); err != nil {

--- a/plugins/coreapi/component.go
+++ b/plugins/coreapi/component.go
@@ -443,7 +443,7 @@ func configure() error {
 	})
 
 	routeGroup.POST(RoutePeers, func(c echo.Context) error {
-		resp, err := addPeer(c)
+		resp, err := addPeer(c, Plugin.Logger())
 		if err != nil {
 			return err
 		}

--- a/plugins/coreapi/peers.go
+++ b/plugins/coreapi/peers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 
+	"github.com/iotaledger/hive.go/core/logger"
 	"github.com/iotaledger/hornet/v2/pkg/p2p"
 	"github.com/iotaledger/hornet/v2/pkg/protocol/gossip"
 	"github.com/iotaledger/hornet/v2/pkg/restapi"
@@ -78,7 +79,7 @@ func listPeers(_ echo.Context) ([]*PeerResponse, error) {
 	return results, nil
 }
 
-func addPeer(c echo.Context) (*PeerResponse, error) {
+func addPeer(c echo.Context, logger *logger.Logger) (*PeerResponse, error) {
 
 	request := &addPeerRequest{}
 
@@ -110,7 +111,9 @@ func addPeer(c echo.Context) (*PeerResponse, error) {
 	}
 
 	// error is ignored because we don't care about the config here
-	_ = deps.PeeringConfigManager.AddPeer(multiAddr, alias)
+	if err := deps.PeeringConfigManager.AddPeer(multiAddr, alias); err != nil {
+		logger.Warn(err.Error())
+	}
 
 	return WrapInfoSnapshot(info), nil
 }

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -31,6 +31,7 @@ mkdir -p testnet/participation
 mkdir -p testnet/dashboard
 if [[ "$OSTYPE" != "darwin"* ]]; then
   chown -R 65532:65532 testnet
+  chown 65532:65532 peering.json
 fi
 
 docker compose up $@


### PR DESCRIPTION
This PR fixes that peers that are added via CLI flags were not automatically stored to peering.json if they didn't exist yet.

It also fixes the file ownership of the peering.json if docker is used.