### PR TITLE
Drop peers that are below pruning index

### DIFF
--- a/core/gossip/sting.go
+++ b/core/gossip/sting.go
@@ -52,18 +52,6 @@ func attachEventsProtocolMessages(proto *gossip.Protocol) {
 		deps.ServerMetrics.ReceivedHeartbeats.Inc()
 
 		proto.LatestHeartbeat = gossip.ParseHeartbeat(data)
-
-		/*
-			// TODO: reintroduce
-			if proto.Autopeering != nil && p.LatestHeartbeat.SolidMilestoneIndex < tangle.SnapshotInfo().PruningIndex {
-				// peer is connected via autopeering and its solid milestone index is below our pruning index.
-				// we can't help this neighbor to become sync, so it's better to drop the connection and free the slots for other peers.
-				log.Infof("dropping autopeered neighbor %s / %s because SMI (%d) is below our pruning index (%d)", p.Autopeering.Address(), p.Autopeering.ID(), p.LatestHeartbeat.SolidMilestoneIndex, tangle.SnapshotInfo().PruningIndex)
-				peering.Manager().Remove(p.ID)
-				return
-			}
-		*/
-
 		proto.HeartbeatReceivedTime = time.Now()
 		proto.Events.HeartbeatUpdated.Trigger(proto.LatestHeartbeat)
 	}))

--- a/pkg/protocol/gossip/protocol.go
+++ b/pkg/protocol/gossip/protocol.go
@@ -200,35 +200,38 @@ func (p *Protocol) SendLatestMilestoneRequest() {
 // HasDataForMilestone tells whether the underlying peer given the latest heartbeat message, has the cone data for the given milestone.
 // Returns false if no heartbeat message was received yet.
 func (p *Protocol) HasDataForMilestone(index iotago.MilestoneIndex) bool {
-	if p.LatestHeartbeat == nil {
+	heartbeat := p.LatestHeartbeat
+	if heartbeat == nil {
 		return false
 	}
 
-	return p.LatestHeartbeat.PrunedMilestoneIndex < index && p.LatestHeartbeat.SolidMilestoneIndex >= index
+	return heartbeat.PrunedMilestoneIndex < index && heartbeat.SolidMilestoneIndex >= index
 }
 
 // CouldHaveDataForMilestone tells whether the underlying peer given the latest heartbeat message, could have parts of the cone data for the given milestone.
 // Returns false if no heartbeat message was received yet.
 func (p *Protocol) CouldHaveDataForMilestone(index iotago.MilestoneIndex) bool {
-	if p.LatestHeartbeat == nil {
+	heartbeat := p.LatestHeartbeat
+	if heartbeat == nil {
 		return false
 	}
 
-	return p.LatestHeartbeat.PrunedMilestoneIndex < index && p.LatestHeartbeat.LatestMilestoneIndex >= index
+	return heartbeat.PrunedMilestoneIndex < index && heartbeat.LatestMilestoneIndex >= index
 }
 
 // IsSynced tells whether the underlying peer is synced.
 func (p *Protocol) IsSynced(cmi iotago.MilestoneIndex) bool {
-	if p.LatestHeartbeat == nil {
+	heartbeat := p.LatestHeartbeat
+	if heartbeat == nil {
 		return false
 	}
 
-	latestIndex := p.LatestHeartbeat.LatestMilestoneIndex
+	latestIndex := heartbeat.LatestMilestoneIndex
 	if latestIndex < cmi {
 		latestIndex = cmi
 	}
 
-	if p.LatestHeartbeat.SolidMilestoneIndex < (latestIndex - minCMISynchronizationThreshold) {
+	if heartbeat.SolidMilestoneIndex < (latestIndex - minCMISynchronizationThreshold) {
 		return false
 	}
 


### PR DESCRIPTION
This PR reintroduces the logic where peers are dropped with a latest solid index below our pruning index.