### PR TITLE
Fix INX deadlock

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,9 @@ linters-settings:
         initialisms: ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
 
 linters:
+    # Disable all linters.
+    disable-all: true
+    # Enable specific linter
     enable:
         - deadcode
         - errcheck

--- a/plugins/inx/server.go
+++ b/plugins/inx/server.go
@@ -3,10 +3,12 @@ package inx
 import (
 	"context"
 	"net"
+	"time"
 
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	"github.com/iotaledger/hive.go/core/workerpool"
@@ -24,7 +26,13 @@ func newServer() *Server {
 	grpcServer := grpc.NewServer(
 		grpc.StreamInterceptor(grpcprometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpcprometheus.UnaryServerInterceptor),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    20 * time.Second,
+			Timeout: 5 * time.Second,
+		}),
+		grpc.MaxConcurrentStreams(10),
 	)
+
 	s := &Server{grpcServer: grpcServer}
 	inx.RegisterINXServer(grpcServer, s)
 

--- a/plugins/inx/server.go
+++ b/plugins/inx/server.go
@@ -42,13 +42,13 @@ func (s *Server) ConfigurePrometheus() {
 
 func (s *Server) Start() {
 	go func() {
-		lis, err := net.Listen("tcp", ParamsINX.BindAddress)
+		listener, err := net.Listen("tcp", ParamsINX.BindAddress)
 		if err != nil {
 			Plugin.LogFatalfAndExit("failed to listen: %v", err)
 		}
-		defer lis.Close()
+		defer listener.Close()
 
-		if err := s.grpcServer.Serve(lis); err != nil {
+		if err := s.grpcServer.Serve(listener); err != nil {
 			Plugin.LogFatalfAndExit("failed to serve: %v", err)
 		}
 	}()

--- a/plugins/inx/server_blocks.go
+++ b/plugins/inx/server_blocks.go
@@ -167,7 +167,11 @@ func (s *Server) ListenToBlocks(_ *inx.NoParams, srv inx.INX_ListenToBlocksServe
 	deps.Tangle.Events.ReceivedNewBlock.Hook(onReceivedNewBlock)
 	<-ctx.Done()
 	deps.Tangle.Events.ReceivedNewBlock.Detach(onReceivedNewBlock)
-	wp.Stop()
+
+	// We need to wait until all tasks are done, otherwise we might call
+	// "SendMsg" and "CloseSend" in parallel on the grpc stream, which is
+	// not safe according to the grpc docs.
+	wp.StopAndWait()
 
 	return ctx.Err()
 }
@@ -210,7 +214,11 @@ func (s *Server) ListenToSolidBlocks(_ *inx.NoParams, srv inx.INX_ListenToSolidB
 	deps.Tangle.Events.BlockSolid.Hook(onBlockSolid)
 	<-ctx.Done()
 	deps.Tangle.Events.BlockSolid.Detach(onBlockSolid)
-	wp.Stop()
+
+	// We need to wait until all tasks are done, otherwise we might call
+	// "SendMsg" and "CloseSend" in parallel on the grpc stream, which is
+	// not safe according to the grpc docs.
+	wp.StopAndWait()
 
 	return ctx.Err()
 }
@@ -252,7 +260,11 @@ func (s *Server) ListenToReferencedBlocks(_ *inx.NoParams, srv inx.INX_ListenToR
 	deps.Tangle.Events.BlockReferenced.Hook(onBlockReferenced)
 	<-ctx.Done()
 	deps.Tangle.Events.BlockReferenced.Detach(onBlockReferenced)
-	wp.Stop()
+
+	// We need to wait until all tasks are done, otherwise we might call
+	// "SendMsg" and "CloseSend" in parallel on the grpc stream, which is
+	// not safe according to the grpc docs.
+	wp.StopAndWait()
 
 	return ctx.Err()
 }
@@ -300,7 +312,11 @@ func (s *Server) ListenToTipScoreUpdates(_ *inx.NoParams, srv inx.INX_ListenToTi
 	<-ctx.Done()
 	deps.TipSelector.Events.TipAdded.Detach(onTipAddedOrRemoved)
 	deps.TipSelector.Events.TipRemoved.Detach(onTipAddedOrRemoved)
-	wp.Stop()
+
+	// We need to wait until all tasks are done, otherwise we might call
+	// "SendMsg" and "CloseSend" in parallel on the grpc stream, which is
+	// not safe according to the grpc docs.
+	wp.StopAndWait()
 
 	return ctx.Err()
 }

--- a/plugins/inx/server_milestones.go
+++ b/plugins/inx/server_milestones.go
@@ -111,7 +111,11 @@ func (s *Server) ListenToLatestMilestones(_ *inx.NoParams, srv inx.INX_ListenToL
 	deps.Tangle.Events.LatestMilestoneChanged.Hook(onLatestMilestoneChanged)
 	<-ctx.Done()
 	deps.Tangle.Events.LatestMilestoneChanged.Detach(onLatestMilestoneChanged)
-	wp.Stop()
+
+	// We need to wait until all tasks are done, otherwise we might call
+	// "SendMsg" and "CloseSend" in parallel on the grpc stream, which is
+	// not safe according to the grpc docs.
+	wp.StopAndWait()
 
 	return ctx.Err()
 }
@@ -291,7 +295,11 @@ func (s *Server) ListenToConfirmedMilestones(req *inx.MilestoneRangeRequest, srv
 	deps.Tangle.Events.ConfirmedMilestoneChanged.Hook(onConfirmedMilestoneChanged)
 	<-ctx.Done()
 	deps.Tangle.Events.ConfirmedMilestoneChanged.Detach(onConfirmedMilestoneChanged)
-	wp.Stop()
+
+	// We need to wait until all tasks are done, otherwise we might call
+	// "SendMsg" and "CloseSend" in parallel on the grpc stream, which is
+	// not safe according to the grpc docs.
+	wp.StopAndWait()
 
 	return innerErr
 }

--- a/plugins/inx/server_utxo.go
+++ b/plugins/inx/server_utxo.go
@@ -385,7 +385,11 @@ func (s *Server) ListenToLedgerUpdates(req *inx.MilestoneRangeRequest, srv inx.I
 	deps.Tangle.Events.LedgerUpdated.Hook(onLedgerUpdated)
 	<-ctx.Done()
 	deps.Tangle.Events.LedgerUpdated.Detach(onLedgerUpdated)
-	wp.Stop()
+
+	// We need to wait until all tasks are done, otherwise we might call
+	// "SendMsg" and "CloseSend" in parallel on the grpc stream, which is
+	// not safe according to the grpc docs.
+	wp.StopAndWait()
 
 	return innerErr
 }
@@ -577,7 +581,11 @@ func (s *Server) ListenToTreasuryUpdates(req *inx.MilestoneRangeRequest, srv inx
 	deps.Tangle.Events.TreasuryMutated.Hook(onTreasuryMutated)
 	<-ctx.Done()
 	deps.Tangle.Events.TreasuryMutated.Detach(onTreasuryMutated)
-	wp.Stop()
+
+	// We need to wait until all tasks are done, otherwise we might call
+	// "SendMsg" and "CloseSend" in parallel on the grpc stream, which is
+	// not safe according to the grpc docs.
+	wp.StopAndWait()
 
 	return innerErr
 }
@@ -619,7 +627,11 @@ func (s *Server) ListenToMigrationReceipts(_ *inx.NoParams, srv inx.INX_ListenTo
 	deps.Tangle.Events.NewReceipt.Hook(onNewReceipt)
 	<-ctx.Done()
 	deps.Tangle.Events.NewReceipt.Detach(onNewReceipt)
-	wp.Stop()
+
+	// We need to wait until all tasks are done, otherwise we might call
+	// "SendMsg" and "CloseSend" in parallel on the grpc stream, which is
+	// not safe according to the grpc docs.
+	wp.StopAndWait()
 
 	return ctx.Err()
 }

--- a/plugins/inx/server_utxo.go
+++ b/plugins/inx/server_utxo.go
@@ -258,7 +258,7 @@ func (s *Server) ListenToLedgerUpdates(req *inx.MilestoneRangeRequest, srv inx.I
 
 	sendMilestoneDiffsRange := func(startIndex iotago.MilestoneIndex, endIndex iotago.MilestoneIndex) error {
 		for currentIndex := startIndex; currentIndex <= endIndex; currentIndex++ {
-			msDiff, err := deps.UTXOManager.MilestoneDiff(currentIndex)
+			msDiff, err := deps.UTXOManager.MilestoneDiffWithoutLocking(currentIndex)
 			if err != nil {
 				return status.Errorf(codes.NotFound, "ledger update for milestoneIndex %d not found", currentIndex)
 			}
@@ -418,7 +418,7 @@ func (s *Server) ListenToTreasuryUpdates(req *inx.MilestoneRangeRequest, srv inx
 
 	sendTreasuryUpdatesRange := func(startIndex iotago.MilestoneIndex, endIndex iotago.MilestoneIndex) error {
 		for currentIndex := startIndex; currentIndex <= endIndex; currentIndex++ {
-			msDiff, err := deps.UTXOManager.MilestoneDiff(currentIndex)
+			msDiff, err := deps.UTXOManager.MilestoneDiffWithoutLocking(currentIndex)
 			if err != nil {
 				return status.Errorf(codes.NotFound, "ledger update for milestoneIndex %d not found", currentIndex)
 			}


### PR DESCRIPTION
Somehow the INX server hangs in the following go routine forever, if the connection to chronicle fails for whatever reason.
This PR tries to fix this bug, by preventing concurrent write on the same stream.

```

goroutine 2928 [select, 23 minutes]:
google.golang.org/grpc/internal/transport.(*writeQuota).get(...)
	/go/pkg/mod/google.golang.org/grpc@v1.48.0/internal/transport/flowcontrol.go:59
google.golang.org/grpc/internal/transport.(*http2Server).Write(0x40034a01a0, 0x4003c54240, {0x4001879906, 0x5, 0x5}, {0x4003ea4b40, 0x10e, 0x10e}, 0x20fcc90?)
	/go/pkg/mod/google.golang.org/grpc@v1.48.0/internal/transport/http2_server.go:1096 +0x1f4
google.golang.org/grpc.(*serverStream).SendMsg(0x400073cc30, {0x1b4f0c0?, 0x4003ed5500})
	/go/pkg/mod/google.golang.org/grpc@v1.48.0/stream.go:1543 +0x12c
github.com/grpc-ecosystem/go-grpc-prometheus.(*monitoredServerStream).SendMsg(0x4003eba888, {0x1b4f0c0?, 0x4003ed5500?})
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:156 +0x38
github.com//inx/go.(*iNXListenToLedgerUpdatesServer).Send(0x400285b898?, 0x1378a8c?)
	/go/pkg/mod/github.com//inx/go@v1.0.0-beta.5/inx_grpc.pb.go:1132 +0x34
github.com//hornet/v2/plugins/inx.(*Server).ListenToLedgerUpdates.func1(0x124, {0x4004646000, 0x2059, 0x0?}, {0x40028be000, 0x2056, 0x1ef005be230?})
	/scratch/plugins/inx/server_utxo.go:234 +0x178
github.com//hornet/v2/plugins/inx.(*Server).ListenToLedgerUpdates.func2(0xb938?, 0x1ef)
	/scratch/plugins/inx/server_utxo.go:266 +0x8c
github.com//hornet/v2/plugins/inx.(*Server).ListenToLedgerUpdates.func3(0x11d, 0x0)
	/scratch/plugins/inx/server_utxo.go:303 +0x94
github.com//hornet/v2/plugins/inx.(*Server).ListenToLedgerUpdates(0x4003eba888?, 0x40015be1e0, {0x210d040?, 0x40043de930})
	/scratch/plugins/inx/server_utxo.go:316 +0x15c
github.com//inx/go._INX_ListenToLedgerUpdates_Handler({0x1bf79c0?, 0x4000011320}, {0x210aff8, 0x4003eba888})
	/go/pkg/mod/github.com//inx/go@v1.0.0-beta.5/inx_grpc.pb.go:1119 +0xd4
github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).StreamServerInterceptor.func1({0x1bf79c0, 0x4000011320}, {0x210b790?, 0x400073cc30}, 0x1950cc0?, 0x1efa8e8)
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:121 +0x10c
google.golang.org/grpc.(*Server).processStreamingRPC(0x40015ce000, {0x21117c0, 0x40034a01a0}, 0x4003c54240, 0x40015c7bc0, 0x2cbb880, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:1565 +0xda4
google.golang.org/grpc.(*Server).handleStream(0x40015ce000, {0x21117c0, 0x40034a01a0}, 0x4003c54240, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:1640 +0x818
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:932 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:930 +0x294
```