### PR TITLE
Fix syncing issue by preventing requests race condition

### DIFF
--- a/pkg/tangle/tangle_processor.go
+++ b/pkg/tangle/tangle_processor.go
@@ -221,6 +221,7 @@ func (t *Tangle) processIncomingTx(incomingBlock *storage.Block, requests gossip
 	if !alreadyAdded {
 		t.serverMetrics.NewBlocks.Inc()
 
+		// increase the new block metric for the peer that submitted the block
 		if proto != nil {
 			proto.Metrics.NewBlocks.Inc()
 		}
@@ -260,6 +261,8 @@ func (t *Tangle) processIncomingTx(incomingBlock *storage.Block, requests gossip
 
 	} else {
 		t.serverMetrics.KnownBlocks.Inc()
+
+		// increase the known block metric for the peer that submitted the block
 		if proto != nil {
 			proto.Metrics.KnownBlocks.Inc()
 		}

--- a/plugins/debug/types.go
+++ b/plugins/debug/types.go
@@ -23,16 +23,18 @@ type milestoneDiffResponse struct {
 
 // request defines an request response.
 type request struct {
-	// The hex encoded block ID of the block.
-	BlockID string `json:"blockId"`
 	// The type of the request.
 	Type string `json:"type"`
-	// Whether the block already exists in the storage layer.
-	BlockExists bool `json:"txExists"`
 	// The time the request was enqueued.
 	EnqueueTimestamp string `json:"enqueueTimestamp"`
 	// The index of the milestone this request belongs to.
 	MilestoneIndex iotago.MilestoneIndex `json:"milestoneIndex"`
+	// The state of the request.
+	State string `json:"state"`
+	// The hex encoded block ID of the block.
+	BlockID string `json:"blockId,omitempty"`
+	// Whether the block already exists in the storage layer.
+	BlockExists *bool `json:"blockExists,omitempty"`
 }
 
 // requestsResponse defines the response of a GET debug requests REST API call.


### PR DESCRIPTION
This PR fixes an issue during syncing, especially with large histories, where the syncing process could deadlock because of a race condition of the block requests. 

The node always had to be restarted to "fix" this problem.

Now the data race does not happen anymore, even if the same block is processed in parallel by several threads.