### PR TITLE
Fix stuck peer

### DIFF
--- a/pkg/p2p/manager.go
+++ b/pkg/p2p/manager.go
@@ -1099,5 +1099,3 @@ func (m *netNotifiee) Disconnected(net network.Network, conn network.Conn) {
 	}
 	m.disconnectedChan <- &disconnectmsg{net: net, conn: conn, reason: errors.New("connection closed by libp2p network event")}
 }
-func (m *netNotifiee) OpenedStream(_ network.Network, _ network.Stream) {}
-func (m *netNotifiee) ClosedStream(_ network.Network, _ network.Stream) {}

--- a/pkg/protocol/gossip/service.go
+++ b/pkg/protocol/gossip/service.go
@@ -562,6 +562,11 @@ func (s *Service) deregisterProtocol(peerID peer.ID) error {
 		return fmt.Errorf("unable to cleanly reset stream to %s: %w", peerID, err)
 	}
 
+	// Drop connection to peer since we no longer have a protocol stream to it
+	if conn := proto.Stream.Conn(); conn != nil {
+		return conn.Close()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
libp2p removed the `OpenedStream`/`ClosedStream` callbacks from `network.Notifee`
https://github.com/libp2p/go-libp2p-core/pull/250

If we have an protocol error on the stream level we no only deregister the protocol, we also close the underlying connection and let the peering manager reconnect to the peer. This fixes stucked peers where a connection is still open, but no protocol is running on top.