### PR TITLE
Fix missing treasury balance in db-hash tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.7] - 10.08.2023
+
+### Fix
+    - Fix missing treasury balance in db-hash tool (#1906)
+
+
 ## [1.2.6] - 09.08.2023
 
 ### Added

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -21,7 +21,7 @@ var (
 	Name = "HORNET"
 
 	// Version of the app.
-	Version = "1.2.6"
+	Version = "1.2.7"
 )
 
 var (

--- a/pkg/toolset/database_hash.go
+++ b/pkg/toolset/database_hash.go
@@ -92,6 +92,7 @@ func calculateDatabaseLedgerHash(dbStorage *storage.Storage, outputJSON bool) er
 		return fmt.Errorf("unable to serialize ledger index: %w", err)
 	}
 
+	var ledgerTokenSupply uint64
 	if treasuryOutput != nil {
 		// write current treasury output
 		if _, err := lsHash.Write(treasuryOutput.MilestoneID[:]); err != nil {
@@ -100,9 +101,9 @@ func calculateDatabaseLedgerHash(dbStorage *storage.Storage, outputJSON bool) er
 		if err := binary.Write(lsHash, binary.LittleEndian, treasuryOutput.Amount); err != nil {
 			return fmt.Errorf("unable to serialize treasury output amount: %w", err)
 		}
+		ledgerTokenSupply += treasuryOutput.Amount
 	}
 
-	var ledgerTokenSupply uint64
 	// write all unspent outputs in lexicographical order
 	for _, output := range outputs {
 		ledgerTokenSupply += output.Amount


### PR DESCRIPTION
This PR fixes a small bug in the hornet tools, where the total token supply is calculated incorrectly because the treasury is ignored.
This doesn't affect the core logic of hornet at all, it's a bug in the helper tools for users / node operators.