### PR TITLE
Fix docs navigation

### DIFF
--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -14,7 +14,6 @@ module.exports = {
     {
       type: "category",
       label: "Hornet",
-      link: { type: 'doc', id: 'welcome' },
       collapsed: false,
       items: [
         {


### PR DESCRIPTION
# Description

Currently it doesn't work to use the same doc as category link AND first page

Fixes #1825 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested my code extensively
- [ ] I have selected the `develop` branch as the target branch