### PR TITLE
Fix missing treasury balance in db-hash tool

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,7 @@ linters:
         #- containedctx
         - contextcheck
         - decorder
-        - depguard
+        #- depguard
         - dogsled
         #- dupl
         - durationcheck

--- a/components/inx/server_tips.go
+++ b/components/inx/server_tips.go
@@ -13,7 +13,7 @@ import (
 	iotago "github.com/iotaledger/iota.go/v3"
 )
 
-func (s *Server) RequestTips(ctx context.Context, req *inx.TipsRequest) (*inx.TipsResponse, error) {
+func (s *Server) RequestTips(_ context.Context, req *inx.TipsRequest) (*inx.TipsResponse, error) {
 	if deps.TipSelector == nil {
 		return nil, status.Error(codes.Unavailable, "no tipselector available")
 	}

--- a/integration-tests/tester/framework/autopeered_network.go
+++ b/integration-tests/tester/framework/autopeered_network.go
@@ -45,11 +45,7 @@ func (n *AutopeeredNetwork) createEntryNode(privKey ed25519.PrivateKey) error {
 		return err
 	}
 
-	if err := n.entryNode.Start(); err != nil {
-		return err
-	}
-
-	return nil
+	return n.entryNode.Start()
 }
 
 // AwaitPeering waits until all peers have reached the minimum amount of peers.

--- a/integration-tests/tester/framework/network.go
+++ b/integration-tests/tester/framework/network.go
@@ -117,11 +117,7 @@ func (n *Network) CreateWhiteFlagMockServer(cfg *WhiteFlagMockServerConfig) erro
 		return err
 	}
 
-	if err := container.Start(); err != nil {
-		return err
-	}
-
-	return nil
+	return container.Start()
 }
 
 // generates a new private key or returns the one from the opt parameter.

--- a/pkg/dag/concurrent_parents_traverser.go
+++ b/pkg/dag/concurrent_parents_traverser.go
@@ -261,11 +261,7 @@ func (t *ConcurrentParentsTraverser) processStack(wg *sync.WaitGroup, doneChan c
 			}
 
 			// stop processing the stack if the caller returns an error
-			if err := t.onMissingParent(currentBlockID); err != nil {
-				return err
-			}
-
-			return nil
+			return t.onMissingParent(currentBlockID)
 		}
 		defer cachedBlockMeta.Release(true) // meta -1
 

--- a/pkg/database/pebble.go
+++ b/pkg/database/pebble.go
@@ -143,7 +143,7 @@ func NewPebbleDB(directory string, reportCompactionRunning func(running bool), e
 	// sublevels. Writes are stopped when this threshold is reached.
 	//
 	// The default value is 12.
-	opts.L0StopWritesThreshold = 12
+	opts.L0StopWritesThreshold = 30
 
 	// The maximum number of bytes for LBase. The base level is the level which
 	// L0 is compacted into. The base level is determined dynamically based on

--- a/pkg/model/migrator/receipt.go
+++ b/pkg/model/migrator/receipt.go
@@ -60,11 +60,8 @@ func (rs *ReceiptService) Init() error {
 	if !rs.BackupEnabled {
 		return nil
 	}
-	if err := os.MkdirAll(rs.backupFolder, os.ModePerm); err != nil {
-		return err
-	}
 
-	return nil
+	return os.MkdirAll(rs.backupFolder, os.ModePerm)
 }
 
 // Backup backups the given receipt to disk.

--- a/pkg/model/storage/storage.go
+++ b/pkg/model/storage/storage.go
@@ -394,11 +394,7 @@ func (s *Storage) configureStorages(tangleStore kvstore.KVStore, cachesProfile .
 		return err
 	}
 
-	if err := s.configureProtocolStore(tangleStore); err != nil {
-		return err
-	}
-
-	return nil
+	return s.configureProtocolStore(tangleStore)
 }
 
 func (s *Storage) FlushAndCloseStores() error {
@@ -475,9 +471,5 @@ func (s *Storage) CheckLedgerState() error {
 		return err
 	}
 
-	if err = s.UTXOManager().CheckLedgerState(protoParams.TokenSupply); err != nil {
-		return err
-	}
-
-	return nil
+	return s.UTXOManager().CheckLedgerState(protoParams.TokenSupply)
 }

--- a/pkg/model/utxo/utxo.go
+++ b/pkg/model/utxo/utxo.go
@@ -61,15 +61,11 @@ func (u *Manager) ClearLedger(pruneReceipts bool) (err error) {
 	if err = u.utxoStorage.DeletePrefix([]byte{UTXOStoreKeyPrefixOutputUnspent}); err != nil {
 		return err
 	}
-
 	if err = u.utxoStorage.DeletePrefix([]byte{UTXOStoreKeyPrefixMilestoneDiffs}); err != nil {
 		return err
 	}
-	if err = u.utxoStorage.DeletePrefix([]byte{UTXOStoreKeyPrefixTreasuryOutput}); err != nil {
-		return err
-	}
 
-	return nil
+	return u.utxoStorage.DeletePrefix([]byte{UTXOStoreKeyPrefixTreasuryOutput})
 }
 
 func (u *Manager) ReadLockLedger() {

--- a/pkg/snapshot/snapshot_read.go
+++ b/pkg/snapshot/snapshot_read.go
@@ -66,11 +66,7 @@ func newFullHeaderConsumer(targetFullHeader *FullSnapshotHeader, utxoManager *ut
 
 		*targetFullHeader = *header
 
-		if err := utxoManager.StoreLedgerIndex(header.LedgerMilestoneIndex); err != nil {
-			return err
-		}
-
-		return nil
+		return utxoManager.StoreLedgerIndex(header.LedgerMilestoneIndex)
 	}
 }
 

--- a/pkg/snapshot/snapshot_write.go
+++ b/pkg/snapshot/snapshot_write.go
@@ -623,9 +623,6 @@ func (s *Manager) createDeltaSnapshotWithoutLocking(ctx context.Context, targetI
 		return err
 	}
 
-	timeSetSnapshotInfo := timeStreamSnapshotData
-	timeSnapshotMilestoneIndexChanged := timeStreamSnapshotData
-
 	// since we write to the database, the targetIndex should exist
 	targetMsTimestamp, err := s.storage.MilestoneTimestampByIndex(targetIndex)
 	if err != nil {
@@ -636,9 +633,9 @@ func (s *Manager) createDeltaSnapshotWithoutLocking(ctx context.Context, targetI
 		s.LogPanic(err)
 	}
 
-	timeSetSnapshotInfo = time.Now()
+	timeSetSnapshotInfo := time.Now()
 	s.Events.SnapshotMilestoneIndexChanged.Trigger(targetIndex)
-	timeSnapshotMilestoneIndexChanged = time.Now()
+	timeSnapshotMilestoneIndexChanged := time.Now()
 
 	snapshotMetrics.DurationInit = timeInit.Sub(timeStart)
 	snapshotMetrics.DurationSetSnapshotInfo = timeSetSnapshotInfo.Sub(timeStreamSnapshotData)

--- a/pkg/toolset/database_hash.go
+++ b/pkg/toolset/database_hash.go
@@ -65,6 +65,8 @@ func calculateDatabaseLedgerHash(dbStorage *storage.Storage, outputJSON bool) er
 		return fmt.Errorf("unable to serialize ledger index: %w", err)
 	}
 
+	var ledgerTokenSupply uint64
+
 	// read out treasury tx
 	treasuryOutput, err := dbStorage.UTXOManager().UnspentTreasuryOutputWithoutLocking()
 	if err != nil {
@@ -79,6 +81,7 @@ func calculateDatabaseLedgerHash(dbStorage *storage.Storage, outputJSON bool) er
 		if err := binary.Write(lsHash, binary.LittleEndian, treasuryOutput.Amount); err != nil {
 			return fmt.Errorf("unable to serialize treasury output amount: %w", err)
 		}
+		ledgerTokenSupply += treasuryOutput.Amount
 	}
 
 	// get all UTXOs
@@ -87,7 +90,6 @@ func calculateDatabaseLedgerHash(dbStorage *storage.Storage, outputJSON bool) er
 		return err
 	}
 
-	var ledgerTokenSupply uint64
 	// write all unspent outputs in lexicographical order
 	for _, outputID := range outputIDs.RemoveDupsAndSort() {
 		output, err := dbStorage.UTXOManager().ReadOutputByOutputID(outputID)

--- a/pkg/toolset/database_health.go
+++ b/pkg/toolset/database_health.go
@@ -111,9 +111,5 @@ func databaseHealth(args []string) error {
 	dbPath := *databasePathFlag
 	dbName := path.Base(dbPath)
 
-	if err := checkDatabaseHealth(dbPath, dbName, *outputJSONFlag); err != nil {
-		return err
-	}
-
-	return nil
+	return checkDatabaseHealth(dbPath, dbName, *outputJSONFlag)
 }

--- a/pkg/toolset/database_verify.go
+++ b/pkg/toolset/database_verify.go
@@ -308,11 +308,7 @@ func verifyDatabase(
 		}
 
 		// cleanup the state changes from the temporary UTXOManager to save memory
-		if err := cleanupMilestoneFromUTXOManager(utxoManagerTemp, milestonePayload, msIndex); err != nil {
-			return err
-		}
-
-		return nil
+		return cleanupMilestoneFromUTXOManager(utxoManagerTemp, milestonePayload, msIndex)
 	}
 
 	// we start to verify the cone with the first index after the solid entry point index of the genesis snapshot
@@ -343,11 +339,8 @@ func verifyDatabase(
 	}
 
 	println("verifying final ledger state ...")
-	if err := compareLedgerState(tangleStoreSource.UTXOManager(), tangleStoreTemp.UTXOManager()); err != nil {
-		return err
-	}
 
-	return nil
+	return compareLedgerState(tangleStoreSource.UTXOManager(), tangleStoreTemp.UTXOManager())
 }
 
 func getSolidEntryPointsSHA256Sum(dbStorage *storage.Storage) ([]byte, error) {
@@ -431,9 +424,5 @@ func cleanupMilestoneFromUTXOManager(utxoManager *utxo.Manager, milestonePayload
 		}
 	}
 
-	if err := utxoManager.PruneMilestoneIndexWithoutLocking(msIndex, true, receiptMigratedAtIndex...); err != nil {
-		return err
-	}
-
-	return nil
+	return utxoManager.PruneMilestoneIndexWithoutLocking(msIndex, true, receiptMigratedAtIndex...)
 }


### PR DESCRIPTION
This PR fixes a small bug in the hornet tools, where the total token supply is calculated incorrectly because the treasury is ignored.
This doesn't affect the core logic of hornet at all, it's a bug in the helper tools for users / node operators.