### PR TITLE
set networkID to testnet-2

### DIFF
--- a/config_testnet.json
+++ b/config_testnet.json
@@ -1,6 +1,6 @@
 {
   "protocol": {
-    "targetNetworkName": "testnet-1",
+    "targetNetworkName": "testnet-2",
     "milestonePublicKeyCount": 7,
     "baseToken": {
       "name": "Shimmer",


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to this repository, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up to smaller PRs. This will help getting it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split to several PRs!!!!!
-->

# Description

* testnet-1 is outdated. 
* testnet-2 is the current network as seen in the node-docker-setup: 
https://github.com/iotaledger/node-docker-setup/blob/5e280df2cca8fd2a1ddda28f90cefeea2b4a562c/testnet/config.json

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

Changed in the config.json file.
-> "targetNetworkName": "testnet-2",

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
