### PR TITLE
Enhance documentation sidebar with home

### DIFF
--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -10,53 +10,62 @@
  */
 
 module.exports = {
-    mySidebar: [{
-        type: 'doc',
-        id: 'welcome',
-    },
+    docs: [
         {
-            type: 'doc',
-            id: 'getting_started/getting_started',
-        },
-        {
-            type: 'category',
-            label: 'How to',
+            type: "category",
+            label: "Hornet",
+            link: {type: 'doc', id: 'welcome'},
+            collapsed: false,
             items: [
                 {
                     type: 'doc',
-                    id: 'how_tos/using_docker',
-                    label: 'Install HORNET using Docker',
+                    id: 'welcome',
                 },
                 {
                     type: 'doc',
-                    id: 'how_tos/post_installation',
-                    label: 'Post Installation',
+                    id: 'getting_started/getting_started',
                 },
                 {
-                    type: 'doc',
-                    id: 'how_tos/private_tangle',
-                    label: 'Run a Private Tangle',
+                    type: 'category',
+                    label: 'How to',
+                    items: [
+                        {
+                            type: 'doc',
+                            id: 'how_tos/using_docker',
+                            label: 'Install HORNET using Docker',
+                        },
+                        {
+                            type: 'doc',
+                            id: 'how_tos/post_installation',
+                            label: 'Post Installation',
+                        },
+                        {
+                            type: 'doc',
+                            id: 'how_tos/private_tangle',
+                            label: 'Run a Private Tangle',
+                        },
+                    ]
                 },
-            ]
-        },
-        {
-            type: 'category',
-            label: 'References',
-            items: [
                 {
-                    type: 'doc',
-                    id: 'references/configuration',
-                    label: 'Configuration',
-                },
-                {
-                    type: 'doc',
-                    id: 'references/peering',
-                    label: 'Peering',
-                },
-                {
-                    type: 'doc',
-                    id: 'references/api_reference',
-                    label: 'API Reference',
+                    type: 'category',
+                    label: 'References',
+                    items: [
+                        {
+                            type: 'doc',
+                            id: 'references/configuration',
+                            label: 'Configuration',
+                        },
+                        {
+                            type: 'doc',
+                            id: 'references/peering',
+                            label: 'Peering',
+                        },
+                        {
+                            type: 'doc',
+                            id: 'references/api_reference',
+                            label: 'API Reference',
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
# Description

Refactored the sidebar so that we have a link to the welcome page in the Breadcrumbs. It als makes it easier to see that you are currently in the Hornet docs

<img width="226" alt="example" src="https://user-images.githubusercontent.com/61637085/205732401-5384745d-f0ff-4d5c-ba93-3faa538f506b.png">

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
