### PR TITLE
Drop unhealthy peers

### DIFF
--- a/core/gossip/component.go
+++ b/core/gossip/component.go
@@ -259,6 +259,7 @@ func checkHeartbeats() {
 		return time.Since(proto.HeartbeatSentTime) > heartbeatSentInterval
 	})
 
+	peersToRemove := make(map[peer.ID]error)
 	peersToReconnect := make(map[peer.ID]struct{})
 
 	// check if peers are alive by checking whether we received heartbeats lately
@@ -270,16 +271,19 @@ func checkHeartbeats() {
 			return true
 		}
 
-		/*
-			// TODO: re-introduce once p2p discovery is implemented
-			// peer is connected but doesn't seem to be alive
-			if p.Autopeering != nil {
-				// it's better to drop the connection to autopeered peers and free the slots for other peers
-				peerIDsToRemove[p.ID] = struct{}{}
-				CoreComponent.LogInfof("dropping autopeered neighbor %s / %s because we didn't receive heartbeats anymore", p.Autopeering.ID(), p.Autopeering.ID())
-				return true
-			}
-		*/
+		// peer is connected but doesn't seem to be alive
+		var peerRelation p2p.PeerRelation
+		deps.PeeringManager.Call(proto.PeerID, func(peer *p2p.Peer) {
+			peerRelation = peer.Relation
+		})
+
+		// it's better to drop the connection to unknown and autopeered peers and free the slots for other peers
+		switch peerRelation {
+		case p2p.PeerRelationUnknown, p2p.PeerRelationAutopeered:
+			peersToRemove[proto.PeerID] = fmt.Errorf("dropping peer %s because we didn't receive heartbeats anymore", proto.PeerID.ShortString())
+
+			return true
+		}
 
 		// close the connection to static connected peers, so they will be moved into reconnect pool to reestablish the connection
 		CoreComponent.LogInfof("closing connection to peer %s because we didn't receive heartbeats anymore", proto.PeerID.ShortString())
@@ -288,12 +292,10 @@ func checkHeartbeats() {
 		return true
 	})
 
-	/*
-		// TODO: re-introduce once p2p discovery is implemented
-		for peerIDToRemove := range peerIDsToRemove {
-			peering.Manager().Remove(peerIDToRemove)
-		}
-	*/
+	// drop the connection to the peers
+	for p, reason := range peersToRemove {
+		_ = deps.PeeringManager.DisconnectPeer(p, reason)
+	}
 
 	// close the connection to the peers to trigger a reconnect
 	for p := range peersToReconnect {


### PR DESCRIPTION
We can drop the connection to unknown and autopeered peers, if they don't seem to be healthy.