### PR TITLE
Add global flag to db-snap tool

### DIFF
--- a/pkg/toolset/database_snapshot.go
+++ b/pkg/toolset/database_snapshot.go
@@ -25,6 +25,7 @@ func databaseSnapshot(args []string) error {
 	databasePathSourceFlag := fs.String(FlagToolDatabasePathSource, "", "the path to the source database")
 	targetIndexFlag := fs.Uint32(FlagToolDatabaseTargetIndex, 0, "the target index")
 	outputJSONFlag := fs.Bool(FlagToolOutputJSON, false, FlagToolDescriptionOutputJSON)
+	globalSnapshotFlag := fs.Bool(FlagToolSnapshotGlobal, false, "create a global snapshot (SEP equal to milestone parents)")
 
 	fs.Usage = func() {
 		_, _ = fmt.Fprintf(os.Stderr, "Usage of %s:\n", ToolDatabaseSnapshot)
@@ -77,6 +78,7 @@ func databaseSnapshot(args []string) error {
 		tangleStoreSource.UTXOManager(),
 		*snapshotPathTargetFlag,
 		*targetIndexFlag,
+		*globalSnapshotFlag,
 		solidEntryPointCheckThresholdPast,
 		solidEntryPointCheckThresholdFuture,
 	)

--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -37,6 +37,7 @@ const (
 	FlagToolSnapshotPathFull   = "fullSnapshotPath"
 	FlagToolSnapshotPathDelta  = "deltaSnapshotPath"
 	FlagToolSnapshotPathTarget = "targetSnapshotPath"
+	FlagToolSnapshotGlobal     = "global"
 
 	FlagToolOutputPath = "outputPath"
 


### PR DESCRIPTION
This PR adds a flag to create global snapshots to the `db-snap` tool.

In case of a global snapshot, the SEP are not calculated based on the future cone history of the milestone.
Instead the parents of the target milestone are used.