### PR TITLE
Remove BlockID lookup from milestone payloads

### DIFF
--- a/pkg/model/milestonemanager/milestone_manager.go
+++ b/pkg/model/milestonemanager/milestone_manager.go
@@ -129,7 +129,7 @@ func (m *MilestoneManager) StoreMilestone(cachedBlock *storage.CachedBlock, mile
 	// Mark every valid milestone block as milestone in the database (needed for whiteflag to find last milestone)
 	cachedBlock.Metadata().SetMilestone(true)
 
-	cachedMilestone, newlyAdded := m.storage.StoreMilestoneIfAbsent(milestonePayload, cachedBlock.Block().BlockID()) // milestone +1
+	cachedMilestone, newlyAdded := m.storage.StoreMilestoneIfAbsent(milestonePayload) // milestone +1
 
 	// Force release to store milestones without caching
 	defer cachedMilestone.Release(true) // milestone -1

--- a/pkg/snapshot/snapshot_read.go
+++ b/pkg/snapshot/snapshot_read.go
@@ -134,8 +134,8 @@ func NewMsDiffConsumer(dbStorage *storage.Storage, utxoManager *utxo.Manager, wr
 	return func(msDiff *MilestoneDiff) error {
 
 		if writeMilestonesToStorage {
-			cachedMilestone, _ := dbStorage.StoreMilestoneIfAbsent(msDiff.Milestone, iotago.EmptyBlockID()) // milestone +1
-			cachedMilestone.Release(true)                                                                   // milestone -1
+			cachedMilestone, _ := dbStorage.StoreMilestoneIfAbsent(msDiff.Milestone) // milestone +1
+			cachedMilestone.Release(true)                                            // milestone -1
 		}
 
 		msIndex := msDiff.Milestone.Index

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -233,14 +233,6 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex iotago.MilestoneIndex, forc
 		return
 	}
 
-	milestoneBlockIDToSolidify, err := t.storage.MilestoneBlockIDByIndex(milestoneIndexToSolidify)
-	if err != nil {
-		// Milestone not found
-		t.LogPanic(storage.ErrMilestoneNotFound)
-
-		return
-	}
-
 	cachedMilestoneToSolidify := t.storage.CachedMilestoneByIndexOrNil(milestoneIndexToSolidify)
 	if cachedMilestoneToSolidify == nil {
 		// Milestone not found
@@ -279,7 +271,7 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex iotago.MilestoneIndex, forc
 		milestoneSolidificationCtx,
 		memcachedTraverserStorage,
 		milestoneIndexToSolidify,
-		iotago.BlockIDs{milestoneBlockIDToSolidify},
+		milestonePayloadToSolidify.Parents,
 	); !becameSolid {
 		if aborted {
 			// check was aborted due to older milestones/other solidifier running

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -319,6 +319,19 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex iotago.MilestoneIndex, forc
 		return
 	}
 
+	// solidify the direct children of the milestone parents,
+	// to eventually solidify all blocks that contained the milestone payload itself.
+	// this is needed to trigger the solid event for the milestone block that is expected by the coordinator.
+	if err := t.futureConeSolidifier.SolidifyDirectChildrenWithMetadataMemcache(
+		milestoneSolidificationCtx,
+		memcachedTraverserStorage,
+		milestonePayloadToSolidify.Parents,
+	); err != nil {
+		t.LogWarnf("Aborted confirmation of milestone %d because solidification of direct children failed: %s", milestoneIndexToSolidify, err.Error())
+
+		return
+	}
+
 	var (
 		timeStart                             time.Time
 		timeSetConfirmedMilestoneIndexStart   time.Time

--- a/pkg/toolset/database.go
+++ b/pkg/toolset/database.go
@@ -109,7 +109,7 @@ func getStorageMilestoneRange(tangleStore *storage.Storage) (iotago.MilestoneInd
 type StoreBlockInterface interface {
 	StoreBlockIfAbsent(block *storage.Block) (cachedBlock *storage.CachedBlock, newlyAdded bool)
 	StoreChild(parentBlockID iotago.BlockID, childBlockID iotago.BlockID) *storage.CachedChild
-	StoreMilestoneIfAbsent(milestonePayload *iotago.Milestone, blockID iotago.BlockID) (*storage.CachedMilestone, bool)
+	StoreMilestoneIfAbsent(milestonePayload *iotago.Milestone) (*storage.CachedMilestone, bool)
 }
 
 // storeBlock adds a new block to the storage,
@@ -134,7 +134,7 @@ func storeBlock(protoParams *iotago.ProtocolParameters, dbStorage StoreBlockInte
 	}
 
 	if milestonePayload := milestoneManager.VerifyMilestoneBlock(block.Block()); milestonePayload != nil {
-		cachedMilestone, _ := dbStorage.StoreMilestoneIfAbsent(milestonePayload, block.BlockID()) // milestone +1
+		cachedMilestone, _ := dbStorage.StoreMilestoneIfAbsent(milestonePayload) // milestone +1
 
 		// Force release to store milestones without caching
 		cachedMilestone.Release(true) // milestone -1

--- a/pkg/toolset/database_merge.go
+++ b/pkg/toolset/database_merge.go
@@ -730,6 +730,6 @@ func (s *ProxyStorage) StoreChild(parentBlockID iotago.BlockID, childBlockID iot
 	return s.storeProxy.StoreChild(parentBlockID, childBlockID)
 }
 
-func (s *ProxyStorage) StoreMilestoneIfAbsent(milestone *iotago.Milestone, blockID iotago.BlockID) (*storage.CachedMilestone, bool) {
-	return s.storeProxy.StoreMilestoneIfAbsent(milestone, blockID)
+func (s *ProxyStorage) StoreMilestoneIfAbsent(milestone *iotago.Milestone) (*storage.CachedMilestone, bool) {
+	return s.storeProxy.StoreMilestoneIfAbsent(milestone)
 }

--- a/pkg/toolset/network_bootstrap.go
+++ b/pkg/toolset/network_bootstrap.go
@@ -328,8 +328,8 @@ func createInitialMilestone(dbStorage *storage.Storage, signer signingprovider.M
 	// Mark milestone block as milestone in the database (needed for whiteflag to find last milestone)
 	cachedBlock.Metadata().SetMilestone(true)
 
-	cachedMilestone, _ := dbStorage.StoreMilestoneIfAbsent(milestonePayload, cachedBlock.Block().BlockID()) // milestone +1
-	defer cachedMilestone.Release(true)                                                                     // milestone -1
+	cachedMilestone, _ := dbStorage.StoreMilestoneIfAbsent(milestonePayload) // milestone +1
+	defer cachedMilestone.Release(true)                                      // milestone -1
 
 	if err := dbStorage.UTXOManager().ApplyConfirmation(index, utxo.Outputs{}, utxo.Spents{}, nil, nil); err != nil {
 		return nil, fmt.Errorf("applying confirmation failed: %w", err)


### PR DESCRIPTION
# Problem
With the stardust upgrade, the internal logic how milestone payloads are handled by hornet had to be changed.

In chrysalis we always solidified and confirmed the block that contained the milestone payload itself under the same milestone index.
In stardust we decided to use the milestone payloads as "virtual markers". The block that contains these milestone payloads itself will be included in the next milestone cone and the coordinator itself takes care of producing a valid chain (this chaining is also verified by the nodes).

In the solidification and confirmation logic, this lead to the problem, that if we only solidify the parents that are included in the milestone payload, there is no guarantee that the milestone block itself is marked as solid by the node. The coordinator relies on that information about solidity of the block that contained the milestone payload, before it can issue the next milestone on top of it (to create a valid chain). This lead to halting of the coordinator.

As a "dirty" workaround, we stored the blockID of the block that contained the milestone payload in the database.
In the moment the milestone was about to get confirmed, we checked the solidify of that particular block.

## This workaround has several disadvantages:
- We need 32 bytes more space in the database for a temporary and otherwise useless information.
- Existing tools like "db-merge" can't query the block that contained the milestone payload via Core API, and therefore wouldn't work properly.
- reattachments of milestone payloads are exactly the reason we choose to use the milestone payloads as these "virtual markers" without any connection to the containing block, therefore we should not do this at all.

## Fix:
- We don't store the blockID anymore
- We solidify all direct children of the parents of a milestone payload directly after these parents were solidified themselves.
This is possible because the block that contained the milestone payload itself exists and attaches to exactly these parents, otherwise the milestone payload would be unknown to the node in the first place.
- This change in the logic is also robust against reattachments in case the coordinator is connected to that node.

## Important notes:
The database layout got changed, but it's backwards compatible because we ignore the removed bytes.