### PR TITLE
Fix new linter warnings (revive, contextcheck)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters-settings:
     gofmt:
         simplify: true
     goimports:
-        local-prefixes: github.com/gohornet,github.com/iotaledger
+        local-prefixes: github.com/iotaledger
     golint:
         min-confidence: 0.9
     gocyclo:

--- a/integration-tests/tester/framework/framework.go
+++ b/integration-tests/tester/framework/framework.go
@@ -170,6 +170,7 @@ func (f *Framework) CreateAutopeeredNetwork(name string, peerCount int, minimumP
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
 	if err := network.AwaitOnline(ctx); err != nil {
 		return nil, err
 	}

--- a/integration-tests/tester/framework/network.go
+++ b/integration-tests/tester/framework/network.go
@@ -58,7 +58,12 @@ func (n *Network) AwaitOnline(ctx context.Context) error {
 				return err
 			}
 
-			if _, err := node.DebugNodeAPIClient.Info(context.Background()); err != nil {
+			ctxInfo, ctxInfoCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+			defer ctxInfoCancel()
+
+			if _, err := node.DebugNodeAPIClient.Info(ctxInfo); err != nil {
+				time.Sleep(500 * time.Millisecond)
+
 				continue
 			}
 
@@ -78,14 +83,21 @@ func (n *Network) AwaitAllSync(ctx context.Context) error {
 				return err
 			}
 
-			info, err := node.DebugNodeAPIClient.Info(context.Background())
+			ctxInfo, ctxInfoCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+			defer ctxInfoCancel()
+
+			info, err := node.DebugNodeAPIClient.Info(ctxInfo)
 			if err != nil {
+				time.Sleep(500 * time.Millisecond)
+
 				continue
 			}
 
 			if info.Status.IsHealthy {
 				break
 			}
+
+			time.Sleep(500 * time.Millisecond)
 		}
 	}
 
@@ -354,7 +366,7 @@ func (n *Network) Shutdown() error {
 
 // RandomNode returns a random peer out of the list of peers.
 func (n *Network) RandomNode() *Node {
-	//nolint:gosec // we do not care about weak random numbers here
+	//nolint:gosec // we don't care about weak random numbers here
 	return n.Nodes[rand.Intn(len(n.Nodes))]
 }
 

--- a/integration-tests/tester/tests/autopeering/autopeering_test.go
+++ b/integration-tests/tester/tests/autopeering/autopeering_test.go
@@ -24,5 +24,6 @@ func TestAutopeering(t *testing.T) {
 
 	syncCtx, syncCtxCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer syncCtxCancel()
+
 	assert.NoError(t, n.AwaitAllSync(syncCtx))
 }

--- a/integration-tests/tester/tests/common/common_test.go
+++ b/integration-tests/tester/tests/common/common_test.go
@@ -21,5 +21,6 @@ func TestCommon(t *testing.T) {
 
 	syncCtx, syncCtxCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer syncCtxCancel()
+
 	assert.NoError(t, n.AwaitAllSync(syncCtx))
 }

--- a/integration-tests/tester/tests/migration/batch_test.go
+++ b/integration-tests/tester/tests/migration/batch_test.go
@@ -61,6 +61,7 @@ func TestBatch(t *testing.T) {
 
 	syncCtx, syncCtxCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer syncCtxCancel()
+
 	assert.NoError(t, n.AwaitAllSync(syncCtx))
 
 	// eventually all migrations should have happened

--- a/integration-tests/tester/tests/migration/migration_test.go
+++ b/integration-tests/tester/tests/migration/migration_test.go
@@ -72,6 +72,7 @@ func TestMigration(t *testing.T) {
 
 	syncCtx, syncCtxCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer syncCtxCancel()
+
 	assert.NoError(t, n.AwaitAllSync(syncCtx))
 
 	// eventually all migrations should have happened
@@ -154,5 +155,6 @@ func TestAPIError(t *testing.T) {
 
 	syncCtx, syncCtxCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer syncCtxCancel()
+
 	assert.NoError(t, n.AwaitAllSync(syncCtx))
 }

--- a/integration-tests/tester/tests/value/value_test.go
+++ b/integration-tests/tester/tests/value/value_test.go
@@ -26,6 +26,7 @@ func TestValue(t *testing.T) {
 
 	syncCtx, syncCtxCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer syncCtxCancel()
+
 	assert.NoError(t, n.AwaitAllSync(syncCtx))
 
 	infoRes, err := n.Coordinator().DebugNodeAPIClient.Info(context.Background())

--- a/pkg/dag/concurrent_parents_traverser.go
+++ b/pkg/dag/concurrent_parents_traverser.go
@@ -98,7 +98,7 @@ func (t *ConcurrentParentsTraverser) reset() {
 				return outbound
 			}
 
-			var out chan *iotago.BlockID = nil
+			var out chan *iotago.BlockID
 
 		inboundLoop:
 			for {
@@ -203,7 +203,7 @@ func (t *ConcurrentParentsTraverser) processStack(doneChan chan struct{}, errCha
 
 	// processStackParents checks if the current element in the stack must be processed or traversed.
 	// the logic in this walker is quite different.
-	// we do not walk in any order, we just process every
+	// we don't walk in any order, we just process every
 	// single block and traverse their parents afterwards.
 	processStackParents := func(currentBlockID iotago.BlockID) error {
 		if err := contextutils.ReturnErrIfCtxDone(t.ctx, common.ErrOperationAborted); err != nil {

--- a/pkg/model/utxo/snapshot.go
+++ b/pkg/model/utxo/snapshot.go
@@ -76,7 +76,7 @@ func (s *Spent) SnapshotBytes() []byte {
 	m := marshalutil.New()
 	m.WriteBytes(s.Output().SnapshotBytes())
 	m.WriteBytes(s.transactionIDSpent[:])
-	// we do not need to write msIndexSpent and msTimestampSpent because this info is available in the milestoneDiff that consumes the output
+	// we don't need to write msIndexSpent and msTimestampSpent because this info is available in the milestoneDiff that consumes the output
 	return m.Bytes()
 }
 

--- a/pkg/model/utxo/spent_status.go
+++ b/pkg/model/utxo/spent_status.go
@@ -14,9 +14,9 @@ type OutputIDConsumer func(outputID iotago.OutputID) bool
 // Returning false from this function indicates to abort the iteration.
 type OutputConsumer func(output *Output) bool
 
-type lookupKey []byte
+type LookupKey []byte
 
-func lookupKeyUnspentOutput(outputID iotago.OutputID) lookupKey {
+func lookupKeyUnspentOutput(outputID iotago.OutputID) LookupKey {
 	ms := marshalutil.New(35)
 	ms.WriteByte(UTXOStoreKeyPrefixOutputUnspent) // 1 byte
 	ms.WriteBytes(outputID[:])                    // 34 bytes
@@ -24,11 +24,11 @@ func lookupKeyUnspentOutput(outputID iotago.OutputID) lookupKey {
 	return ms.Bytes()
 }
 
-func (o *Output) UnspentLookupKey() lookupKey {
+func (o *Output) UnspentLookupKey() LookupKey {
 	return lookupKeyUnspentOutput(o.outputID)
 }
 
-func outputIDFromDatabaseKey(key lookupKey) (iotago.OutputID, error) {
+func outputIDFromDatabaseKey(key LookupKey) (iotago.OutputID, error) {
 	ms := marshalutil.New([]byte(key))
 
 	// prefix

--- a/pkg/p2p/manager_test.go
+++ b/pkg/p2p/manager_test.go
@@ -100,7 +100,7 @@ func TestManager(t *testing.T) {
 		_ = node2Manager.ConnectPeer(node3AddrInfo, p2p.PeerRelationUnknown)
 	}()
 
-	// note we do not explicitly let node 3 connect to node 2
+	// note we don't explicitly let node 3 connect to node 2
 
 	// should eventually both be connected to each other
 	connectivity(t, node1Manager, node2.ID(), false)

--- a/pkg/protocol/gossip/service_test.go
+++ b/pkg/protocol/gossip/service_test.go
@@ -35,6 +35,7 @@ func newNode(ctx context.Context, name string, t *testing.T, mngOpts []p2p.Manag
 	)
 	require.NoError(t, err)
 
+	//nolint:contextcheck // false positive
 	n, err := libp2p.New(
 		libp2p.DefaultListenAddrs,
 		libp2p.Identity(privateKey),

--- a/pkg/protocol/gossip/warpsync.go
+++ b/pkg/protocol/gossip/warpsync.go
@@ -358,7 +358,7 @@ func (w *WarpSyncMilestoneRequester) RequestMilestoneRange(ctx context.Context, 
 		msIndexToRequest := startingPoint + i
 
 		if !w.storage.ContainsMilestoneIndex(msIndexToRequest) {
-			// only request if we do not have the milestone
+			// only request if we don't have the milestone
 			requested++
 			msIndexes = append(msIndexes, msIndexToRequest)
 

--- a/pkg/pruning/pruning.go
+++ b/pkg/pruning/pruning.go
@@ -486,7 +486,7 @@ func (p *Manager) HandleNewConfirmedMilestoneEvent(ctx context.Context, confirme
 		return
 	}
 
-	var targetIndex iotago.MilestoneIndex = 0
+	var targetIndex iotago.MilestoneIndex
 	if p.pruningMilestonesEnabled && confirmedMilestoneIndex > p.pruningMilestonesMaxMilestonesToKeep {
 		targetIndex = confirmedMilestoneIndex - p.pruningMilestonesMaxMilestonesToKeep
 	}

--- a/pkg/snapshot/snapshot_file.go
+++ b/pkg/snapshot/snapshot_file.go
@@ -549,7 +549,7 @@ func ReadFullSnapshotHeader(reader io.Reader) (*FullSnapshotHeader, error) {
 	}
 	readHeader.TreasuryOutput = to
 
-	var protoParamsMsOptionLength uint16 = 0
+	var protoParamsMsOptionLength uint16
 	if err := binary.Read(reader, binary.LittleEndian, &protoParamsMsOptionLength); err != nil {
 		return nil, fmt.Errorf("unable to read LS protocol parameters milestone option length: %w", err)
 	}
@@ -1271,7 +1271,7 @@ func StreamFullSnapshotDataFrom(
 		}
 		increaseOffsets(msDiffLength, &msDiffsParsedLength)
 
-		// we do not consume milestone diffs that are below the target milestone index.
+		// we don't consume milestone diffs that are below the target milestone index.
 		// these additional milestone diffs are only used to get the protocol parameter updates.
 		if msDiff.Milestone.Index <= fullHeader.TargetMilestoneIndex {
 			// we can break the loop here since we are walking backwards.

--- a/pkg/tangle/revalidation.go
+++ b/pkg/tangle/revalidation.go
@@ -110,7 +110,7 @@ func (t *Tangle) RevalidateDatabase(snapshotImporter *snapshot.Importer, pruneRe
 		return err
 	}
 
-	// deletes all unreferenced blocks that are left in the database (we do not need them since we deleted all unreferenced blocks).
+	// deletes all unreferenced blocks that are left in the database (we don't need them since we deleted all unreferenced blocks).
 	if err := t.cleanupUnreferencedBlocks(); err != nil {
 		return err
 	}
@@ -379,7 +379,7 @@ func (t *Tangle) cleanupChildren() error {
 		copy(childrenMapKey[:iotago.BlockIDLength], blockID[:])
 		copy(childrenMapKey[iotago.BlockIDLength:], childBlockID[:])
 
-		// we do not check if the parent still exists, to speed up the revalidation of children by 50%.
+		// we don't check if the parent still exists, to speed up the revalidation of children by 50%.
 		// if children entries would remain, but the block is missing, we would never start a walk from the
 		// parent block, since we always walk the future cone.
 		/*
@@ -428,7 +428,7 @@ func (t *Tangle) cleanupChildren() error {
 	return nil
 }
 
-// deletes all unreferenced blocks that are left in the database (we do not need them since we deleted all unreferenced blocks).
+// deletes all unreferenced blocks that are left in the database (we don't need them since we deleted all unreferenced blocks).
 func (t *Tangle) cleanupUnreferencedBlocks() error {
 
 	start := time.Now()

--- a/pkg/testsuite/utils.go
+++ b/pkg/testsuite/utils.go
@@ -382,7 +382,7 @@ func (m *Block) BookOnWallets() *Block {
 					continue
 				}
 			}
-			// Note: we do not care about SDRUC here right now
+			// Note: we don't care about SDRUC here right now
 			m.builder.fromWallet.BookOutput(sentOutput)
 
 		case *iotago.AliasOutput:

--- a/pkg/tipselect/random.go
+++ b/pkg/tipselect/random.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	//nolint:gosec // we do not care about weak random numbers here
+	//nolint:gosec // we don't care about weak random numbers here
 	seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 	randLock   = &syncutils.Mutex{}
 )

--- a/pkg/toolset/database.go
+++ b/pkg/toolset/database.go
@@ -85,7 +85,7 @@ func getMilestonePayloadFromStorage(tangleStore *storage.Storage, msIndex iotago
 // getStorageMilestoneRange returns the range of milestones that are found in the storage.
 func getStorageMilestoneRange(tangleStore *storage.Storage) (iotago.MilestoneIndex, iotago.MilestoneIndex) {
 	var msIndexStart iotago.MilestoneIndex = math.MaxUint32
-	var msIndexEnd iotago.MilestoneIndex = 0
+	var msIndexEnd iotago.MilestoneIndex
 
 	tangleStore.ForEachMilestoneIndex(func(msIndex iotago.MilestoneIndex) bool {
 		if msIndexStart > msIndex {
@@ -223,7 +223,7 @@ func createTangleStorage(name string, tangleDatabasePath string, utxoDatabasePat
 }
 
 // loadGenesisSnapshot loads the genesis snapshot to the storage and checks if the networkID fits.
-func loadGenesisSnapshot(storage *storage.Storage, genesisSnapshotFilePath string, checkSourceNetworkID bool, sourceNetworkID uint64) error {
+func loadGenesisSnapshot(ctx context.Context, storage *storage.Storage, genesisSnapshotFilePath string, checkSourceNetworkID bool, sourceNetworkID uint64) error {
 
 	fullHeader, err := snapshot.ReadFullSnapshotHeaderFromFile(genesisSnapshotFilePath)
 	if err != nil {
@@ -239,7 +239,7 @@ func loadGenesisSnapshot(storage *storage.Storage, genesisSnapshotFilePath strin
 		return fmt.Errorf("source storage networkID not equal to genesis snapshot networkID (%d != %d)", sourceNetworkID, fullHeaderProtoParams.NetworkID())
 	}
 
-	if _, _, err := snapshot.LoadSnapshotFilesToStorage(context.Background(), storage, false, genesisSnapshotFilePath); err != nil {
+	if _, _, err := snapshot.LoadSnapshotFilesToStorage(ctx, storage, false, genesisSnapshotFilePath); err != nil {
 		return err
 	}
 

--- a/pkg/toolset/database_verify.go
+++ b/pkg/toolset/database_verify.go
@@ -111,6 +111,7 @@ func verifyDatabase(
 
 	println(fmt.Sprintf("existing milestone range source database: %d-%d", msIndexStart, msIndexEnd))
 
+	//nolint:contextcheck // false positive
 	tangleStoreTemp, err := createTangleStorage("temp", "", "", database.EngineMapDB)
 	if err != nil {
 		return err
@@ -129,7 +130,7 @@ func verifyDatabase(
 
 	// load the genesis ledger state into the temporary storage (SEP and ledger state only)
 	println("loading genesis snapshot...")
-	if err := loadGenesisSnapshot(tangleStoreTemp, genesisSnapshotFilePath, true, protoParamsSource.NetworkID()); err != nil {
+	if err := loadGenesisSnapshot(ctx, tangleStoreTemp, genesisSnapshotFilePath, true, protoParamsSource.NetworkID()); err != nil {
 		return fmt.Errorf("loading genesis snapshot failed: %w", err)
 	}
 

--- a/pkg/toolset/network_bootstrap.go
+++ b/pkg/toolset/network_bootstrap.go
@@ -141,7 +141,7 @@ func networkBootstrap(args []string) error {
 
 	// load the genesis ledger state into the storage (SEP and ledger state only)
 	println("loading genesis snapshot...")
-	if err := loadGenesisSnapshot(tangleStore, genesisSnapshotPath, false, 0); err != nil {
+	if err := loadGenesisSnapshot(context.Background(), tangleStore, genesisSnapshotPath, false, 0); err != nil {
 		return fmt.Errorf("failed to load genesis snapshot: %w", err)
 	}
 

--- a/pkg/toolset/snap_gen.go
+++ b/pkg/toolset/snap_gen.go
@@ -215,7 +215,7 @@ func snapshotGen(args []string) error {
 	}
 
 	// create snapshot file
-	var targetIndex iotago.MilestoneIndex = 0
+	var targetIndex iotago.MilestoneIndex
 	fullHeader := &snapshot.FullSnapshotHeader{
 		Version:                  snapshot.SupportedFormatVersion,
 		Type:                     snapshot.Full,

--- a/pkg/toolset/snap_merge.go
+++ b/pkg/toolset/snap_merge.go
@@ -1,6 +1,7 @@
 package toolset
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -56,7 +57,7 @@ func snapshotMerge(args []string) error {
 
 	ts := time.Now()
 
-	mergeInfo, err := snapshot.MergeSnapshotsFiles(fullPath, deltaPath, targetPath)
+	mergeInfo, err := snapshot.MergeSnapshotsFiles(context.Background(), fullPath, deltaPath, targetPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/tpkg/random.go
+++ b/pkg/tpkg/random.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	//nolint:gosec // we do not care about weak random numbers here
+	//nolint:gosec // we don't care about weak random numbers here
 	seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 	randLock   = &sync.Mutex{}
 )

--- a/plugins/coreapi/node.go
+++ b/plugins/coreapi/node.go
@@ -24,7 +24,7 @@ func info() (*infoResponse, error) {
 
 	// latest milestone
 	var latestMilestoneIndex = deps.SyncManager.LatestMilestoneIndex()
-	var latestMilestoneTimestamp uint32 = 0
+	var latestMilestoneTimestamp uint32
 	var latestMilestoneIDHex string
 	cachedMilestoneLatest := deps.Storage.CachedMilestoneByIndexOrNil(latestMilestoneIndex) // milestone +1
 	if cachedMilestoneLatest != nil {
@@ -35,7 +35,7 @@ func info() (*infoResponse, error) {
 
 	// confirmed milestone index
 	var confirmedMilestoneIndex = deps.SyncManager.ConfirmedMilestoneIndex()
-	var confirmedMilestoneTimestamp uint32 = 0
+	var confirmedMilestoneTimestamp uint32
 	var confirmedMilestoneIDHex string
 	cachedMilestoneConfirmed := deps.Storage.CachedMilestoneByIndexOrNil(confirmedMilestoneIndex) // milestone +1
 	if cachedMilestoneConfirmed != nil {

--- a/plugins/inx/server_tips.go
+++ b/plugins/inx/server_tips.go
@@ -48,7 +48,7 @@ func (s *Server) ListenToTipsMetrics(req *inx.TipsMetricRequest, srv inx.INX_Lis
 	}
 
 	var innerErr error
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(Plugin.Daemon().ContextStopped())
 	defer cancel()
 
 	ticker := timeutil.NewTicker(func() {

--- a/plugins/prometheus/component.go
+++ b/plugins/prometheus/component.go
@@ -229,11 +229,14 @@ func run() error {
 		Plugin.LogInfo("Stopping Prometheus exporter ...")
 
 		shutdownCtx, shutdownCtxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCtxCancel()
+
+		//nolint:contextcheck // false positive
 		err := deps.PrometheusEcho.Shutdown(shutdownCtx)
 		if err != nil {
 			Plugin.LogWarn(err)
 		}
-		shutdownCtxCancel()
+
 		Plugin.LogInfo("Stopping Prometheus exporter ... done")
 	}, daemon.PriorityPrometheus); err != nil {
 		Plugin.LogPanicf("failed to start worker: %s", err)

--- a/plugins/restapi/component.go
+++ b/plugins/restapi/component.go
@@ -146,10 +146,13 @@ func run() error {
 		Plugin.LogInfo("Stopping REST-API server ...")
 
 		shutdownCtx, shutdownCtxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCtxCancel()
+
+		//nolint:contextcheck // false positive
 		if err := deps.Echo.Shutdown(shutdownCtx); err != nil {
 			Plugin.LogWarn(err)
 		}
-		shutdownCtxCancel()
+
 		Plugin.LogInfo("Stopping REST-API server ... done")
 	}, daemon.PriorityRestAPI); err != nil {
 		Plugin.LogPanicf("failed to start worker: %s", err)


### PR DESCRIPTION
The CI fails now because golangci-lint has a new version that is more verbose.

The updated version of the contextcheck linter found several paths in the code, where new contexts were created without taking the root contexts into account. This PR tries to fix these problems, which could reduce blocking at node shutdown.